### PR TITLE
fix(ecstore): avoid decommission walk deadline on backpressure

### DIFF
--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -94,6 +94,9 @@ const DECOMMISSION_BUCKET_CONCURRENCY_DEFAULT_CAP: usize = 4;
 const DECOMMISSION_TARGET_CAPACITY_OVERHEAD_PERCENT: usize = 30;
 const DECOMMISSION_LISTING_MAX_ATTEMPTS: usize = 3;
 const DECOMMISSION_LISTING_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
+/// Background decommission walks must tolerate slow object migrations; the
+/// stall timeout is the drive-health bound, not the total listing duration.
+const DECOMMISSION_BACKGROUND_WALKDIR_STALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
 pub const POOL_META_NAME: &str = "pool.bin";
 pub const POOL_META_FORMAT: u16 = 1;
@@ -5047,6 +5050,8 @@ impl SetDisks {
                 path: bucket_info.prefix.clone(),
                 recursive: true,
                 min_disks: listing_quorum,
+                skip_walkdir_total_timeout: true,
+                walkdir_stall_timeout: Some(DECOMMISSION_BACKGROUND_WALKDIR_STALL_TIMEOUT),
                 agreed: Some(Box::new(move |entry: MetaCacheEntry| Box::pin(cb1(entry)))),
                 partial: Some(Box::new(move |entries: MetaCacheEntries, _: &[Option<DiskError>]| {
                     let resolver = resolver.clone();


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Decommission object listing inherited the default five-second whole-walk deadline. The listing callback can legitimately apply backpressure while the producer is still making progress, so healthy slow consumers were counted as a walk timeout and the bounded retry loop eventually marked the decommission failed.

This change gives decommission background walks the same timeout profile used by rebalance and healing: the whole walk is not capped, while each underlying directory/read operation retains a 60-second stall bound. The retry limit, cancellation behavior, metadata format, and routing semantics are unchanged.

## Verification

- `make pre-pr` (full integration branch: 14,052 nextest tests passed, 137 skipped; all doctests passed)
- `cargo test -p rustfs-ecstore --lib decommission -- --nocapture` (224 passed)
- `cargo test -p rustfs-ecstore --lib walk_dir_does_not_charge_consumer_backpressure_to_the_stall_budget`
- `cargo test -p rustfs-ecstore --lib with_walk_stall_timeout_fails_only_when_a_read_stops_answering`
- `cargo test -p rustfs-ecstore --lib with_walk_stall_deadline_bounds_reads_that_do_not_yield_a_result`
- `cargo test -p rustfs-ecstore --lib list_path_raw_cancels_a_blocked_peek_without_waiting_for_the_stall_timeout`
- `cargo test -p rustfs-ecstore --lib walk_dir_options_preserve_zero_total_and_inherited_stall_timeouts`
- `cargo clippy -p rustfs-ecstore --lib --tests -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

## Impact

No S3 API, wire protocol, on-disk metadata, configuration, or authentication changes. A decommission listing may run longer when the consumer is applying normal backpressure, but a drive read that stops answering is still bounded and fails through the existing retry path.

## Additional Notes

The larger task-drain/concurrency redesign identified during review is intentionally not included; this PR is limited to the reproduced five-second whole-walk timeout. Scanner publication fencing is tracked in a separate PR.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
