### PR TITLE
feat(ecstore): bound put commit lock admission

### DIFF
--- a/crates/config/src/constants/object.rs
+++ b/crates/config/src/constants/object.rs
@@ -427,6 +427,19 @@ pub const ENV_OBJECT_LOCK_ACQUIRE_TIMEOUT: &str = "RUSTFS_OBJECT_LOCK_ACQUIRE_TI
 /// Default lock acquisition timeout: 5 seconds.
 pub const DEFAULT_OBJECT_LOCK_ACQUIRE_TIMEOUT: u64 = 5;
 
+/// Environment variable for the experimental PUT commit namespace lock acquire timeout in milliseconds.
+///
+/// A value of `0` disables the experiment and keeps
+/// `RUSTFS_OBJECT_LOCK_ACQUIRE_TIMEOUT` as the timeout. This only bounds the
+/// `put_object_commit` namespace write-lock wait and is intended for #925
+/// tail-drain admission experiments.
+///
+/// Default: 0 milliseconds (disabled).
+pub const ENV_PUT_COMMIT_NAMESPACE_LOCK_ACQUIRE_TIMEOUT_MS: &str = "RUSTFS_PUT_COMMIT_NAMESPACE_LOCK_ACQUIRE_TIMEOUT_MS";
+
+/// Default: PUT commit namespace lock acquire timeout override is disabled.
+pub const DEFAULT_PUT_COMMIT_NAMESPACE_LOCK_ACQUIRE_TIMEOUT_MS: u64 = 0;
+
 /// Environment variable for remote namespace lock RPC transport timeout in milliseconds.
 ///
 /// This timeout bounds the internode RPC call itself. It is intentionally

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -1501,6 +1501,58 @@ pub fn get_lock_acquire_timeout() -> Duration {
     }
 }
 
+fn get_put_object_commit_lock_acquire_timeout_override_ms() -> u64 {
+    #[cfg(test)]
+    {
+        rustfs_utils::get_env_u64(
+            rustfs_config::ENV_PUT_COMMIT_NAMESPACE_LOCK_ACQUIRE_TIMEOUT_MS,
+            rustfs_config::DEFAULT_PUT_COMMIT_NAMESPACE_LOCK_ACQUIRE_TIMEOUT_MS,
+        )
+    }
+    #[cfg(not(test))]
+    {
+        static CACHED: OnceLock<u64> = OnceLock::new();
+        *CACHED.get_or_init(|| {
+            rustfs_utils::get_env_u64(
+                rustfs_config::ENV_PUT_COMMIT_NAMESPACE_LOCK_ACQUIRE_TIMEOUT_MS,
+                rustfs_config::DEFAULT_PUT_COMMIT_NAMESPACE_LOCK_ACQUIRE_TIMEOUT_MS,
+            )
+        })
+    }
+}
+
+fn get_put_object_commit_lock_acquire_timeout(op: &'static str) -> Duration {
+    let default_timeout = get_lock_acquire_timeout();
+    if op != "put_object_commit" {
+        return default_timeout;
+    }
+
+    let timeout_ms = get_put_object_commit_lock_acquire_timeout_override_ms();
+    if timeout_ms == 0 {
+        default_timeout
+    } else {
+        Duration::from_millis(timeout_ms)
+    }
+}
+
+fn put_object_commit_lock_timeout_override_enabled(op: &'static str) -> bool {
+    op == "put_object_commit" && get_put_object_commit_lock_acquire_timeout_override_ms() != 0
+}
+
+fn map_put_object_commit_lock_acquire_error(
+    set: &SetDisks,
+    op: &'static str,
+    bucket: &str,
+    object: &str,
+    err: rustfs_lock::error::LockError,
+) -> StorageError {
+    if put_object_commit_lock_timeout_override_enabled(op) && matches!(err, rustfs_lock::error::LockError::Timeout { .. }) {
+        StorageError::SlowDown
+    } else {
+        set.map_namespace_lock_error(bucket, object, "write", err)
+    }
+}
+
 pub fn is_object_lock_diag_enabled() -> bool {
     *OBJECT_LOCK_DIAG_ENABLED.get_or_init(|| {
         let enabled = rustfs_utils::get_env_bool(
@@ -3302,10 +3354,11 @@ impl SetDisks {
         let diag_enabled = is_object_lock_diag_enabled();
         let ns_lock = self.new_ns_lock(bucket, object).await?;
         let acquire_start = Instant::now();
+        let acquire_timeout = get_put_object_commit_lock_acquire_timeout(op);
         let guard = ns_lock
-            .get_write_lock(get_lock_acquire_timeout())
+            .get_write_lock(acquire_timeout)
             .await
-            .map_err(|e| self.map_namespace_lock_error(bucket, object, "write", e))?;
+            .map_err(|e| map_put_object_commit_lock_acquire_error(self, op, bucket, object, e))?;
         Self::record_put_object_commit_namespace_lock_wait(op, acquire_start);
         let owner = diag_enabled.then(|| ns_lock.owner().to_string());
         self.log_object_lock_acquire_if_slow(
@@ -3340,7 +3393,8 @@ impl SetDisks {
         let diag_enabled = is_object_lock_diag_enabled();
         let ns_lock = self.new_ns_lock(bucket, object).await?;
         let acquire_start = Instant::now();
-        let acquire = ns_lock.get_write_lock(get_lock_acquire_timeout());
+        let acquire_timeout = get_put_object_commit_lock_acquire_timeout(op);
+        let acquire = ns_lock.get_write_lock(acquire_timeout);
         tokio::pin!(acquire);
         let mut on_pending = Some(on_pending);
         let guard = futures::future::poll_fn(|cx| match std::future::Future::poll(acquire.as_mut(), cx) {
@@ -3353,7 +3407,7 @@ impl SetDisks {
             std::task::Poll::Ready(result) => std::task::Poll::Ready(result),
         })
         .await
-        .map_err(|e| self.map_namespace_lock_error(bucket, object, "write", e))?;
+        .map_err(|e| map_put_object_commit_lock_acquire_error(self, op, bucket, object, e))?;
         Self::record_put_object_commit_namespace_lock_wait(op, acquire_start);
         let owner = diag_enabled.then(|| ns_lock.owner().to_string());
         self.log_object_lock_acquire_if_slow(
@@ -5717,8 +5771,8 @@ mod tests {
             .filter(|(composite, _, _, _)| {
                 composite.key().name() == "rustfs_s3_put_object_stage_duration_ms"
                     && composite.key().labels().any(|label| {
-                        label.key().to_string() == "stage"
-                            && label.value().to_string() == rustfs_io_metrics::PUT_STAGE_PUT_OBJECT_COMMIT_NAMESPACE_LOCK_WAIT
+                        label.key() == "stage"
+                            && label.value() == rustfs_io_metrics::PUT_STAGE_PUT_OBJECT_COMMIT_NAMESPACE_LOCK_WAIT
                     })
             })
             .map(|(_, _, _, value)| match value {
@@ -5789,6 +5843,64 @@ mod tests {
                 assert_eq!(put_object_commit_namespace_lock_wait_sample_count(&snapshotter), 1);
 
                 rustfs_io_metrics::set_put_stage_metrics_enabled(false);
+            });
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn put_object_commit_lock_timeout_override_only_applies_to_put_commit() {
+        temp_env::with_vars([(rustfs_config::ENV_PUT_COMMIT_NAMESPACE_LOCK_ACQUIRE_TIMEOUT_MS, Some("17"))], || {
+            assert_eq!(get_put_object_commit_lock_acquire_timeout("put_object_commit"), Duration::from_millis(17));
+            assert_eq!(
+                get_put_object_commit_lock_acquire_timeout("complete_multipart_upload_commit"),
+                get_lock_acquire_timeout()
+            );
+        });
+
+        temp_env::with_vars([(rustfs_config::ENV_PUT_COMMIT_NAMESPACE_LOCK_ACQUIRE_TIMEOUT_MS, Some("0"))], || {
+            assert_eq!(
+                get_put_object_commit_lock_acquire_timeout("put_object_commit"),
+                get_lock_acquire_timeout()
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn put_object_commit_lock_timeout_override_bounds_contention_wait() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime should start");
+
+        temp_env::with_vars([(rustfs_config::ENV_PUT_COMMIT_NAMESPACE_LOCK_ACQUIRE_TIMEOUT_MS, Some("1"))], || {
+            runtime.block_on(async {
+                let ctx = Arc::new(InstanceContext::new());
+                ctx.update_erasure_type(SetupType::Erasure).await;
+                let set = make_test_set_disks_with_ctx(Vec::new(), ctx).await;
+                let bucket = "bucket";
+                let object = "object";
+
+                let held_guard = set
+                    .acquire_write_lock_diag("put_object_commit", bucket, object)
+                    .await
+                    .expect("holder acquire should succeed");
+                let started = Instant::now();
+                let err = match set.acquire_write_lock_diag("put_object_commit", bucket, object).await {
+                    Ok(_) => panic!("contended PUT commit lock should honor the short timeout"),
+                    Err(err) => err,
+                };
+                assert!(
+                    started.elapsed() < Duration::from_secs(1),
+                    "short PUT commit lock timeout should not wait for the global timeout"
+                );
+                assert!(matches!(err, StorageError::SlowDown));
+
+                drop(held_guard);
+                set.acquire_write_lock_diag("put_object_commit", bucket, object)
+                    .await
+                    .expect("permit should not leak after timeout");
             });
         });
     }


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#925 and rustfs/backlog#1856.

## Summary of Changes

Adds a default-off PUT commit namespace-lock admission experiment for the #925 tail-drain follow-up.

- Adds `RUSTFS_PUT_COMMIT_NAMESPACE_LOCK_ACQUIRE_TIMEOUT_MS`, defaulting to `0` which preserves the existing global `RUSTFS_OBJECT_LOCK_ACQUIRE_TIMEOUT` behavior.
- Applies the override only to the `put_object_commit` namespace write-lock acquisition path.
- Maps an override-triggered `put_object_commit` lock timeout to `StorageError::SlowDown`, so the experiment behaves as explicit admission/backpressure instead of a generic lock failure.
- Leaves tail-drain namespace lock retention, rename/fdatasync ordering, on-disk data, and default behavior unchanged.
- Keeps the existing #6310 `put_object_commit_namespace_lock_wait` metric wiring intact, with a small test-only clippy cleanup in its label comparison helper.

This is intentionally not a `renameat` optimization and does not try to release the early-ACK tail-drain lock earlier. It is a bounded, rollback-safe admission probe for same-object overwrite pressure observed in the 1MiB c16 #1856/#925 runs.

## Verification

- `cargo fmt --all --check`
- `cargo test -p rustfs-ecstore put_object_commit_lock_timeout_override -- --nocapture`
- `cargo test -p rustfs-ecstore put_object_commit_namespace_lock_wait_metric_is_wired_to_both_write_lock_paths -- --nocapture`
- `cargo clippy -p rustfs-ecstore --tests -- -D warnings`
- `git diff --check`

Adversarial validation:

- Correctness: attacked default-off behavior, non-`put_object_commit` paths, contended same-object timeout, and permit release after timeout; no break found.
- Simplicity: kept the change to a single env override plus the two existing write-lock acquisition paths; no new queue/manager or tail-drain rewrite.
- Security: no path/key/secret labels or logs added; timeout returns a bounded static error variant.
- Concurrency/durability: does not change lock ordering, tail-drain retention, rename/fdatasync order, rollback, or cancellation ownership.
- Compatibility: default-off and no S3/on-disk/RPC format change; enabled mode intentionally returns existing SlowDown semantics for admission.
- Performance: default-off path only reads a cached `OnceLock<u64>` and uses the existing lock acquisition path; no extra syscall or logging.
- Test coverage: added focused tests for default-off/PUT-only timeout selection and contended same-object timeout returning SlowDown without leaking the lock.

## Impact

Default behavior is unchanged.

Operators can opt in with `RUSTFS_PUT_COMMIT_NAMESPACE_LOCK_ACQUIRE_TIMEOUT_MS=<milliseconds>` to bound `put_object_commit` namespace lock waits under same-object commit/tail-drain contention. A bounded wait timeout returns SlowDown so clients can retry instead of waiting for the global object-lock timeout.

## Additional Notes

The intended next validation, after CI is stable and this remains a merge candidate, is the same 4-node clean-data 1MiB PUT c16 short probe with `RUSTFS_OBS_PUT_STAGE_METRICS_ENABLED=true`, `RUSTFS_PUT_RENAME_EARLY_ACK_ENABLE=true`, and this new timeout enabled. Do not expand the size matrix.
