### PR TITLE
fix(ci): update package checksums safely

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -189,6 +189,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         include:
           - arch: x86_64
@@ -510,14 +511,12 @@ jobs:
 
           CHECKSUM_DIR="$(mktemp -d)"
           gh release download "$TAG" -p 'SHA256SUMS' -p 'SHA512SUMS' \
-            -D "$CHECKSUM_DIR" --clobber 2>/dev/null || true
+            -D "$CHECKSUM_DIR" --clobber
 
           for spec in "SHA256SUMS:sha256sum" "SHA512SUMS:sha512sum"; do
             asset="${spec%%:*}"
             checksum_cmd="${spec##*:}"
             checksum_file="${CHECKSUM_DIR}/${asset}"
-
-            touch "$checksum_file"
 
             for f in "$DEB_FILE" "$RPM_FILE"; do
               if [[ -n "$f" && -f "$f" ]]; then
@@ -531,7 +530,8 @@ jobs:
                 grep -Fv -- "$base" "$checksum_file" > "${checksum_file}.tmp" || true
                 grep -Fv -- "$github_base" "${checksum_file}.tmp" > "${checksum_file}.tmp2" || true
                 mv "${checksum_file}.tmp2" "$checksum_file"
-                (cd "$(dirname "$f")" && "$checksum_cmd" -- "$github_base") >> "$checksum_file"
+                digest=$("$checksum_cmd" -- "$f" | awk '{print $1}')
+                printf '%s  %s\n' "$digest" "$github_base" >> "$checksum_file"
               fi
             done
 


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Hash package files by their actual local names while writing the normalized GitHub asset names into the checksum files. Package matrix jobs now run serially so each architecture preserves the checksum entries uploaded by the previous one, and a missing checksum asset fails instead of replacing the release checksums with an incomplete file.

## Verification

- `git diff --check`
- `actionlint -ignore SC2012 -ignore SC2129 .github/workflows/package.yml`
- `scripts/security/check_job_timeouts.sh`
- `scripts/security/check_preview_release_workflow.sh`
- `scripts/security/check_workflow_pins.sh`
- `scripts/security/check_persist_credentials.sh`
- `scripts/security/check_cache_save_if.sh`
- Local checksum update probe for both package architectures

## Impact

DEB and RPM release assets are included in SHA256SUMS and SHA512SUMS without checksum update races.

## Additional Notes

The 1.0.0-rc.3 checksum assets were repaired separately after verifying all four package files.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
