### PR TITLE
test: stabilize release-blocking full E2E checks

### DIFF
--- a/crates/e2e_test/src/common.rs
+++ b/crates/e2e_test/src/common.rs
@@ -53,7 +53,8 @@ pub(crate) const FAST_DATA_USAGE_SCANNER_ENV: &[(&str, &str)] =
 pub const TEST_BUCKET: &str = "e2e-test-bucket";
 const RUSTFS_FULL_FEATURE: &str = "full";
 const TEST_PORT_MIN: u16 = 20_000;
-const TEST_PORT_RANGE: u16 = 40_000;
+// Keep allocator ports below the ephemeral range used by bind(..., 0) test helpers.
+const TEST_PORT_RANGE: u16 = 10_000;
 const TEST_PORT_COUNTER_PATH: &str = "/tmp/rustfs_e2e_next_port";
 const TEST_PORT_LOCK_DIR: &str = "/tmp/rustfs_e2e_port_allocator.lock";
 const TEST_PORT_LOCK_STALE_AFTER: Duration = Duration::from_secs(30);

--- a/crates/e2e_test/src/inline_fast_path_cluster_test.rs
+++ b/crates/e2e_test/src/inline_fast_path_cluster_test.rs
@@ -2255,6 +2255,7 @@ async fn four_node_manual_transition_distributed_admission_conflict_reports_stat
     hot.set_env("RUSTFS_SCANNER_CYCLE", "3600");
     hot.set_env("RUSTFS_MAX_TRANSITION_WORKERS", "1");
     hot.set_env("RUSTFS_TRANSITION_QUEUE_CAPACITY", "1");
+    hot.set_env("RUSTFS_TRANSITION_QUEUE_SEND_TIMEOUT_MS", "1");
     hot.start().await?;
 
     let hot_client = hot.create_s3_client(0)?;
@@ -2271,7 +2272,7 @@ async fn four_node_manual_transition_distributed_admission_conflict_reports_stat
             .put_object()
             .bucket(&bucket)
             .key(key)
-            .body(ByteStream::from(payload(64 * KIB, index)))
+            .body(ByteStream::from(payload(1024 * KIB, index)))
             .send()
             .await?;
     }

--- a/crates/e2e_test/src/quota_test.rs
+++ b/crates/e2e_test/src/quota_test.rs
@@ -634,6 +634,7 @@ mod integration_tests {
         let env = QuotaTestEnv::new().await?;
 
         env.create_bucket().await?;
+        env.wait_for_quota_usage_for(&env.bucket_name).await?;
 
         // Test 1: GET quota for bucket without quota config
         let url = format!("{}/rustfs/admin/v3/quota/{}", env.env.url, env.bucket_name);


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Wait for authoritative quota usage before the quota endpoint test's first GET.
- Make the distributed transition backpressure scenario deterministic with a 1 ms queue timeout and 1 MiB objects.
- Keep E2E allocator ports below the Linux ephemeral range used by `bind(..., 0)` helpers.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo nextest run -p e2e_test quota_test::integration_tests::test_quota_http_endpoints --no-capture`
- `cargo nextest run -p e2e_test inline_fast_path_cluster_test::four_node_manual_transition_distributed_admission_conflict_reports_status_and_backpressure` (passed twice after the final change)
- Correctness and simplicity adversarial reviews passed.

## Impact

Test-only stabilization. No runtime or API changes.

## Additional Notes

Fixes the two failures from the full merge gate on `main` run 32425245836. The port-range update addresses the `Address already in use` smoke failure in PR run 32430373252.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
