### PR TITLE
docs(admin): pin two authorization semantics against a dedup rewrite

### DIFF
--- a/rustfs/src/admin/handlers/is_admin.rs
+++ b/rustfs/src/admin/handlers/is_admin.rs
@@ -46,6 +46,12 @@ impl Operation for IsAdminHandler {
 
         let access_key_to_check = input_cred.access_key.clone();
 
+        // This endpoint reports a capability; it does not gate on one. The
+        // `is_allowed` result below becomes the `is_admin` field of a 200
+        // response — a caller without admin rights gets `{"is_admin": false}`,
+        // not a 403. Turning this into a rejection would change the API
+        // contract, so it must stay out of any shared-gate normalisation
+        // (backlog#1886).
         // Check if the user is admin: root user check, then evaluate through the policy engine
         let is_admin = if let Some(sys_cred) = current_action_credentials() {
             constant_time_eq(&access_key_to_check, &sys_cred.access_key)

--- a/rustfs/src/admin/handlers/service_account.rs
+++ b/rustfs/src/admin/handlers/service_account.rs
@@ -359,6 +359,13 @@ impl Operation for AddServiceAccount {
             return Err(s3_error!(InvalidRequest, "iam not init"));
         };
 
+        // This family deliberately calls `is_allowed` directly instead of going
+        // through `validate_admin_request`, and must keep doing so
+        // (backlog#1886). The shared helper returns as soon as *any* candidate
+        // action is allowed — an OR. The checks here are an AND: each one must
+        // pass, and a later stage additionally needs `owner` for the GHSA-5354
+        // parent-scope guard and drives `deny_only` dynamically. Replacing these
+        // with the shared gate would widen authorization.
         if !iam_store
             .is_allowed(&Args {
                 account: &cred.access_key,


### PR DESCRIPTION
## What

Items 3 and 4 of backlog#1886. Comment-only, no behaviour change.

The #1829 audit compared ~100 admin authorization preambles and found four semantic anomalies. Two of them are correct as they stand and need their shape recorded so a later normalisation does not quietly flatten them. That recording is time-sensitive: the dedup they would be swept into is being worked now.

## `is_admin` — authorization as an answer, not a gate

`is_allowed` here feeds the `is_admin` field of a 200 response. A caller without admin rights gets `{"is_admin": false}`, not a 403. That is the endpoint's contract — a capability query — so it must stay out of any shared-gate rewrite.

## `service_account` — AND, where the shared helper is OR

The eight sites in this family conjoin two checks: the first `is_allowed` refuses outright, and `no_explicit_deny` must then pass as well. Both must hold.

`validate_admin_request` → `evaluate_admin_actions` disjoins instead, returning as soon as *any* candidate action is allowed. Its own comment says so.

So moving this family onto the shared helper would **widen authorization**, not merely deduplicate it. Two further differences make the same point: a later stage needs `owner` for the GHSA-5354 parent-scope guard, and `deny_only` is driven dynamically rather than fixed. The comment sits at the family's entry point, where someone doing the dedup will meet it.

## Items 1 and 2 are not touched

Both are intent questions rather than defects, and answering them by guessing would be worse than leaving them:

- `GetKmsStatusHandler` is the only KMS authorization site not wrapped in `KmsAdminAudit::gate_admin`; its four siblings are. Deliberate exemption for a status read, or an audit gap?
- `quota` writes go through an unscoped admin action while quota reads go through bucket-scoped `validate_admin_request_with_bucket`. Reads being stricter than writes is the wrong way round — either writes are over-permitted, or the asymmetry is deliberate and wants a comment of its own.

Asked on the issue.

## Verification

`cargo clippy -p rustfs --lib -- -D warnings` clean, `cargo fmt --all` applied, all four guard scripts pass. Per the issue's own acceptance criteria, comment-only items need no test run.
