### PR TITLE
fix(scripts): stop the assertless-test census truncating bodies at string braces

### DIFF
--- a/scripts/find_assertless_tests.py
+++ b/scripts/find_assertless_tests.py
@@ -81,6 +81,78 @@ FN_LINE = re.compile(r"^\s*(?:pub\s+)?(?:async\s+)?fn\s+([a-zA-Z0-9_]+)")
 
 
 
+# A char literal is 'x' or '\n'; a lone `'` is a lifetime (`&'a str`), and
+# consuming to the next quote on one would swallow the rest of the line.
+CHAR_LITERAL = re.compile(r"'(?:[^'\\]|\\.)'")
+RAW_STRING_OPEN = re.compile(r'r(#*)"')
+
+
+class LiteralStripper:
+    """Blanks out literals and comments so brace matching sees only code.
+
+    Carries state across lines: Rust string literals — the JSON and `r#"..."#`
+    fixtures these tests are full of — routinely span lines, and a per-line
+    scanner falls out of phase on the first one. A `{` inside a string would
+    otherwise unbalance the count and truncate a test body before its
+    assertions.
+    """
+
+    def __init__(self) -> None:
+        self.in_string = False
+        self.raw_hashes = None  # None when the open string is not raw
+
+    def feed(self, line: str) -> str:
+        out = []
+        i = 0
+        n = len(line)
+        while i < n:
+            if self.in_string:
+                if self.raw_hashes is not None:
+                    close = '"' + "#" * self.raw_hashes
+                    idx = line.find(close, i)
+                    if idx == -1:
+                        return "".join(out)
+                    i = idx + len(close)
+                    self.in_string = False
+                    self.raw_hashes = None
+                    continue
+                if line[i] == "\\":
+                    i += 2
+                    continue
+                if line[i] == '"':
+                    self.in_string = False
+                    i += 1
+                    continue
+                i += 1
+                continue
+
+            ch = line[i]
+            if ch == "/" and i + 1 < n and line[i + 1] == "/":
+                break
+            m = RAW_STRING_OPEN.match(line, i)
+            if m:
+                self.in_string = True
+                self.raw_hashes = len(m.group(1))
+                i = m.end()
+                continue
+            if ch == '"':
+                self.in_string = True
+                self.raw_hashes = None
+                i += 1
+                continue
+            if ch == "'":
+                cm = CHAR_LITERAL.match(line, i)
+                if cm:
+                    i = cm.end()
+                    continue
+                out.append(ch)
+                i += 1
+                continue
+            out.append(ch)
+            i += 1
+        return "".join(out)
+
+
 def extract_body(text: str) -> str:
     """Return what is between the outermost braces of a scanned function."""
     start = text.find("{")
@@ -121,8 +193,9 @@ def scan_file(path: Path):
         begun = False
         body = []
         k = j
+        stripper = LiteralStripper()
         while k < len(lines):
-            for ch in lines[k]:
+            for ch in stripper.feed(lines[k]):
                 if ch == "{":
                     depth += 1
                     begun = True


### PR DESCRIPTION
## What

The assertless-test census (backlog#1836) matched braces over raw source, so a `{` inside a string literal unbalanced the count and truncated the test body — hiding any assertions below it.

`crates/utils/src/string.rs:942` was the visible symptom: reported as assertionless while asserting two lines further down, because its input string is `"http://:brace-secret@server/{1...2}}"`.

## The fix, and why it is stateful

Brace matching now runs over a literal-stripped view of each line.

The stripper carries state **across** lines. A per-line version is the obvious first attempt and it is wrong: the JSON and `r#"..."#` fixtures these tests are built from routinely span several lines, so the scanner ends a line mid-string, falls out of phase on the next one, and truncates far more bodies than it fixes. I tried that first and the candidate list went from 15 to 105 — the count itself is what caught it.

Two smaller traps are handled for the same reason:

- Raw strings close on their own hash count (`r#"…"#`), not on the first `"`.
- A lone `'` is left alone. Consuming to the next quote would treat a lifetime — `&'a str` — as a char literal and swallow the rest of the line, braces included. Only a complete `'x'` / `'\n'` is skipped.

## The result is a swap, not a reduction

The count stays at 15, which is the useful part:

- **out:** `utils/src/string.rs:942` — it does assert; a genuine false positive, now gone.
- **in:** `io-metrics/src/lib.rs:3308` — `test_record_get_object_path_and_stage` makes twenty-odd `record_*` calls and asserts nothing. Same shape as the smoke tests #6238 fixed elsewhere in that same file, and it had been hidden behind a truncated body all along.

So the census was over-reporting and under-reporting at once. The new candidate is left for a follow-up rather than folded in here, to keep the tooling change separable from a test change.

## Verification

`python3 scripts/find_assertless_tests.py` before and after, diffed — the swap above is the entire delta. Script parses (`ast.parse`). No Rust source touched.
