### PR TITLE
chore(protocols): narrow the SessionDiag blanket to its one unread field

### DIFF
--- a/crates/protocols/src/sftp/lifecycle.rs
+++ b/crates/protocols/src/sftp/lifecycle.rs
@@ -84,11 +84,11 @@ const TCP_STATE_RADIX: u32 = 16;
 /// and the SftpDriver, registered weakly into the SessionRegistry so an
 /// outside observer can enumerate live sessions without holding their
 /// lifetime.
-#[allow(dead_code)]
 pub struct SessionDiag {
     pub session_id: u64,
     pub local: SocketAddr,
     pub peer: SocketAddr,
+    #[allow(dead_code, reason = "written at accept time but never read back (backlog#1823)")]
     pub accepted_at: Instant,
     pub last_activity_ms: AtomicU64,
 }


### PR DESCRIPTION
## What

The last item-level bare allow of backlog#1823 step 10, after #6254, #6259 and #6265.

`crates/protocols` needed its own pass because the `sftp` module only compiles under `--features sftp`, so it could not be verified alongside the other crates.

## The finding

`SessionDiag` carried a struct-level `#[allow(dead_code)]`, but the struct is thoroughly live: `sftp/server.rs` builds one per accepted connection and registers it weakly, and `wedge_watchdog` reads `session_id`, `peer` and `last_activity_ms` off it. The blanket was covering exactly one field — `accepted_at`, written at accept time and never read back.

So this is not a deletion: the allow moves onto that single field with a reason, which is the shape step 10 asks for. A struct-level blanket would also have silenced any field added later.

## Not in scope

The three remaining `#![allow(dead_code)]` in this crate — `sftp/test_support.rs` and `common/dummy_storage.rs` — are module-root blankets in test-support files. Those belong to steps 1-5, not step 10. `test_support.rs` even documents its own reason in the module comment above the attribute.

## Verification

`cargo clippy -p rustfs-protocols --features sftp --all-targets -- -D warnings` clean, `cargo nextest run -p rustfs-protocols --features sftp` — 238 passed, `cargo fmt --all` applied, all four guard scripts pass.
