### PR TITLE
chore(rustfs): adjudicate the remaining 36 bare dead_code allows

### DIFF
--- a/rustfs/src/admin/handlers/account_info.rs
+++ b/rustfs/src/admin/handlers/account_info.rs
@@ -42,7 +42,6 @@ fn map_data_usage_result<E>(result: Result<DataUsageInfo, E>) -> S3Result<DataUs
     result.map_err(|_| S3Error::with_message(S3ErrorCode::InternalError, DATA_USAGE_LOAD_ERROR_MESSAGE))
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Serialize, Default)]
 #[serde(rename_all = "PascalCase", default)]
 pub struct AccountInfo {

--- a/rustfs/src/admin/handlers/bucket_meta.rs
+++ b/rustfs/src/admin/handlers/bucket_meta.rs
@@ -394,7 +394,6 @@ impl Operation for ExportBucketMetadata {
 
 #[derive(Debug, Default, Deserialize)]
 pub struct ImportBucketMetadataQuery {
-    #[allow(dead_code)]
     pub bucket: String,
 }
 

--- a/rustfs/src/admin/handlers/replication.rs
+++ b/rustfs/src/admin/handlers/replication.rs
@@ -455,12 +455,6 @@ pub fn register_replication_route(r: &mut S3Router<AdminOperation>) -> std::io::
 async fn validate_replication_admin_request(req: &S3Request<Body>, action: AdminAction) -> S3Result<Credentials> {
     authorize_admin_request(req, vec![Action::AdminAction(action)]).await
 }
-
-#[allow(dead_code)]
-fn is_local_host(_host: String) -> bool {
-    false
-}
-
 pub(crate) async fn cluster_replication_stats(bucket: &str, context: Option<Arc<AppContext>>) -> BucketStats {
     let Some(stats) = current_replication_stats_handle_for_context(context.clone()) else {
         return BucketStats::default();

--- a/rustfs/src/admin/handlers/trace.rs
+++ b/rustfs/src/admin/handlers/trace.rs
@@ -21,7 +21,6 @@ use matchit::Params;
 use rustfs_madmin::service_commands::ServiceTraceOpts;
 use s3s::{Body, S3Request, S3Response, S3Result, s3_error};
 
-#[allow(dead_code)]
 fn extract_trace_options(uri: &Uri) -> S3Result<ServiceTraceOpts> {
     let mut st_opts = ServiceTraceOpts::default();
     st_opts
@@ -31,7 +30,6 @@ fn extract_trace_options(uri: &Uri) -> S3Result<ServiceTraceOpts> {
     Ok(st_opts)
 }
 
-#[allow(dead_code)]
 pub struct Trace {}
 
 #[async_trait::async_trait]

--- a/rustfs/src/admin/mod.rs
+++ b/rustfs/src/admin/mod.rs
@@ -19,7 +19,6 @@ pub mod handlers;
 mod plugin_contract;
 pub(crate) mod replication_metrics_wire;
 // Contract inventory is validated by tests before later runtime integration.
-#[allow(dead_code)]
 pub(crate) mod route_policy;
 pub mod router;
 pub(crate) mod runtime_sources;

--- a/rustfs/src/admin/route_policy.rs
+++ b/rustfs/src/admin/route_policy.rs
@@ -1598,6 +1598,10 @@ pub const DEFERRED_ADMIN_ROUTE_POLICIES: &[DeferredAdminRoutePolicy] = &[
     ),
 ];
 
+#[allow(
+    dead_code,
+    reason = "asserted by this file's tests; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub fn validate_admin_route_policy_specs() -> Result<(), AdminRouteMatrixError> {
     validate_admin_route_specs(ADMIN_ROUTE_POLICY_SPECS)
 }

--- a/rustfs/src/admin/router.rs
+++ b/rustfs/src/admin/router.rs
@@ -5800,7 +5800,6 @@ mod tests {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct Extra {
     pub credentials: Option<s3s::auth::Credentials>,

--- a/rustfs/src/app/context/global.rs
+++ b/rustfs/src/app/context/global.rs
@@ -45,7 +45,6 @@ pub struct AppContext {
     object_store: Arc<ECStore>,
     iam: Arc<dyn IamInterface>,
     federated_identity: Arc<dyn FederatedIdentityInterface>,
-    #[allow(dead_code)]
     kms: Arc<dyn KmsInterface>,
     kms_runtime: Arc<dyn KmsRuntimeInterface>,
     outbound_tls_runtime: Arc<dyn OutboundTlsRuntimeInterface>,
@@ -162,7 +161,6 @@ impl AppContext {
         self.federated_identity.publish_handle(service)
     }
 
-    #[allow(dead_code)]
     pub fn kms(&self) -> Arc<dyn KmsInterface> {
         self.kms.clone()
     }

--- a/rustfs/src/app/context/handles.rs
+++ b/rustfs/src/app/context/handles.rs
@@ -49,7 +49,6 @@ use tokio::sync::RwLock;
 
 /// Default IAM interface adapter.
 pub struct IamHandle {
-    #[allow(dead_code)]
     iam: Arc<IamSys<ObjectStore>>,
 }
 
@@ -110,7 +109,6 @@ impl FederatedIdentityInterface for FederatedIdentityHandle {
 }
 
 /// Default KMS interface adapter.
-#[allow(dead_code)]
 pub struct KmsHandle {
     kms: Arc<KmsServiceManager>,
 }

--- a/rustfs/src/app/context/interfaces.rs
+++ b/rustfs/src/app/context/interfaces.rs
@@ -36,7 +36,6 @@ use tokio::sync::RwLock;
 
 /// IAM interface for application-layer use-cases.
 pub trait IamInterface: Send + Sync {
-    #[allow(dead_code)]
     fn handle(&self) -> Arc<IamSys<ObjectStore>>;
     fn is_ready(&self) -> bool;
     fn token_signing_key(&self) -> Option<String> {
@@ -53,7 +52,6 @@ pub trait FederatedIdentityInterface: Send + Sync {
 }
 
 /// KMS interface for application-layer use-cases.
-#[allow(dead_code)]
 pub trait KmsInterface: Send + Sync {
     fn handle(&self) -> Arc<KmsServiceManager>;
 }

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -738,7 +738,7 @@ struct GetObjectPreparedRead {
 }
 
 struct GetObjectStrategyContext {
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "written but never read back (backlog#1823)")]
     io_strategy: concurrency::IoStrategy,
     optimal_buffer_size: usize,
     enable_readahead: bool,

--- a/rustfs/src/capacity/capacity_integration.rs
+++ b/rustfs/src/capacity/capacity_integration.rs
@@ -31,7 +31,6 @@ pub async fn init_capacity_management_managed() -> Option<CapacityBackgroundTask
 }
 
 /// Get capacity statistics with metrics
-#[allow(dead_code)]
 pub async fn get_capacity_with_metrics() -> Option<(u64, String)> {
     get_cached_capacity_with_metrics()
         .await

--- a/rustfs/src/init.rs
+++ b/rustfs/src/init.rs
@@ -765,7 +765,6 @@ fn resolve_buffer_profile_config(
 
 /// Parse and normalize server address for FTP/FTPS
 /// Forces IPv4 binding to avoid libunftp IPv6 compatibility issues
-#[allow(dead_code)]
 async fn parse_and_normalize_server_address(
     address_str: &str,
 ) -> Result<std::net::SocketAddr, Box<dyn std::error::Error + Send + Sync>> {
@@ -781,45 +780,6 @@ async fn parse_and_normalize_server_address(
 
     Ok(normalized_addr)
 }
-
-/// Start FTP/FTPS server in background with shutdown support
-/// # Arguments
-/// * `server` - The FTP/FTPS server instance
-/// * `protocol_name` - Name of the protocol (e.g., "FTP", "FTPS")
-#[allow(dead_code)]
-fn spawn_server<S>(server: S, protocol_name: &'static str) -> tokio::sync::broadcast::Sender<()>
-where
-    S: std::future::Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static,
-{
-    let (shutdown_tx, _) = tokio::sync::broadcast::channel(1);
-
-    tokio::spawn(async move {
-        if let Err(e) = server.await {
-            error!(
-                target: "rustfs::init",
-                event = "protocol_server_state",
-                component = LOG_COMPONENT_INIT,
-                subsystem = LOG_SUBSYSTEM_PROTOCOL,
-                protocol = protocol_name,
-                state = "runtime_failed",
-                error = %e,
-                "Protocol server failed"
-            );
-        }
-        info!(
-            target: "rustfs::init",
-            event = "protocol_server_state",
-            component = LOG_COMPONENT_INIT,
-            subsystem = LOG_SUBSYSTEM_PROTOCOL,
-            protocol = protocol_name,
-            state = "stopped",
-            "Protocol server stopped"
-        );
-    });
-
-    shutdown_tx
-}
-
 /// Starts the auto-tuner for performance optimization if enabled via environment variable.
 ///
 /// The auto-tuner reads `RUSTFS_AUTOTUNER_ENABLED` to decide whether to run.

--- a/rustfs/src/license.rs
+++ b/rustfs/src/license.rs
@@ -211,7 +211,6 @@ fn apply_valid_status(state: &mut LicenseState, token: Token) {
 ///
 /// This is the extension point for OEM/build-time overlays.
 /// Returns `false` if the verifier was already initialized.
-#[allow(dead_code)]
 pub fn set_license_verifier(verifier: SharedLicenseVerifier) -> bool {
     LICENSE_VERIFIER.set(verifier).is_ok()
 }

--- a/rustfs/src/startup_iam.rs
+++ b/rustfs/src/startup_iam.rs
@@ -352,17 +352,6 @@ fn should_fail_test_init_attempt() -> bool {
         false
     }
 }
-
-/// Reset the test failure counter so the next `should_fail_test_init_attempt`
-/// call re-reads the environment variable by restoring the sentinel value.
-/// Intended for use in integration tests that share a process.
-#[doc(hidden)]
-#[allow(dead_code)]
-pub(crate) fn reset_test_failure_counter() {
-    use std::sync::atomic::Ordering;
-    TEST_REMAINING_FAILURES.store(u64::MAX, Ordering::SeqCst);
-}
-
 async fn attempt_init_iam_sys(
     store: Arc<ECStore>,
 ) -> std::result::Result<Arc<rustfs_iam::sys::IamSys<rustfs_iam::store::object::ObjectStore>>, std::io::Error> {

--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -61,7 +61,7 @@ pub(crate) struct ReqInfo {
     pub object: Option<String>,
     pub version_id: Option<String>,
     pub replication_request_authorized: bool,
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "written but never read back (backlog#1823)")]
     pub region: Option<s3s::region::Region>,
     pub request_context: Option<RequestContext>,
     /// Set by probe-style callers that treat AccessDenied as an expected filter

--- a/rustfs/src/storage/concurrency/manager.rs
+++ b/rustfs/src/storage/concurrency/manager.rs
@@ -50,7 +50,7 @@ pub struct ConcurrencyManager {
     /// I/O load metrics for adaptive strategy calculation
     io_metrics: Arc<Mutex<IoLoadMetrics>>,
     /// I/O priority queue for request scheduling
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "written but never read back (backlog#1823)")]
     priority_queue: Arc<IoPriorityQueue<()>>,
     /// Bytes pool for buffer allocation and reuse
     bytes_pool: Arc<BytesPool>,
@@ -131,7 +131,6 @@ pub enum PutObjectAdmission {
     Rejected,
 }
 
-#[allow(dead_code)]
 impl ConcurrencyManager {
     /// Create a new concurrency manager with default settings
     ///

--- a/rustfs/src/storage/concurrency/request_guard.rs
+++ b/rustfs/src/storage/concurrency/request_guard.rs
@@ -64,7 +64,6 @@ impl GetObjectGuard {
     }
 
     /// Get the elapsed time since this guard was created.
-    #[allow(dead_code)]
     // This helper is primarily used by unit tests to assert timing.
     // It's intentionally kept public for callers that may want to inspect
     // a guard's duration without dropping it.

--- a/rustfs/src/storage/ecfs_extend.rs
+++ b/rustfs/src/storage/ecfs_extend.rs
@@ -254,7 +254,10 @@ pub(crate) fn apply_bucket_default_lock_retention(
 /// );
 /// ```
 ///
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "exercised by ecfs_test; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) fn get_adaptive_buffer_size_with_profile(file_size: i64, profile: Option<WorkloadProfile>) -> usize {
     let config = match profile {
         Some(p) => RustFSBufferConfig::new(p),
@@ -798,26 +801,10 @@ fn cache_remove(bucket: &str) {
         map.remove(bucket);
     }
 }
-
-/// Clear all entries in the cache.
-#[allow(dead_code)]
-fn cache_clear() {
-    if let Ok(mut map) = small_cache().write() {
-        map.clear();
-    }
-}
-
 /// Invalidate the validation cache for a specific bucket.
 pub fn invalidate_bucket_validation_cache(bucket: &str) {
     cache_remove(bucket);
 }
-
-/// Invalidate all bucket validation cache entries.
-#[allow(dead_code)]
-pub fn invalidate_all_bucket_validation_cache() {
-    cache_clear();
-}
-
 /// Helper function to get store and validate bucket exists.
 ///
 /// Uses adaptive cache with 5s TTL to avoid repeated stat_volume() calls.

--- a/rustfs/src/storage/head_prefix.rs
+++ b/rustfs/src/storage/head_prefix.rs
@@ -15,15 +15,6 @@
 use super::ECStore;
 use crate::storage::storage_api::head_prefix_consumer::contract::list::ListOperations as _;
 use std::sync::Arc;
-
-/// Determines if the key "looks like a prefix" (ends with `/`).
-/// Note: No special handling for empty strings here; the caller must ensure the key has passed `validate_object_key`.
-#[allow(dead_code)]
-#[inline]
-pub(crate) fn is_prefix_key(key: &str) -> bool {
-    key.ends_with('/')
-}
-
 /// Constructs a more explicit error message when `HEAD` is performed on a `prefix`-style key but the directory marker object is missing.
 ///
 /// `has_children`:

--- a/rustfs/src/storage/options.rs
+++ b/rustfs/src/storage/options.rs
@@ -1018,12 +1018,6 @@ pub fn parse_copy_source_range(range_str: &str) -> S3Result<HTTPRangeSpec> {
         Err(s3_error!(InvalidArgument, "Invalid range format"))
     }
 }
-
-#[allow(dead_code)]
-pub(crate) fn get_content_sha256(headers: &HeaderMap<HeaderValue>) -> Option<String> {
-    get_content_sha256_with_query(headers, None)
-}
-
 pub(crate) fn get_content_sha256_with_query(headers: &HeaderMap<HeaderValue>, query: Option<&str>) -> Option<String> {
     match get_request_auth_type_with_query(headers, query) {
         AuthType::Presigned | AuthType::Signed => {
@@ -1036,14 +1030,6 @@ pub(crate) fn get_content_sha256_with_query(headers: &HeaderMap<HeaderValue>, qu
         _ => None,
     }
 }
-
-/// skip_content_sha256_cksum returns true if caller needs to skip
-/// payload checksum, false if not.
-#[allow(dead_code)]
-fn skip_content_sha256_cksum(headers: &HeaderMap<HeaderValue>) -> bool {
-    skip_content_sha256_cksum_with_query(headers, None)
-}
-
 fn skip_content_sha256_cksum_with_query(headers: &HeaderMap<HeaderValue>, query: Option<&str>) -> bool {
     let include_query_values = matches!(get_request_auth_type_with_query(headers, query), AuthType::Presigned);
     let content_sha256 = get_content_sha256_value(headers, query, include_query_values);
@@ -1138,12 +1124,6 @@ fn get_content_sha256_value(
         .and_then(|v| v.to_str().ok())
         .map(str::to_owned)
 }
-
-#[allow(dead_code)]
-fn get_content_sha256_cksum(headers: &HeaderMap<HeaderValue>, service_type: ServiceType) -> String {
-    get_content_sha256_cksum_with_query(headers, None, service_type)
-}
-
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {

--- a/rustfs/src/storage/sse.rs
+++ b/rustfs/src/storage/sse.rs
@@ -3354,7 +3354,6 @@ async fn get_local_sse_dek_provider() -> Result<Arc<dyn SseDekProvider>, ApiErro
 /// Clears GLOBAL_SSE_DEK_PROVIDER (local/test providers) and
 /// GLOBAL_KMS_DEK_PROVIDER (test-injected KMS providers).
 #[cfg(test)]
-#[allow(dead_code)]
 pub fn reset_sse_dek_provider() {
     if let Ok(mut slot) = GLOBAL_SSE_DEK_PROVIDER.write() {
         *slot = None;
@@ -3365,7 +3364,6 @@ pub fn reset_sse_dek_provider() {
 }
 
 #[cfg(test)]
-#[allow(dead_code)]
 pub fn set_sse_dek_provider_for_test(provider: Arc<dyn SseDekProvider>) {
     if let Ok(mut slot) = GLOBAL_KMS_DEK_PROVIDER.write() {
         *slot = Some(provider.clone());

--- a/rustfs/src/storage/tonic_service.rs
+++ b/rustfs/src/storage/tonic_service.rs
@@ -16,5 +16,4 @@ pub(crate) use crate::storage::rpc::node_service::make_heal_control_server_with_
 #[cfg(test)]
 pub(crate) use crate::storage::rpc::node_service::{heal::heal_topology_fingerprint, make_heal_control_server_for_source};
 pub use crate::storage::rpc::{make_heal_control_server, make_server, make_tier_mutation_control_server};
-#[allow(dead_code)]
 pub type NodeService = crate::storage::rpc::NodeService;

--- a/rustfs/src/update.rs
+++ b/rustfs/src/update.rs
@@ -45,7 +45,6 @@ pub struct VersionInfo {
 }
 
 /// Update check result
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateCheckResult {
     /// Whether update is available
@@ -91,7 +90,6 @@ impl VersionChecker {
     }
 
     /// Create version checker with custom configuration
-    #[allow(dead_code)]
     pub fn with_config(url: String, timeout: Duration) -> Self {
         let client = reqwest::Client::builder()
             .timeout(timeout)
@@ -175,7 +173,6 @@ pub async fn check_updates() -> Result<UpdateCheckResult, UpdateCheckError> {
 }
 
 /// Update check with custom URL
-#[allow(dead_code)]
 pub async fn check_updates_with_url(url: String) -> Result<UpdateCheckResult, UpdateCheckError> {
     let checker = VersionChecker::with_config(url, Duration::from_secs(10));
     checker.check_for_updates().await


### PR DESCRIPTION
## What

The second half of step 10 for `rustfs/src`, following #6254. That PR merged its first commit only — this is the rest, rebased onto current main and re-verified there.

36 bare allows spread across 23 files. Stripped first, then clippy asked which the compiler actually missed: **22 were inert**. After this, `rustfs/src` has **no bare `#[allow(dead_code)]` left`**. Seven remain, each with a trailing `//` justification (`// used in config_test`, `// kept for backward compatibility`); converting those to `reason =` is a separate question.

## Ten deletions, in three recurring shapes

**No-argument shims (3).** `storage/options.rs`'s `get_content_sha256`, `skip_content_sha256_cksum` and `get_content_sha256_cksum` each forward to a `_with_query` variant carrying 8, 2 and 2 live callers; none of the shims had one. Same residue as `auth.rs`'s two shims in #6254 — threading the `query` parameter through left the old signatures behind.

**A local shadow (1).** `admin/handlers/replication.rs::is_local_host` was never called: the one call site that looks like its own uses `rustfs_utils::net::is_local_host`.

**A dead cluster (2).** `cache_clear` is reachable only from `invalidate_all_bucket_validation_cache`, which nothing calls.

Plus `head_prefix.rs::is_prefix_key`, `startup_iam.rs::reset_test_failure_counter` (no consumer anywhere, including `rustfs/tests` and `crates/e2e_test`, despite its doc claiming integration-test use), and `init.rs::spawn_server`.

## Four kept with a reason

Test-only consumers the lib target cannot see: `admin/route_policy.rs::validate_admin_route_policy_specs`, `storage/ecfs_extend.rs::get_adaptive_buffer_size_with_profile`.

Written and never read back: `app/object_usecase.rs::io_strategy`, `storage/access.rs::region`, `storage/concurrency/manager.rs::priority_queue`.

`get_adaptive_buffer_size_with_profile` was briefly deleted while preparing this and had to be restored: its reference count looked like doc-comment examples plus a facade re-export, but that came from a truncated grep — `ecfs_test.rs` calls it a dozen times. The compiler caught it at once. Worth naming because "the lib lane cannot see `#[cfg(test)]` consumers" is the trap this whole series keeps hitting.

## Verification

Re-run on current main (which has since taken #6255 and #6256): `cargo clippy -p rustfs --all-targets -- -D warnings` clean, `cargo nextest run -p rustfs --lib` — **3647 passed**, `cargo fmt --all` applied, all four guard scripts pass.
