### PR TITLE
perf(server): trim internode REST compat stack

### DIFF
--- a/rustfs/src/server/http.rs
+++ b/rustfs/src/server/http.rs
@@ -1537,7 +1537,7 @@ fn process_connection(
                 None
             }
         };
-        // ── Canonical Middleware Stack Order (outermost → innermost) ──
+        // ── Canonical External Middleware Stack Order (outermost → innermost) ──
         // This order MUST be preserved across refactorings.
         // Only AddExtensionLayer (layers 1-2) are per-connection; most remaining layers are stateless.
         //
@@ -1565,6 +1565,8 @@ fn process_connection(
         // 22. PublicHealthEndpointLayer              — handles public health before s3s host parsing
         // 23. VirtualHostStyleHintLayer              — actionable error for unroutable virtual-hosted-style (conditional)
         // 24. DoubleSlashListBucketsCompatLayer      — rewrites `GET //` to `GET /` for ListBuckets (MinIO browser compat)
+        // The internode lane below intentionally keeps only the shared
+        // transport/auth/observability subset needed by `/rustfs/rpc/...`.
         // ─────────────────────────────────────────────────────────────
         let build_external_stack = |service| {
             ServiceBuilder::new()
@@ -1747,16 +1749,9 @@ fn process_connection(
                 .layer(PropagateRequestIdLayer::x_request_id())
                 .layer(CompressionLayer::new().compress_when(PathAwareHttpCompressionPredicate::new(compression_config.clone())))
                 .option_layer(compression_config.enabled.then_some(PathCategoryInjectionLayer))
-                .layer(S3ErrorMessageCompatLayer)
-                .layer(IcebergRestErrorCompatLayer)
-                .layer(ObjectAttributesEtagFixLayer)
-                .layer(ConditionalCorsLayer::new())
-                .option_layer(if is_console { Some(RedirectLayer) } else { None })
-                .layer(BodylessStatusFixLayer)
-                .layer(HeadRequestBodyFixLayer)
-                .layer(PublicHealthEndpointLayer::new(Arc::clone(&server_ctx)))
-                .option_layer((!server_domains_configured && !is_console).then_some(VirtualHostStyleHintLayer))
-                .layer(DoubleSlashListBucketsCompatLayer)
+                // The internode lane only serves `/rustfs/rpc/...` gRPC requests.
+                // Keep safety/observability layers above, but leave S3/REST
+                // compatibility rewrites on the external lane.
                 .service(service)
         };
         let external_stack_service = build_external_stack(external_service);


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#1879.

## Summary of Changes

Trim the internode `/rustfs/rpc/...` HTTP service stack by leaving S3/REST compatibility rewrite layers on the external lane only.

The internode lane still keeps the shared transport, request-id, request-context, panic handling, readiness, Keystone auth, in-flight, trace, request-id propagation, compression, and path-category layers. It no longer pays the per-request wrapper cost for external S3/REST-only compatibility layers such as S3 error message rewriting, Iceberg REST error shaping, GetObjectAttributes ETag fixup, CORS, console redirect, bodyless status fixup, HEAD body stripping, public health aliases, virtual-host hints, and double-slash ListBuckets compatibility.

This is intentionally a narrow output-path candidate. It does not change the external S3 API lane, and it does not claim a measured throughput gain until the follow-up testing1 metrics-on A/B run.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs --lib rpc_ -- --nocapture`
- `cargo test -p rustfs --lib peer_rest_heal_control_uses_production_auth_and_keeps_validation_errors_online -- --nocapture`

Adversarial validation:

- Correctness: attacked RPC routing, auth target binding, health-control peer behavior, and removed layer semantics; no break found for internode gRPC, because the removed layers are external S3/REST compatibility rewrites and the RPC path/auth tests remain green.
- Simplicity: attacked helper extraction and test-only instrumentation alternatives; kept the diff to a local stack trim plus comment boundary update.
- Security: attacked auth/readiness/panic/trace removal risk; Keystone auth, readiness gate, panic guard, request context, trusted proxy, in-flight, and tracing remain in the internode lane.
- Concurrency/durability: no storage, locking, persistence, or retry semantics changed.
- Compatibility: external S3/REST compatibility behavior is unchanged; internode RPC is not a browser/S3 compatibility surface.
- Performance: removes fixed wrapper/future work from every internode RPC lane request; whole-node impact still requires testing1 A/B.
- Test coverage: focused RPC/auth/heal-control tests passed, but the exact throughput effect remains intentionally unclaimed until deployment validation.

## Impact

No configuration, wire-format, or public S3 API change is expected. Internode RPC requests should traverse fewer HTTP compatibility wrappers. External client requests continue to use the existing compatibility stack.

## Additional Notes

Follow-up plan: after merge, build latest main and run testing1 metrics-on small GET A/B, then compare obj/s, avg/p95/p99, h2/http/writev/allocation profile, and output/header stages. If the gain is inside noise, continue with broader h2/writev/output wrapper lifecycle attribution rather than pursuing single small header/wrapper items.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
