### PR TITLE
feat(helm): add istio gateway class support

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -267,7 +267,7 @@ uer. `ClusterIssuer` or `Issuer`. |
 | topologySpreadConstraints.enabled | bool | `false` | Enable custom topology spread constraints on distributed-mode StatefulSet pods. |
 | topologySpreadConstraints.constraints | list | `[]` | Raw `spec.template.spec.topologySpreadConstraints` entries applied to the distributed StatefulSet when enabled. |
 | gatewayApi.enabled | bool | `false` | To enable/disable gateway api support. |
-| gatewayApi.gatewayClass | string | `traefik` | Gateway class implementation. |
+| gatewayApi.gatewayClass | string | `traefik` | Gateway class implementation (traefik, contour, istio). |
 | gatewayApi.httpToHttpsRedirect | bool | `true` | To enable/disable the redirect httproute. |
 | gatewayApi.listeners.http.name | string | `web` | Gateway API http listener name. |
 | gatewayApi.listeners.http.port| int | `8000` | Gateway API http listener port. |
@@ -437,7 +437,7 @@ helm install rustfs rustfs/rustfs -n rustfs --set tls.enabled=true,--set-file tl
 
 # Gateway API support (alpha)
 
-Due to [ingress nginx retirement](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/) in March 2026, so RustFS adds support for [gateway api](https://gateway-api.sigs.k8s.io/). Currently, RustFS only supports traefik as gateway class, more and more gateway class support will be added in the future after those classes are tested. If you want to enable gateway api, specify `gatewayApi.enabled` to `true` while specify `ingress.enabled` to `false`. After installation, you can find the `Gateway` and `HttpRoute` resources,
+Due to [ingress nginx retirement](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/) in March 2026, so RustFS adds support for [gateway api](https://gateway-api.sigs.k8s.io/). Currently, RustFS supports traefik, contour, and istio as gateway classes. If you want to enable gateway api, specify `gatewayApi.enabled` to `true` while specify `ingress.enabled` to `false`. After installation, you can find the `Gateway` and `HttpRoute` resources,
 
 ```
 $ kubectl -n rustfs get gateway

--- a/helm/rustfs/templates/gateway-api/istio-destinationrule.yaml
+++ b/helm/rustfs/templates/gateway-api/istio-destinationrule.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.gatewayApi.enabled (eq .Values.gatewayApi.gatewayClass "istio") }}
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: {{ include "rustfs.fullname" . }}-sticky
+  namespace: {{ .Release.Namespace }}
+spec:
+  host: {{ include "rustfs.fullname" . }}-svc.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+  trafficPolicy:
+    loadBalancer:
+      consistentHash:
+        httpCookie:
+          name: rustfs
+          path: /
+          ttl: 0s
+{{- end }}

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -361,7 +361,7 @@ ingress:
 
 gatewayApi:
   enabled: false
-  gatewayClass: traefik # Only support for traefik and contour gatewayClass at the moment.
+  gatewayClass: traefik # Supported gatewayClass: traefik, contour, istio.
   listeners: # Specify which listeners to create on the Gateway.
     http:
       name: web


### PR DESCRIPTION
## Related Issues

Fixes #5675.

## Summary of Changes

Adds `istio` as a supported `gatewayApi.gatewayClass`. The chart's `Gateway` and `HTTPRoute` templates are class-agnostic and already render for istio; this change updates the values comment and README, and adds an istio `DestinationRule` with cookie consistent-hash so session affinity matches the existing traefik (`TraefikService`) and contour (annotation) behavior. Existing gatewayClass values (traefik, contour) and default rendering are unchanged.

## Verification

- `helm template` with `gatewayApi.enabled=true` and `gatewayApi.gatewayClass=istio` renders the `Gateway` (gatewayClassName: istio), `HTTPRoute` (plain Service backend), and the istio `DestinationRule`; no `TraefikService` or contour annotation is emitted
- `helm template` with default, traefik, and contour renders is byte-identical to before the change (compatibility check)
- `helm lint ./helm/rustfs` passes

## Impact

New opt-in value `gatewayApi.gatewayClass: istio`; default behavior unchanged. Users must have Istio installed with Gateway API support and an `istio.io/gateway-controller` GatewayClass.

## Additional Notes

N/A
