### PR TITLE
test(e2e): wait for heal peers after node rejoin

### DIFF
--- a/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
+++ b/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
@@ -380,10 +380,24 @@ mod tests {
         cluster.start_node(1).await?;
 
         let status_url = format!("{}/rustfs/admin/v3/background-heal/status", cluster.nodes[0].url);
-        let status_body = signed_admin_post(&status_url, None, &cluster.access_key, &cluster.secret_key).await?;
-        assert!(
-            !status_body.contains("MissingContentLength"),
-            "background heal status should not fail without an explicit Content-Length: {status_body}"
+        let mut recovered = serde_json::Value::Null;
+        for _ in 0..60 {
+            let status_body = signed_admin_post(&status_url, None, &cluster.access_key, &cluster.secret_key).await?;
+            assert!(
+                !status_body.contains("MissingContentLength"),
+                "background heal status should not fail without an explicit Content-Length: {status_body}"
+            );
+            recovered = serde_json::from_str(&status_body)
+                .map_err(|err| format!("background heal status is not JSON ({err}): {status_body}"))?;
+            if recovered["clusterStatusComplete"] == serde_json::Value::Bool(true) {
+                break;
+            }
+            sleep(Duration::from_secs(1)).await;
+        }
+        assert_eq!(
+            recovered["clusterStatusComplete"],
+            serde_json::Value::Bool(true),
+            "cluster heal status should recover before root heal starts: {recovered}"
         );
 
         let heal_body = r#"{"recursive":true,"dryRun":false,"remove":false,"recreate":true,"scanMode":2,"updateParity":false,"nolock":false}"#;


### PR DESCRIPTION
## Related Issues

- Validation follow-up for https://github.com/rustfs/backlog/issues/1897
- Reproduced in https://github.com/rustfs/rustfs/actions/runs/32491838504

## Summary of Changes

Wait for the cluster heal status to report complete after the replaced node rejoins, then submit the root heal once. The old one-shot status request could race peer recovery and send the heal request while the rejoined node was still considered offline.

This only changes the E2E test. The object-body and rebuilt `xl.meta` assertions are unchanged.

## Verification

- Exact E2E test with the patch: 3/3 passed
- Exact E2E test with the wait temporarily removed: failed with HTTP 500 `cluster heal coordination unavailable`
- `cargo fmt --all --check`
- `git diff --check`

## Impact

No production, API, compatibility, deployment, or configuration impact. The nightly heal test now waits on an observable readiness condition instead of racing peer recovery.

## Additional Notes

The heal request itself is not retried, so a real root-heal failure still fails the test.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
