### PR TITLE
refactor(heal): store completed heal results once

### DIFF
--- a/crates/heal/src/heal/manager.rs
+++ b/crates/heal/src/heal/manager.rs
@@ -217,11 +217,11 @@ impl ForegroundPressure {
 struct CompletedHealStatus {
     heal_type: HealType,
     status: HealTaskStatus,
-    result_items: Vec<HealResultItem>,
     result_items_truncated: bool,
     completed_at: SystemTime,
     /// Sequence-stamped retained window, archived with the completion so
     /// incremental consumers keep their cursor across the transition (HS-06).
+    /// The un-stamped legacy view is derived from it on demand.
     seqed_items: Vec<(u64, HealResultItem)>,
     next_seq: u64,
     min_seq: u64,
@@ -283,7 +283,7 @@ fn empty_task_report(status: HealTaskStatus) -> HealTaskReport {
 fn completed_task_report(completed: &CompletedHealStatus, since: Option<u64>) -> HealTaskReport {
     let mut lagged = false;
     let result_items = match since {
-        None => completed.result_items.clone(),
+        None => completed.seqed_items.iter().map(|(_, item)| item.clone()).collect(),
         Some(cursor) => {
             if cursor + 1 < completed.min_seq {
                 lagged = true;
@@ -3461,16 +3461,19 @@ impl HealManager {
                             completed_task.get_status().await
                         };
                         let completed_progress = completed_task.get_progress().await;
-                        let final_window = completed_task.get_result_items_since(None).await;
+                        // Single snapshot of the retained window: the task is
+                        // finished and already off the active map, so there is
+                        // no concurrent writer to race with.
+                        let seqed_items = completed_task.get_seqed_result_items().await;
+                        let (next_seq, min_seq) = completed_task.result_seq_cursors();
                         let completed_status_entry = CompletedHealStatus {
                             heal_type: completed_task.heal_type.clone(),
                             status: completed_status.clone(),
-                            result_items: final_window.items.clone(),
                             result_items_truncated: completed_task.result_items_truncated(),
                             completed_at: SystemTime::now(),
-                            seqed_items: completed_task.get_seqed_result_items().await,
-                            next_seq: final_window.next_seq,
-                            min_seq: final_window.min_seq,
+                            seqed_items,
+                            next_seq,
+                            min_seq,
                         };
                         let mut completed_heals_guard = completed_heals_clone.lock().await;
                         prune_completed_heal_statuses(&mut completed_heals_guard);
@@ -5200,7 +5203,6 @@ mod tests {
                     error: "Lock acquisition timeout".to_string(),
                     retry_attempt: request.retry_attempts,
                 },
-                result_items: Vec::new(),
                 result_items_truncated: false,
                 seqed_items: Vec::new(),
                 next_seq: 0,
@@ -5916,7 +5918,6 @@ mod tests {
                     bucket: "bucket".to_string(),
                 },
                 status: HealTaskStatus::Completed,
-                result_items: Vec::new(),
                 result_items_truncated: false,
                 seqed_items: Vec::new(),
                 next_seq: 0,
@@ -5948,16 +5949,18 @@ mod tests {
                     version_id: None,
                 },
                 status: HealTaskStatus::Completed,
-                result_items: vec![HealResultItem {
-                    bucket: "bucket".to_string(),
-                    object: "object".to_string(),
-                    object_size: 1024,
-                    ..Default::default()
-                }],
                 result_items_truncated: true,
-                seqed_items: Vec::new(),
-                next_seq: 0,
-                min_seq: 0,
+                seqed_items: vec![(
+                    1,
+                    HealResultItem {
+                        bucket: "bucket".to_string(),
+                        object: "object".to_string(),
+                        object_size: 1024,
+                        ..Default::default()
+                    },
+                )],
+                next_seq: 2,
+                min_seq: 1,
                 completed_at: SystemTime::now(),
             },
         );
@@ -5971,6 +5974,10 @@ mod tests {
         assert_eq!(report.status, HealTaskStatus::Completed);
         assert_eq!(report.result_items.len(), 1);
         assert_eq!(report.result_items[0].object_size, 1024);
+        // The archived cursors pass through to the report so an incremental
+        // consumer can resume against the next expected sequence.
+        assert_eq!(report.next_seq, 2);
+        assert_eq!(report.min_seq, 1);
     }
 
     #[tokio::test]

--- a/crates/heal/src/heal/task.rs
+++ b/crates/heal/src/heal/task.rs
@@ -945,6 +945,13 @@ impl HealTask {
         self.result_items.read().await.iter().cloned().collect::<Vec<_>>()
     }
 
+    /// Sequence cursors of the retained window (next to assign, oldest
+    /// retained) — the same pair `get_result_items_since` reports, without
+    /// copying the items. Used when archiving a finished task.
+    pub fn result_seq_cursors(&self) -> (u64, u64) {
+        (self.next_item_seq.load(Ordering::Relaxed), self.min_available_seq.load(Ordering::Relaxed))
+    }
+
     /// Incremental result window (HS-06): `since = None` returns the full
     /// retained window (legacy snapshot semantics); `since = Some(seq)`
     /// returns only items stamped with a sequence greater than `seq`.


### PR DESCRIPTION
## Related Issues

N/A (follow-up of the backlog#1862 heal/scanner audit review; stacked on #6272)

## Summary of Changes

`CompletedHealStatus` stored the finished task's retained result window twice: `result_items` (the pre-HS-06 un-stamped view) and `seqed_items` (the sequence-stamped archive). Archiving cloned the window twice (once via `get_result_items_since(None)` + a full `Vec` clone, once via `get_seqed_result_items`), and the un-stamped copy had exactly one reader — the `since=None` branch of `completed_task_report`. Drop the duplicate storage: the None branch now derives the legacy view from `seqed_items` on demand, and the archive path takes a single snapshot — one `get_seqed_result_items` call plus the new `result_seq_cursors` accessor (next/oldest seq, the same pair `get_result_items_since` reports, without copying the items). The task is finished and already off the active map when this runs, so there is no concurrent writer; the single snapshot also removes the theoretical drift the old double-read allowed between the two lock acquisitions. Memory for a completed entry halves, and the archive path's per-completion item clones drop from 3N to N.

## Verification

- `cargo fmt --all`
- `cargo test -p rustfs-heal` — 328 passed lib + all integration targets, 0 failed

Adversarial review (Standard tier + performance/concurrency domains) — no break found: the no-concurrent-writer premise was verified against every `record_result_item` call site (all inside `execute()`, which is awaited before archiving; cancel/timeout orderings included); the None-branch derivation is element-for-element equivalent (same deque order, same content); the reworked test construction is now internally consistent (the old one paired non-empty items with zero seq cursors) and additionally pins the next_seq/min_seq pass-through.

## Impact

Performance/memory only; no API, wire, or persistence change. Completed entries retain one window instead of two (<=1024 items), and legacy full-snapshot reports clone on demand instead of being pre-paid at archive time. Rollback is a single revert.

## Additional Notes

Informational: the no-concurrent-writer invariant at the archive site is enforced by `record_result_item` being private and `execute()` being awaited exactly once — a future public recording path or background refresher would invalidate the comment there.
