### PR TITLE
chore(common): drop dead rule helpers and the s3s dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9278,7 +9278,6 @@ dependencies = [
  "jiff",
  "metrics",
  "rmp-serde",
- "s3s",
  "serde",
  "serde_json",
  "smallvec",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -44,7 +44,6 @@ metrics = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 smallvec = { workspace = true }
 rmp-serde = { workspace = true }
-s3s = { workspace = true, features = ["minio"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/common/src/heal_channel.rs
+++ b/crates/common/src/heal_channel.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use s3s::dto::{BucketLifecycleConfiguration, ExpirationStatus, LifecycleRule, ReplicationConfiguration, ReplicationRuleStatus};
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::{self, Display},
@@ -631,104 +630,6 @@ pub fn create_heal_response(
         data,
         error,
     }
-}
-
-fn lc_get_prefix(rule: &LifecycleRule) -> String {
-    if let Some(p) = &rule.prefix {
-        return p.to_string();
-    } else if let Some(filter) = &rule.filter {
-        if let Some(p) = &filter.prefix {
-            return p.to_string();
-        } else if let Some(and) = &filter.and
-            && let Some(p) = &and.prefix
-        {
-            return p.to_string();
-        }
-    }
-
-    "".into()
-}
-
-pub fn lc_has_active_rules(config: &BucketLifecycleConfiguration, prefix: &str) -> bool {
-    if config.rules.is_empty() {
-        return false;
-    }
-
-    for rule in config.rules.iter() {
-        if rule.status == ExpirationStatus::from_static(ExpirationStatus::DISABLED) {
-            continue;
-        }
-        let rule_prefix = lc_get_prefix(rule);
-        if !prefix.is_empty() && !rule_prefix.is_empty() && !prefix.starts_with(&rule_prefix) && !rule_prefix.starts_with(prefix)
-        {
-            continue;
-        }
-
-        if let Some(e) = &rule.noncurrent_version_expiration {
-            if e.noncurrent_days.is_some() {
-                return true;
-            }
-            if let Some(true) = e.newer_noncurrent_versions.map(|d| d > 0) {
-                return true;
-            }
-        }
-
-        if rule.noncurrent_version_transitions.is_some() {
-            return true;
-        }
-        if let Some(true) = rule.expiration.as_ref().map(|e| e.date.is_some()) {
-            return true;
-        }
-
-        if let Some(true) = rule.expiration.as_ref().map(|e| e.days.is_some()) {
-            return true;
-        }
-
-        if let Some(Some(true)) = rule.expiration.as_ref().map(|e| e.expired_object_delete_marker) {
-            return true;
-        }
-
-        if let Some(true) = rule.transitions.as_ref().map(|t| !t.is_empty()) {
-            return true;
-        }
-
-        if rule.transitions.is_some() {
-            return true;
-        }
-    }
-    false
-}
-
-pub fn rep_has_active_rules(config: &ReplicationConfiguration, prefix: &str, recursive: bool) -> bool {
-    if config.rules.is_empty() {
-        return false;
-    }
-
-    for rule in config.rules.iter() {
-        if rule
-            .status
-            .eq(&ReplicationRuleStatus::from_static(ReplicationRuleStatus::DISABLED))
-        {
-            continue;
-        }
-        if !prefix.is_empty()
-            && let Some(filter) = &rule.filter
-            && let Some(r_prefix) = &filter.prefix
-            && !r_prefix.is_empty()
-        {
-            // incoming prefix must be in rule prefix
-            if !recursive && !prefix.starts_with(r_prefix) {
-                continue;
-            }
-            // If recursive, we can skip this rule if it doesn't match the tested prefix or level below prefix
-            // does not match
-            if recursive && !r_prefix.starts_with(prefix) && !prefix.starts_with(r_prefix) {
-                continue;
-            }
-        }
-        return true;
-    }
-    false
 }
 
 pub async fn send_heal_disk(set_disk_id: String, priority: Option<HealChannelPriority>) -> Result<(), String> {


### PR DESCRIPTION
## Related Issues

N/A (follow-up of the backlog#1862 heal/scanner audit review)

## Summary of Changes

`common/heal_channel.rs` carried three orphaned rule helpers — `lc_get_prefix`, `lc_has_active_rules`, `rep_has_active_rules` — left behind when the old data-scanner code was reorganized: they have had zero production callers for a long time, and the canonical implementations live in the lifecycle crate (`has_active_rules` on `BucketLifecycleConfiguration`) and the replication crate (`ReplicationConfigurationExt::has_active_rules`). The `use s3s::dto::{...}` import at the top of the file existed solely for these dead functions and was the only s3s usage inside rustfs-common, so the crate dependency is dropped as well. Pure deletion: 99 lines of dead helpers plus the two dependency lines; behavior, wire types, and the remaining heal-channel surface are untouched.

## Verification

- `cargo fmt --all`
- `cargo check -p rustfs-common` and `cargo check -p rustfs` — clean
- `cargo test -p rustfs-common` — 84 passed, 0 failed

Adversarial review (Mechanical tier): correctness and simplicity roles ran against the final diff — zero remaining references to the three helpers across the workspace, remaining imports all still used, Cargo.lock diff limited to the single `s3s` edge under rustfs-common.

## Impact

No runtime impact. The common crate's public API shrinks by two `pub fn`s that nothing in the workspace used. If rustfs-common is ever published, that is technically a semver-major removal; in-workspace it is unobservable.

## Additional Notes

The deleted names (`lc_*`) referred to the local copies; the surviving canonical methods are `get_prefix`/`has_active_rules` in the lifecycle and replication crates.
