### PR TITLE
test(ci): bound s3-tests failure logs

### DIFF
--- a/scripts/check_test_wiring.py
+++ b/scripts/check_test_wiring.py
@@ -206,6 +206,13 @@ def check_runner_selection(root: Path) -> list[str]:
     return errors
 
 
+def check_s3_tests_runner(root: Path) -> list[str]:
+    runner = (root / "scripts/s3-tests/run.sh").read_text()
+    if "--showlocals" in runner:
+        return ["scripts/s3-tests/run.sh: pytest failure diagnostics must not dump local values"]
+    return []
+
+
 def profile_selection(root: Path, profile: str) -> str:
     if not re.fullmatch(r"e2e-[a-z0-9-]+", profile):
         raise ValueError(f"invalid e2e profile name: {profile}")
@@ -272,6 +279,7 @@ def validate(root: Path) -> list[str]:
     errors.extend(check_e2e_modules(root))
     errors.extend(check_fuzz_targets(root))
     errors.extend(check_runner_selection(root))
+    errors.extend(check_s3_tests_runner(root))
     errors.extend(check_profile_definitions(root))
     return errors
 
@@ -340,6 +348,23 @@ class SelfTests(unittest.TestCase):
                 "  fuzz/prebuilt/${{ env.CARGO_BUILD_TARGET }}/release/one\n"
             )
             self.assertEqual(len(check_fuzz_targets(root)), 1)
+
+    def test_s3_runner_rejects_unbounded_failure_locals(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runner = root / "scripts/s3-tests/run.sh"
+            runner.parent.mkdir(parents=True)
+            runner.write_text("tox -- -vv -ra --tb=long\n")
+            self.assertEqual(check_s3_tests_runner(root), [])
+            runner.write_text("tox -- -vv -ra --showlocals --tb=long\n")
+            self.assertEqual(len(check_s3_tests_runner(root)), 1)
+            with (
+                mock.patch(__name__ + ".check_e2e_modules", return_value=[]),
+                mock.patch(__name__ + ".check_fuzz_targets", return_value=[]),
+                mock.patch(__name__ + ".check_runner_selection", return_value=[]),
+                mock.patch(__name__ + ".check_profile_definitions", return_value=[]),
+            ):
+                self.assertEqual(len(validate(root)), 1)
 
     def test_profile_listing_enforces_selection(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -411,7 +436,7 @@ def main() -> int:
         for error in errors:
             print(f"ERROR: {error}", file=sys.stderr)
         return 1
-    print("OK: e2e modules, runner selection, fuzz matrices, and profile guards are wired")
+    print("OK: e2e modules, runner selection, fuzz matrices, profiles, and bounded diagnostics are wired")
     return 0
 
 

--- a/scripts/s3-tests/run.sh
+++ b/scripts/s3-tests/run.sh
@@ -1028,10 +1028,11 @@ else
 fi
 
 # Run tests from s3tests/functional
+# Failure locals can contain multi-MiB request bodies; keep tracebacks without expanding local values.
 set +e
 S3TEST_CONF="${CONF_OUTPUT_PATH}" \
     tox -- \
-    -vv -ra --showlocals --tb=long \
+    -vv -ra --tb=long \
     --maxfail="${MAXFAIL}" \
     --timeout="${TEST_TIMEOUT}" \
     --junitxml="${ARTIFACTS_DIR}/junit.xml" \


### PR DESCRIPTION
## Related Issues

- Validation follow-up for https://github.com/rustfs/backlog/issues/1897
- Reproduced in https://github.com/rustfs/rustfs/actions/runs/32491842623 and https://github.com/rustfs/rustfs/actions/runs/32491846212

## Summary of Changes

Stop pytest from expanding every local value in S3 compatibility failure tracebacks. Both observed runs reached 100% test progress in about five minutes, then printed a failed test's 2 MiB request payload as millions of log lines and never reached report generation before cancellation.

Long tracebacks, per-test timeouts, JUnit output, and compatibility classification are unchanged. A test-wiring guard prevents the unbounded diagnostic option from being reintroduced.

## Verification

- `python3 scripts/check_test_wiring.py --self-test`
- `python3 scripts/check_test_wiring.py`
- `python3 scripts/s3-tests/test_report_compat.py`
- `bash -n scripts/s3-tests/run.sh`
- `git diff --check`

## Impact

No production, API, compatibility, deployment, or configuration impact. Failed S3 compatibility runs retain actionable tracebacks while keeping payloads and credentials out of expanded local-value dumps.

## Additional Notes

The test execution and fail-closed compatibility gate are unchanged; this only bounds failure diagnostics so report and artifact steps can run.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
