### PR TITLE
fix(ecstore): fence deletes against decommission commits

### DIFF
--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -3532,6 +3532,22 @@ impl ECStore {
         Ok(())
     }
 
+    #[cfg(test)]
+    pub(crate) async fn decommission_entry_for_test(
+        self: &Arc<Self>,
+        idx: usize,
+        entry: MetaCacheEntry,
+        bucket: String,
+        set: Arc<SetDisks>,
+    ) -> Result<()> {
+        let worker_permit = Arc::new(Semaphore::new(1))
+            .acquire_owned()
+            .await
+            .map_err(|err| Error::other(format!("decommission test worker permit acquire failed: {err}")))?;
+        self.decommission_entry(CancellationToken::new(), idx, entry, bucket, set, worker_permit, None, None, None, None)
+            .await
+    }
+
     #[tracing::instrument(skip(self, rx))]
     async fn decommission_pool(
         self: &Arc<Self>,

--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -3416,6 +3416,9 @@ impl ECStore {
             )
             .await?;
 
+            let source_cleanup_mutation_fence = self
+                .acquire_decommission_source_cleanup_fence(bucket.as_str(), entry.name.as_str(), set.as_ref())
+                .await?;
             let cleanup_result = data_movement::cleanup_source_entry_if_unchanged(
                 set.clone(),
                 bucket.as_str(),
@@ -3427,6 +3430,7 @@ impl ECStore {
                     lifecycle_guard: bucket_incarnation_fence
                         .as_ref()
                         .and_then(|guard| guard.namespace_lock_guard()),
+                    object_mutation_fence: Some(&source_cleanup_mutation_fence),
                 },
                 "decommission",
             )

--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -4464,7 +4464,7 @@ impl ECStore {
     ) -> Result<()> {
         warn!("decommission_object: start {} {}", &bucket, &rd.object_info.name);
         let object_name = rd.object_info.name.clone();
-        let result = data_movement::migrate_object(
+        let result = data_movement::migrate_decommission_object(
             self,
             pool_idx,
             bucket.clone(),

--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -4484,15 +4484,20 @@ impl ECStore {
     ) -> Result<()> {
         warn!("decommission_object: start {} {}", &bucket, &rd.object_info.name);
         let object_name = rd.object_info.name.clone();
-        let result = data_movement::migrate_decommission_object(
+        let mut migration = tokio::task::JoinSet::new();
+        migration.spawn(data_movement::migrate_decommission_object(
             self,
             pool_idx,
             bucket.clone(),
             rd,
             expected_bucket_incarnation_id,
             "decommission_object",
-        )
-        .await;
+        ));
+        let result = migration
+            .join_next()
+            .await
+            .ok_or_else(|| Error::other("decommission migration task was not started"))?
+            .map_err(|err| Error::other(format!("decommission migration task join error: {err}")))?;
         if result.is_ok() {
             warn!("decommission_object: migrated {} {}", &bucket, &object_name);
         }

--- a/crates/ecstore/src/data_movement/mod.rs
+++ b/crates/ecstore/src/data_movement/mod.rs
@@ -1447,11 +1447,8 @@ async fn migrate_object_inner(
     if should_use_multipart_data_movement(&object_info, has_part_checksums) {
         let mut new_multipart_opts = data_movement_new_multipart_opts(&object_info, pool_idx);
         new_multipart_opts.expected_bucket_incarnation_id = source_bucket_incarnation_id;
-        if let Some(fence) = mutation_fence {
-            fence.add_namespace_lock_fence(&mut new_multipart_opts);
-        }
         let (res, target_pool_idx, expected_bucket_incarnation_id) = match store
-            .handle_new_multipart_upload_with_pool_idx(&bucket, &object_info.name, &new_multipart_opts)
+            .handle_new_multipart_upload_with_pool_idx(&bucket, &object_info.name, &new_multipart_opts, mutation_fence)
             .await
         {
             Ok(res) => res,
@@ -1546,9 +1543,6 @@ async fn migrate_object_inner(
                     )
                 })?;
             complete_multipart_opts.expected_bucket_incarnation_id = expected_bucket_incarnation_id;
-            if let Some(fence) = mutation_fence {
-                fence.add_namespace_lock_fence(&mut complete_multipart_opts);
-            }
             if let Err(err) = store
                 .clone()
                 .complete_multipart_upload_for_data_movement(
@@ -1558,6 +1552,7 @@ async fn migrate_object_inner(
                     &res.upload_id,
                     parts,
                     &complete_multipart_opts,
+                    mutation_fence,
                 )
                 .await
             {
@@ -1712,11 +1707,8 @@ async fn migrate_object_inner(
 
     let mut put_opts = data_movement_put_object_opts(&object_info, pool_idx);
     put_opts.expected_bucket_incarnation_id = source_bucket_incarnation_id;
-    if let Some(fence) = mutation_fence {
-        fence.add_namespace_lock_fence(&mut put_opts);
-    }
     let (target_pool_idx, put_result) = store
-        .put_object_for_data_movement(&bucket, &object_info.name, &mut data, &put_opts)
+        .put_object_for_data_movement(&bucket, &object_info.name, &mut data, &put_opts, mutation_fence)
         .await
         .map_err(|err| data_movement_stage_error(op_label, "prepare_put_object", &bucket, &object_info.name, err))?;
     if let Err(err) = put_result {

--- a/crates/ecstore/src/data_movement/mod.rs
+++ b/crates/ecstore/src/data_movement/mod.rs
@@ -26,8 +26,7 @@ use crate::storage_api_contracts::{
     namespace::NamespaceLocking as _,
     object::{HTTPPreconditions, ObjectOperations as _},
 };
-use crate::store::ECStore;
-use crate::store::ObjectLockDiagGuard;
+use crate::store::{ECStore, ObjectLockDiagGuard, SourceCleanupMutationFence};
 use bytes::Bytes;
 use rustfs_filemeta::{FileInfo, FileInfoVersions, ObjectPartInfo};
 use rustfs_rio::{EtagResolvable, HashReader, HashReaderDetector, Index, TryGetIndex};
@@ -1029,6 +1028,7 @@ pub(crate) enum SourceCleanupError {
 pub(crate) struct SourceCleanupBucketFence<'a> {
     pub(crate) expected_incarnation_id: Option<uuid::Uuid>,
     pub(crate) lifecycle_guard: Option<&'a rustfs_lock::NamespaceLockGuard>,
+    pub(crate) object_mutation_fence: Option<&'a SourceCleanupMutationFence>,
 }
 
 fn ensure_source_cleanup_versions_match(
@@ -1066,7 +1066,9 @@ pub(crate) async fn ensure_source_cleanup_versions_unchanged(
 struct SourceCleanupDeleteBarrierState {
     bucket: String,
     object: String,
+    fence_pending: tokio::sync::Notify,
     arrived: tokio::sync::Notify,
+    is_paused: AtomicBool,
     release: tokio::sync::Notify,
 }
 
@@ -1080,7 +1082,7 @@ pub(crate) struct SourceCleanupDeleteBarrier {
 }
 
 #[cfg(test)]
-static SOURCE_CLEANUP_DELETE_BARRIER: std::sync::OnceLock<std::sync::Mutex<Option<Arc<SourceCleanupDeleteBarrierState>>>> =
+static SOURCE_CLEANUP_DELETE_BARRIERS: std::sync::OnceLock<std::sync::Mutex<Vec<Arc<SourceCleanupDeleteBarrierState>>>> =
     std::sync::OnceLock::new();
 
 #[cfg(test)]
@@ -1093,15 +1095,22 @@ impl SourceCleanupDeleteBarrier {
         let state = Arc::new(SourceCleanupDeleteBarrierState {
             bucket: bucket.to_string(),
             object: object.to_string(),
+            fence_pending: tokio::sync::Notify::new(),
             arrived: tokio::sync::Notify::new(),
+            is_paused: AtomicBool::new(false),
             release: tokio::sync::Notify::new(),
         });
-        let mut slot = SOURCE_CLEANUP_DELETE_BARRIER
-            .get_or_init(|| std::sync::Mutex::new(None))
+        let mut barriers = SOURCE_CLEANUP_DELETE_BARRIERS
+            .get_or_init(|| std::sync::Mutex::new(Vec::new()))
             .lock()
             .expect("source cleanup delete barrier mutex should not poison");
-        assert!(slot.is_none(), "source cleanup delete barrier must be unique");
-        *slot = Some(Arc::clone(&state));
+        assert!(
+            !barriers
+                .iter()
+                .any(|barrier| barrier.bucket == bucket && barrier.object == object),
+            "source cleanup delete barrier must be unique per object"
+        );
+        barriers.push(Arc::clone(&state));
         Self { state }
     }
 
@@ -1111,8 +1120,32 @@ impl SourceCleanupDeleteBarrier {
             .expect("source cleanup should reach the pre-delete barrier");
     }
 
+    pub(crate) async fn wait_until_fence_pending(&self) {
+        tokio::time::timeout(StdDuration::from_secs(30), self.state.fence_pending.notified())
+            .await
+            .expect("source cleanup should attempt the fixed mutation fence");
+    }
+
+    pub(crate) fn is_paused(&self) -> bool {
+        self.state.is_paused.load(Ordering::Acquire)
+    }
+
     pub(crate) fn release(&self) {
         self.state.release.notify_one();
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn notify_source_cleanup_mutation_fence_pending(bucket: &str, object: &str) {
+    let barrier = SOURCE_CLEANUP_DELETE_BARRIERS
+        .get_or_init(|| std::sync::Mutex::new(Vec::new()))
+        .lock()
+        .expect("source cleanup delete barrier mutex should not poison")
+        .iter()
+        .find(|barrier| barrier.bucket == bucket && barrier.object == object)
+        .cloned();
+    if let Some(barrier) = barrier {
+        barrier.fence_pending.notify_one();
     }
 }
 
@@ -1120,26 +1153,25 @@ impl SourceCleanupDeleteBarrier {
 impl Drop for SourceCleanupDeleteBarrier {
     fn drop(&mut self) {
         self.state.release.notify_one();
-        let mut slot = SOURCE_CLEANUP_DELETE_BARRIER
-            .get_or_init(|| std::sync::Mutex::new(None))
+        let mut barriers = SOURCE_CLEANUP_DELETE_BARRIERS
+            .get_or_init(|| std::sync::Mutex::new(Vec::new()))
             .lock()
             .expect("source cleanup delete barrier mutex should not poison");
-        if slot.as_ref().is_some_and(|state| Arc::ptr_eq(state, &self.state)) {
-            *slot = None;
-        }
+        barriers.retain(|state| !Arc::ptr_eq(state, &self.state));
     }
 }
 
 #[cfg(test)]
 async fn pause_source_cleanup_before_delete(bucket: &str, object: &str) {
-    let barrier = SOURCE_CLEANUP_DELETE_BARRIER
-        .get_or_init(|| std::sync::Mutex::new(None))
+    let barrier = SOURCE_CLEANUP_DELETE_BARRIERS
+        .get_or_init(|| std::sync::Mutex::new(Vec::new()))
         .lock()
         .expect("source cleanup delete barrier mutex should not poison")
-        .as_ref()
-        .filter(|barrier| barrier.bucket == bucket && barrier.object == object)
+        .iter()
+        .find(|barrier| barrier.bucket == bucket && barrier.object == object)
         .cloned();
     if let Some(barrier) = barrier {
+        barrier.is_paused.store(true, Ordering::Release);
         barrier.arrived.notify_one();
         barrier.release.notified().await;
     }
@@ -1155,11 +1187,20 @@ pub(crate) async fn cleanup_source_entry_if_unchanged(
     op_label: &str,
 ) -> std::result::Result<ObjectInfo, SourceCleanupError> {
     let cleanup_key = encode_dir_object(object);
-    let ns_lock = set.new_ns_lock(bucket, cleanup_key.as_str()).await?;
-    let _guard = ns_lock
-        .get_write_lock(get_lock_acquire_timeout())
-        .await
-        .map_err(Error::from)?;
+    let source_guard = if bucket_fence
+        .object_mutation_fence
+        .is_some_and(SourceCleanupMutationFence::source_lock_covered)
+    {
+        None
+    } else {
+        let ns_lock = set.new_ns_lock(bucket, cleanup_key.as_str()).await?;
+        Some(
+            ns_lock
+                .get_write_lock(get_lock_acquire_timeout())
+                .await
+                .map_err(Error::from)?,
+        )
+    };
 
     if bucket_fence
         .lifecycle_guard
@@ -1167,6 +1208,14 @@ pub(crate) async fn cleanup_source_entry_if_unchanged(
     {
         return Err(SourceCleanupError::Storage(Error::other(format!(
             "{op_label}: bucket incarnation fence was lost before source cleanup"
+        ))));
+    }
+    if bucket_fence
+        .object_mutation_fence
+        .is_some_and(SourceCleanupMutationFence::is_lock_lost)
+    {
+        return Err(SourceCleanupError::Storage(Error::other(format!(
+            "{op_label}: object mutation fence was lost before source cleanup"
         ))));
     }
 
@@ -1183,7 +1232,12 @@ pub(crate) async fn cleanup_source_entry_if_unchanged(
         expected_bucket_incarnation_id: bucket_fence.expected_incarnation_id,
         ..Default::default()
     };
-    opts.add_namespace_lock_guard(&_guard);
+    if let Some(source_guard) = source_guard.as_ref() {
+        opts.add_namespace_lock_guard(source_guard);
+    }
+    if let Some(object_mutation_fence) = bucket_fence.object_mutation_fence {
+        object_mutation_fence.add_namespace_lock_fence(&mut opts);
+    }
     if let Some(bucket_lifecycle_guard) = bucket_fence.lifecycle_guard {
         opts.add_bucket_lifecycle_lock_guard(bucket_lifecycle_guard);
     }

--- a/crates/ecstore/src/data_movement/mod.rs
+++ b/crates/ecstore/src/data_movement/mod.rs
@@ -1545,13 +1545,12 @@ async fn migrate_object_inner(
             if let Err(err) = store
                 .clone()
                 .complete_multipart_upload_for_data_movement(
-                    target_pool_idx,
+                    (target_pool_idx, mutation_fence),
                     &bucket,
                     &object_info.name,
                     &res.upload_id,
                     parts,
                     &complete_multipart_opts,
-                    mutation_fence,
                 )
                 .await
             {

--- a/crates/ecstore/src/data_movement/mod.rs
+++ b/crates/ecstore/src/data_movement/mod.rs
@@ -856,7 +856,6 @@ fn is_equivalent_data_movement_object(source: &ObjectInfo, target: &ObjectInfo) 
 fn is_superseding_unversioned_data_movement_object(source: &ObjectInfo, target: &ObjectInfo) -> bool {
     is_unversioned_data_movement_object(source)
         && is_unversioned_data_movement_object(target)
-        && !target.delete_marker
         && source
             .mod_time
             .zip(target.mod_time)
@@ -3640,25 +3639,47 @@ mod tests {
     }
 
     #[test]
-    fn test_precondition_conflict_rejects_newer_delete_marker() {
-        let source = ObjectInfo {
-            size: 128,
-            etag: Some("etag-source".to_string()),
-            mod_time: Some(OffsetDateTime::UNIX_EPOCH),
-            ..Default::default()
-        };
-        let target = ObjectInfo {
-            delete_marker: true,
-            etag: None,
-            mod_time: OffsetDateTime::UNIX_EPOCH.checked_add(time::Duration::SECOND),
-            ..source.clone()
-        };
+    fn test_precondition_conflict_accepts_only_newer_null_delete_marker() {
+        for version_id in [None, Some(Uuid::nil())] {
+            let source = ObjectInfo {
+                version_id,
+                size: 128,
+                etag: Some("etag-source".to_string()),
+                mod_time: Some(OffsetDateTime::UNIX_EPOCH),
+                ..Default::default()
+            };
+            let target = ObjectInfo {
+                delete_marker: true,
+                etag: None,
+                mod_time: OffsetDateTime::UNIX_EPOCH.checked_add(time::Duration::SECOND),
+                ..source.clone()
+            };
 
-        let should_resume =
-            resolve_data_movement_overwrite_resume_result(&Error::PreconditionFailed, Ok(Some(target)), &source, 0, 1)
-                .expect("delete marker conflict should be evaluated");
+            assert!(
+                resolve_data_movement_overwrite_resume_result(
+                    &Error::PreconditionFailed,
+                    Ok(Some(target.clone())),
+                    &source,
+                    0,
+                    1,
+                )
+                .expect("newer null delete marker should be evaluated")
+            );
 
-        assert!(!should_resume);
+            let mut same_time = target.clone();
+            same_time.mod_time = source.mod_time;
+            assert!(
+                !resolve_data_movement_overwrite_resume_result(&Error::PreconditionFailed, Ok(Some(same_time)), &source, 0, 1,)
+                    .expect("same-generation null delete marker should be rejected")
+            );
+
+            let mut versioned = target;
+            versioned.version_id = Some(Uuid::new_v4());
+            assert!(
+                !resolve_data_movement_overwrite_resume_result(&Error::PreconditionFailed, Ok(Some(versioned)), &source, 0, 1,)
+                    .expect("a UUID delete marker must not erase a null source version")
+            );
+        }
     }
 
     #[test]

--- a/crates/ecstore/src/data_movement/mod.rs
+++ b/crates/ecstore/src/data_movement/mod.rs
@@ -27,6 +27,7 @@ use crate::storage_api_contracts::{
     object::{HTTPPreconditions, ObjectOperations as _},
 };
 use crate::store::ECStore;
+use crate::store::ObjectLockDiagGuard;
 use bytes::Bytes;
 use rustfs_filemeta::{FileInfo, FileInfoVersions, ObjectPartInfo};
 use rustfs_rio::{EtagResolvable, HashReader, HashReaderDetector, Index, TryGetIndex};
@@ -1330,6 +1331,37 @@ fn data_movement_part_upload_failure_stage(err: &Error) -> &'static str {
     }
 }
 
+pub(crate) async fn migrate_decommission_object(
+    store: Arc<ECStore>,
+    pool_idx: usize,
+    bucket: String,
+    rd: GetObjectReader,
+    source_bucket_incarnation_id: Option<uuid::Uuid>,
+    op_label: &str,
+) -> Result<()> {
+    let source = rd.object_info.clone();
+    let _mutation_fence = store
+        .acquire_decommission_object_mutation_fence(&bucket, &source.name)
+        .await?;
+    let current = find_data_movement_target_info(store.as_ref(), pool_idx, &bucket, &source)
+        .await?
+        .ok_or(Error::FileNotFound)?;
+    if !is_equivalent_data_movement_object_identity(&source, &current, true, false) {
+        return Err(Error::FileNotFound);
+    }
+
+    migrate_object_inner(
+        store,
+        pool_idx,
+        bucket,
+        rd,
+        source_bucket_incarnation_id,
+        op_label,
+        Some(&_mutation_fence),
+    )
+    .await
+}
+
 pub(crate) async fn migrate_object(
     store: Arc<ECStore>,
     pool_idx: usize,
@@ -1337,6 +1369,18 @@ pub(crate) async fn migrate_object(
     rd: GetObjectReader,
     source_bucket_incarnation_id: Option<uuid::Uuid>,
     op_label: &str,
+) -> Result<()> {
+    migrate_object_inner(store, pool_idx, bucket, rd, source_bucket_incarnation_id, op_label, None).await
+}
+
+async fn migrate_object_inner(
+    store: Arc<ECStore>,
+    pool_idx: usize,
+    bucket: String,
+    rd: GetObjectReader,
+    source_bucket_incarnation_id: Option<uuid::Uuid>,
+    op_label: &str,
+    mutation_fence: Option<&ObjectLockDiagGuard>,
 ) -> Result<()> {
     let object_info = rd.object_info.clone();
     let has_part_checksums = object_info
@@ -1349,6 +1393,9 @@ pub(crate) async fn migrate_object(
     if should_use_multipart_data_movement(&object_info, has_part_checksums) {
         let mut new_multipart_opts = data_movement_new_multipart_opts(&object_info, pool_idx);
         new_multipart_opts.expected_bucket_incarnation_id = source_bucket_incarnation_id;
+        if let Some(fence) = mutation_fence {
+            fence.add_namespace_lock_fence(&mut new_multipart_opts);
+        }
         let (res, target_pool_idx, expected_bucket_incarnation_id) = match store
             .handle_new_multipart_upload_with_pool_idx(&bucket, &object_info.name, &new_multipart_opts)
             .await
@@ -1445,6 +1492,9 @@ pub(crate) async fn migrate_object(
                     )
                 })?;
             complete_multipart_opts.expected_bucket_incarnation_id = expected_bucket_incarnation_id;
+            if let Some(fence) = mutation_fence {
+                fence.add_namespace_lock_fence(&mut complete_multipart_opts);
+            }
             if let Err(err) = store
                 .clone()
                 .complete_multipart_upload_for_data_movement(
@@ -1608,6 +1658,9 @@ pub(crate) async fn migrate_object(
 
     let mut put_opts = data_movement_put_object_opts(&object_info, pool_idx);
     put_opts.expected_bucket_incarnation_id = source_bucket_incarnation_id;
+    if let Some(fence) = mutation_fence {
+        fence.add_namespace_lock_fence(&mut put_opts);
+    }
     let (target_pool_idx, put_result) = store
         .put_object_for_data_movement(&bucket, &object_info.name, &mut data, &put_opts)
         .await

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -858,6 +858,7 @@ const EVENT_DISK_LOCAL_DIRECT_IO_FALLBACK: &str = "disk_local_direct_io_fallback
 #[cfg(target_os = "linux")]
 const EVENT_DISK_LOCAL_URING_LATCH_OFF: &str = "disk_local_uring_latch_off";
 const EVENT_DISK_LOCAL_DELETE_FAILED: &str = "disk_local_delete_failed";
+const EVENT_DISK_LOCAL_DELETE_ROLLBACK_FAILED: &str = "disk_local_delete_rollback_failed";
 const EVENT_DISK_LOCAL_CHECK_PARTS: &str = "disk_local_check_parts";
 const EVENT_DISK_LOCAL_ACCESS_FAILED: &str = "disk_local_access_failed";
 const EVENT_DISK_LOCAL_VOLUME_SETUP_FAILED: &str = "disk_local_volume_setup_failed";
@@ -6106,6 +6107,43 @@ impl LocalDisk {
         Ok((bytes, modtime))
     }
 
+    async fn write_missing_delete_marker(
+        &self,
+        volume: &str,
+        path: &str,
+        fi: FileInfo,
+        object_dir: &Path,
+        xl_path: &Path,
+        rollback_dir: Option<Uuid>,
+    ) -> Result<()> {
+        if let Some(rollback_dir) = rollback_dir {
+            let rollback_path = object_dir.join(rollback_dir.to_string());
+            fs::create_dir_all(&rollback_path).await.map_err(to_file_error)?;
+            fs::write(rollback_path.join(DELETE_MARKER_ROLLBACK_FILE), [])
+                .await
+                .map_err(to_file_error)?;
+        }
+        if let Err(err) = self.write_metadata("", volume, path, fi).await {
+            if let Some(rollback_dir) = rollback_dir
+                && let Err(restore_err) = restore_delete_rollback(object_dir, xl_path, rollback_dir, &self.publication_root).await
+            {
+                warn!(
+                    event = EVENT_DISK_LOCAL_DELETE_ROLLBACK_FAILED,
+                    component = LOG_COMPONENT_ECSTORE,
+                    subsystem = LOG_SUBSYSTEM_DISK_LOCAL,
+                    result = "failed",
+                    volume,
+                    path,
+                    rollback_dir = %rollback_dir,
+                    error = ?restore_err,
+                    "Disk local delete rollback failed"
+                );
+            }
+            return Err(err);
+        }
+        Ok(())
+    }
+
     async fn delete_versions_internal(&self, volume: &str, path: &str, fis: &[FileInfo], opts: &DeleteOptions) -> Result<()> {
         let volume_dir = self.io_get_bucket_path(volume)?;
         let xlpath = self.io_get_object_path(volume, format!("{path}/{STORAGE_FORMAT_FILE}").as_str())?;
@@ -6123,7 +6161,20 @@ impl LocalDisk {
             return restore_metadata_backup(object_dir, &xlpath, rollback_dir, &self.publication_root).await;
         }
 
-        let (data, _) = self.read_all_data_with_dmtime(volume, volume_dir.as_path(), &xlpath).await?;
+        let (data, _) = match self.read_all_data_with_dmtime(volume, volume_dir.as_path(), &xlpath).await {
+            Ok(data) => data,
+            Err(DiskError::FileNotFound) => {
+                // `deleted` alone can be an explicit marker purge; only
+                // `mark_deleted` may create metadata that was not present.
+                let Some(delete_marker) = fis.iter().find(|fi| fi.deleted && fi.mark_deleted).cloned() else {
+                    return Err(DiskError::FileNotFound);
+                };
+                return self
+                    .write_missing_delete_marker(volume, path, delete_marker, object_dir, &xlpath, opts.old_data_dir)
+                    .await;
+            }
+            Err(err) => return Err(err),
+        };
 
         if data.is_empty() {
             return Err(DiskError::FileNotFound);
@@ -10422,29 +10473,9 @@ impl DiskAPI for LocalDisk {
                 }
 
                 if fi.deleted && force_del_marker {
-                    if let Some(rollback_dir) = rollback_dir {
-                        let rollback_path = file_path.join(rollback_dir.to_string());
-                        fs::create_dir_all(&rollback_path).await.map_err(to_file_error)?;
-                        fs::write(rollback_path.join(DELETE_MARKER_ROLLBACK_FILE), [])
-                            .await
-                            .map_err(to_file_error)?;
-                    }
-                    if let Err(err) = self.write_metadata("", volume, path, fi).await {
-                        if let Some(rollback_dir) = rollback_dir
-                            && let Err(restore_err) =
-                                restore_delete_rollback(file_path.as_path(), &xl_path, rollback_dir, &self.publication_root).await
-                        {
-                            warn!(
-                                volume,
-                                path,
-                                rollback_dir = %rollback_dir,
-                                error = ?restore_err,
-                                "failed to restore metadata after delete marker commit error"
-                            );
-                        }
-                        return Err(err);
-                    }
-                    return Ok(());
+                    return self
+                        .write_missing_delete_marker(volume, path, fi, file_path.as_path(), &xl_path, rollback_dir)
+                        .await;
                 }
 
                 return if fi.version_id.is_some() {

--- a/crates/ecstore/src/object_api/types.rs
+++ b/crates/ecstore/src/object_api/types.rs
@@ -24,7 +24,7 @@ use crate::storage_api_contracts::{
 pub struct NamespaceLockFence {
     signals: Arc<Vec<Arc<rustfs_lock::distributed_lock::LockLostSignal>>>,
     #[cfg(test)]
-    forced_lost: Arc<std::sync::atomic::AtomicBool>,
+    forced_lost: Arc<Vec<Arc<std::sync::atomic::AtomicBool>>>,
 }
 
 impl Debug for NamespaceLockFence {
@@ -40,13 +40,17 @@ impl NamespaceLockFence {
         Self {
             signals: Arc::default(),
             #[cfg(test)]
-            forced_lost: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            forced_lost: Arc::new(vec![Arc::new(std::sync::atomic::AtomicBool::new(false))]),
         }
     }
 
     pub(crate) fn is_lock_lost(&self) -> bool {
         #[cfg(test)]
-        if self.forced_lost.load(std::sync::atomic::Ordering::Acquire) {
+        if self
+            .forced_lost
+            .iter()
+            .any(|lost| lost.load(std::sync::atomic::Ordering::Acquire))
+        {
             return true;
         }
         self.signals.iter().any(|signal| signal.is_lost())
@@ -57,27 +61,26 @@ impl NamespaceLockFence {
     }
 
     fn extend(&mut self, other: &Self) {
-        if Arc::ptr_eq(&self.signals, &other.signals) {
-            return;
+        if !Arc::ptr_eq(&self.signals, &other.signals) {
+            Arc::make_mut(&mut self.signals).extend(other.signals.iter().cloned());
         }
-        Arc::make_mut(&mut self.signals).extend(other.signals.iter().cloned());
         #[cfg(test)]
-        if other.forced_lost.load(std::sync::atomic::Ordering::Acquire) {
-            self.forced_lost.store(true, std::sync::atomic::Ordering::Release);
+        if !Arc::ptr_eq(&self.forced_lost, &other.forced_lost) {
+            Arc::make_mut(&mut self.forced_lost).extend(other.forced_lost.iter().cloned());
         }
     }
 
     #[cfg(test)]
     pub(crate) fn lost_for_test() -> Self {
         let fence = Self::new();
-        fence.forced_lost.store(true, std::sync::atomic::Ordering::Release);
+        fence.forced_lost[0].store(true, std::sync::atomic::Ordering::Release);
         fence
     }
 
     #[cfg(test)]
     pub(crate) fn loss_handle_for_test() -> (Self, Arc<std::sync::atomic::AtomicBool>) {
         let fence = Self::new();
-        (fence.clone(), Arc::clone(&fence.forced_lost))
+        (fence.clone(), Arc::clone(&fence.forced_lost[0]))
     }
 }
 
@@ -409,6 +412,13 @@ impl ObjectOptions {
 
     pub(crate) fn ensure_namespace_lock_fence(&mut self) {
         self.namespace_lock_fence.get_or_insert_with(NamespaceLockFence::new);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn add_namespace_lock_fence_for_test(&mut self, fence: &NamespaceLockFence) {
+        self.namespace_lock_fence
+            .get_or_insert_with(NamespaceLockFence::new)
+            .extend(fence);
     }
 
     pub(crate) fn ensure_lifecycle_delete_all_journal(&mut self) {

--- a/crates/ecstore/src/services/rebalance/entry.rs
+++ b/crates/ecstore/src/services/rebalance/entry.rs
@@ -334,6 +334,7 @@ impl ECStore {
                             lifecycle_guard: bucket_incarnation_fence
                                 .as_ref()
                                 .and_then(|guard| guard.namespace_lock_guard()),
+                            ..Default::default()
                         },
                         "rebalance",
                     ),

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -4588,11 +4588,11 @@ fn should_preserve_delete_replication_state(opts: &ObjectOptions) -> bool {
 }
 
 fn should_force_delete_marker_for_missing_version(opts: &ObjectOptions) -> bool {
-    opts.delete_marker || (opts.versioned && opts.version_id.is_none() && !opts.data_movement)
+    opts.delete_marker || ((opts.versioned || opts.version_suspended) && opts.version_id.is_none() && !opts.data_movement)
 }
 
 fn resolve_delete_version_state(opts: &ObjectOptions, goi: &ObjectInfo, version_found: bool) -> (bool, bool) {
-    let mut mark_delete = goi.version_id.is_some() || (opts.versioned && opts.version_id.is_none());
+    let mut mark_delete = goi.version_id.is_some() || ((opts.versioned || opts.version_suspended) && opts.version_id.is_none());
     let mut delete_marker = opts.versioned;
 
     if opts.version_id.is_some() {

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -3604,6 +3604,15 @@ impl SetDisks {
         &self.ctx
     }
 
+    /// Whether both sets' namespace-lock implementations cover the same object key.
+    pub(crate) async fn shares_namespace_lock_domain(&self, other: &Self) -> bool {
+        match (self.ctx.is_dist_erasure().await, other.ctx.is_dist_erasure().await) {
+            (false, false) => Arc::ptr_eq(&self.local_lock_manager, &other.local_lock_manager),
+            (true, true) => Arc::ptr_eq(&self.ctx, &other.ctx) && self.set_lock_namespace == other.set_lock_namespace,
+            _ => false,
+        }
+    }
+
     /// The lock manager this set actually uses (test-only; Phase 5 Slice 3).
     #[cfg(test)]
     pub(crate) fn local_lock_manager_for_test(&self) -> &Arc<rustfs_lock::GlobalLockManager> {

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -735,8 +735,12 @@ pub(crate) use core::io_primitives::disk_call_counters;
 mod ctx;
 mod metadata;
 mod ops;
+#[cfg(test)]
+pub(crate) use ops::multipart::NewMultipartUploadCommitObservation;
 #[cfg(any(test, feature = "test-util"))]
 pub use ops::multipart::{MultipartCommitBarrier, MultipartCommitPause};
+#[cfg(test)]
+pub(crate) use ops::object::DeleteObjectCommitBarrier;
 #[cfg(feature = "test-util")]
 pub(crate) use ops::object::TransitionCleanupStoreBarrier as SetDiskTransitionCleanupStoreBarrier;
 pub(crate) use ops::object::body_cache_plaintext_len;

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -3029,6 +3029,16 @@ pub struct SetDisks {
     storage_class_config_override: Arc<std::sync::RwLock<Option<Arc<storageclass::Config>>>>,
 }
 
+// DistributedLock sends the raw ObjectKey to its clients; LockRegistry clones
+// each endpoint's canonical Arc, so an exact Arc set identifies the lock domain.
+pub(crate) fn same_distributed_lock_domain(left: &[Arc<dyn LockClient>], right: &[Arc<dyn LockClient>]) -> bool {
+    left.iter()
+        .all(|left_client| right.iter().any(|right_client| Arc::ptr_eq(left_client, right_client)))
+        && right
+            .iter()
+            .all(|right_client| left.iter().any(|left_client| Arc::ptr_eq(left_client, right_client)))
+}
+
 const ERASURE_CACHE_MAX_ENTRIES: usize = 32;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -3608,7 +3618,7 @@ impl SetDisks {
     pub(crate) async fn shares_namespace_lock_domain(&self, other: &Self) -> bool {
         match (self.ctx.is_dist_erasure().await, other.ctx.is_dist_erasure().await) {
             (false, false) => Arc::ptr_eq(&self.local_lock_manager, &other.local_lock_manager),
-            (true, true) => Arc::ptr_eq(&self.ctx, &other.ctx) && self.set_lock_namespace == other.set_lock_namespace,
+            (true, true) => same_distributed_lock_domain(&self.lockers, &other.lockers),
             _ => false,
         }
     }

--- a/crates/ecstore/src/set_disk/ops/multipart.rs
+++ b/crates/ecstore/src/set_disk/ops/multipart.rs
@@ -32,6 +32,8 @@ use crate::crash_inject::{self, CrashPoint};
 use crate::multipart_listing::paginate_multipart_listing;
 use futures::{StreamExt, stream};
 use std::future::Future;
+#[cfg(test)]
+use std::sync::atomic::AtomicBool;
 #[cfg(any(test, feature = "test-util"))]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -65,6 +67,7 @@ impl StaleMultipartCleanupGuard {
 #[cfg(any(test, feature = "test-util"))]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum MultipartCommitPause {
+    NewUploadBeforeLockLost,
     PutPartBeforeLockAcquire,
     PutPartBeforeLockLost,
     PutPartAfterRename,
@@ -153,6 +156,72 @@ impl Drop for MultipartCommitBarrier {
         if slot.as_ref().is_some_and(|state| Arc::ptr_eq(state, &self.state)) {
             *slot = None;
         }
+    }
+}
+
+#[cfg(test)]
+struct NewMultipartUploadCommitObservationState {
+    bucket: String,
+    object: String,
+    committed: AtomicBool,
+}
+
+#[cfg(test)]
+pub(crate) struct NewMultipartUploadCommitObservation {
+    state: Arc<NewMultipartUploadCommitObservationState>,
+}
+
+#[cfg(test)]
+static NEW_MULTIPART_UPLOAD_COMMIT_OBSERVATION: std::sync::OnceLock<
+    std::sync::Mutex<Option<Arc<NewMultipartUploadCommitObservationState>>>,
+> = std::sync::OnceLock::new();
+
+#[cfg(test)]
+impl NewMultipartUploadCommitObservation {
+    pub(crate) fn install(bucket: &str, object: &str) -> Self {
+        let state = Arc::new(NewMultipartUploadCommitObservationState {
+            bucket: bucket.to_string(),
+            object: object.to_string(),
+            committed: AtomicBool::new(false),
+        });
+        let mut slot = NEW_MULTIPART_UPLOAD_COMMIT_OBSERVATION
+            .get_or_init(|| std::sync::Mutex::new(None))
+            .lock()
+            .expect("new multipart upload commit observation mutex should not poison");
+        assert!(slot.is_none(), "new multipart upload commit observation must be unique");
+        *slot = Some(Arc::clone(&state));
+        Self { state }
+    }
+
+    pub(crate) fn committed(&self) -> bool {
+        self.state.committed.load(Ordering::Acquire)
+    }
+}
+
+#[cfg(test)]
+impl Drop for NewMultipartUploadCommitObservation {
+    fn drop(&mut self) {
+        let mut slot = NEW_MULTIPART_UPLOAD_COMMIT_OBSERVATION
+            .get_or_init(|| std::sync::Mutex::new(None))
+            .lock()
+            .expect("new multipart upload commit observation mutex should not poison");
+        if slot.as_ref().is_some_and(|state| Arc::ptr_eq(state, &self.state)) {
+            *slot = None;
+        }
+    }
+}
+
+#[cfg(test)]
+fn observe_new_multipart_upload_commit(bucket: &str, object: &str) {
+    let state = NEW_MULTIPART_UPLOAD_COMMIT_OBSERVATION
+        .get_or_init(|| std::sync::Mutex::new(None))
+        .lock()
+        .expect("new multipart upload commit observation mutex should not poison")
+        .as_ref()
+        .filter(|state| state.bucket == bucket && state.object == object)
+        .cloned();
+    if let Some(state) = state {
+        state.committed.store(true, Ordering::Release);
     }
 }
 
@@ -1615,6 +1684,30 @@ impl crate::storage_api_contracts::multipart::MultipartOperations for SetDisks {
 
         let upload_path = Self::get_multipart_upload_dir(bucket, object, upload_uuid.as_str(), opts.data_movement);
 
+        #[cfg(any(test, feature = "test-util"))]
+        pause_multipart_commit(bucket, object, MultipartCommitPause::NewUploadBeforeLockLost).await;
+        if _object_lock_guard.as_ref().is_some_and(|guard| guard.is_lock_lost()) {
+            return Err(StorageError::NamespaceLockQuorumUnavailable {
+                mode: "new_multipart_upload_commit",
+                bucket: bucket.to_string(),
+                object: object.to_string(),
+                required: 1,
+                achieved: 0,
+            });
+        }
+        if opts
+            .namespace_lock_fence
+            .as_ref()
+            .is_some_and(NamespaceLockFence::is_lock_lost)
+        {
+            return Err(StorageError::NamespaceLockQuorumUnavailable {
+                mode: "new_multipart_upload_outer_lock",
+                bucket: bucket.to_string(),
+                object: object.to_string(),
+                required: 1,
+                achieved: 0,
+            });
+        }
         ensure_multipart_bucket_lifecycle_lock_held(bucket, object, opts)?;
         Self::write_unique_file_info(
             &shuffle_disks,
@@ -1626,6 +1719,8 @@ impl crate::storage_api_contracts::multipart::MultipartOperations for SetDisks {
         )
         .await
         .map_err(|e| to_object_err(e.into(), vec![bucket, object]))?;
+        #[cfg(test)]
+        observe_new_multipart_upload_commit(bucket, object);
 
         // evalDisks
 

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -5941,6 +5941,7 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
             if dobj.version_id.is_none() && (version_suspended || versioned) {
                 vr.mod_time = Some(OffsetDateTime::now_utc());
                 vr.deleted = true;
+                vr.mark_deleted = true;
                 if versioned {
                     vr.version_id = Some(Uuid::new_v4());
                 }

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -11804,6 +11804,7 @@ mod transition_upload_integrity_tests {
                 crate::data_movement::SourceCleanupBucketFence {
                     expected_incarnation_id: None,
                     lifecycle_guard: Some(&bucket_guard),
+                    ..Default::default()
                 },
                 "test_data_movement",
             )

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -2497,6 +2497,7 @@ impl SetDisks {
                         })
                         .await?,
                     );
+                    notify_put_object_commit_namespace_acquired(bucket, object);
                 }
                 #[cfg(not(any(test, feature = "test-util")))]
                 {
@@ -4644,6 +4645,7 @@ struct PutObjectCommitBarrierState {
     arrived: tokio::sync::Notify,
     release: tokio::sync::Notify,
     namespace_pending: tokio::sync::Notify,
+    namespace_acquired: std::sync::atomic::AtomicBool,
 }
 
 #[cfg(any(test, feature = "test-util"))]
@@ -4665,6 +4667,7 @@ impl PutObjectCommitBarrier {
             arrived: tokio::sync::Notify::new(),
             release: tokio::sync::Notify::new(),
             namespace_pending: tokio::sync::Notify::new(),
+            namespace_acquired: std::sync::atomic::AtomicBool::new(false),
         });
         let mut slot = PUT_OBJECT_COMMIT_BARRIER
             .get_or_init(|| std::sync::Mutex::new(Vec::new()))
@@ -4698,6 +4701,10 @@ impl PutObjectCommitBarrier {
         tokio::time::timeout(Duration::from_secs(5), namespace_pending)
             .await
             .expect("put object should wait for the namespace lock after leaving the commit barrier");
+    }
+
+    pub fn namespace_acquired(&self) -> bool {
+        self.state.namespace_acquired.load(std::sync::atomic::Ordering::Acquire)
     }
 }
 
@@ -4752,6 +4759,22 @@ fn notify_put_object_commit_namespace_pending(bucket: &str, object: &str) {
         .cloned();
     if let Some(barrier) = barrier {
         barrier.namespace_pending.notify_one();
+    }
+}
+
+#[cfg(any(test, feature = "test-util"))]
+fn notify_put_object_commit_namespace_acquired(bucket: &str, object: &str) {
+    let barrier = PUT_OBJECT_COMMIT_BARRIER
+        .get_or_init(|| std::sync::Mutex::new(Vec::new()))
+        .lock()
+        .expect("put object commit barrier mutex should not poison")
+        .iter()
+        .find(|barrier| {
+            barrier.bucket == bucket && barrier.object == object && barrier.pause == PutObjectCommitPause::BeforeNamespace
+        })
+        .cloned();
+    if let Some(barrier) = barrier {
+        barrier.namespace_acquired.store(true, std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -4787,7 +4787,7 @@ struct DeleteObjectCommitBarrierState {
 }
 
 #[cfg(test)]
-struct DeleteObjectCommitBarrier {
+pub(crate) struct DeleteObjectCommitBarrier {
     state: Arc<DeleteObjectCommitBarrierState>,
 }
 
@@ -4797,7 +4797,7 @@ static DELETE_OBJECT_COMMIT_BARRIER: std::sync::OnceLock<std::sync::Mutex<Option
 
 #[cfg(test)]
 impl DeleteObjectCommitBarrier {
-    fn install(bucket: &str, object: &str) -> Self {
+    pub(crate) fn install(bucket: &str, object: &str) -> Self {
         let state = Arc::new(DeleteObjectCommitBarrierState {
             bucket: bucket.to_string(),
             object: object.to_string(),
@@ -4813,13 +4813,13 @@ impl DeleteObjectCommitBarrier {
         Self { state }
     }
 
-    async fn wait_until_paused(&self) {
+    pub(crate) async fn wait_until_paused(&self) {
         tokio::time::timeout(Duration::from_secs(30), self.state.arrived.notified())
             .await
             .expect("delete object should reach the deterministic commit barrier");
     }
 
-    fn release(&self) {
+    pub(crate) fn release(&self) {
         self.state.release.notify_one();
     }
 }

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -604,15 +604,15 @@ mod tests {
         storage_api_contracts::{
             bucket::{BucketOperations as _, MakeBucketOptions},
             multipart::MultipartOperations as _,
-            object::{ObjectIO, ObjectOperations as _},
+            object::{ObjectIO, ObjectOperations as _, ObjectToDelete},
             range::HTTPRangeSpec,
         },
     };
     use http::HeaderMap;
     use rustfs_config::server_config::KVS;
-    use rustfs_filemeta::ObjectPartInfo;
     #[cfg(feature = "test-util")]
     use rustfs_filemeta::{FileInfo, FileMeta};
+    use rustfs_filemeta::{FileInfoVersions, ObjectPartInfo};
     #[cfg(feature = "test-util")]
     use rustfs_protos::{TIER_MUTATION_RPC_PROTOCOL_VERSION, TierMutationRpcPhase};
     use rustfs_rio::{Checksum, ChecksumType};
@@ -1224,6 +1224,79 @@ mod tests {
         assert!(matches!(err, StorageError::ErasureWriteQuorum));
 
         shutdown.cancel();
+    }
+
+    async fn migrate_versioned_decommission_test_object(
+        store: &Arc<crate::store::ECStore>,
+        bucket: &str,
+        object: &str,
+        payload: &[u8],
+        op_label: &'static str,
+    ) -> (uuid::Uuid, FileInfoVersions) {
+        let mut source = PutObjReader::from_vec(payload.to_vec());
+        let source_info = store.pools[0]
+            .put_object(
+                bucket,
+                object,
+                &mut source,
+                &ObjectOptions {
+                    versioned: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("write versioned source to the pool being decommissioned");
+        let source_version = source_info.version_id.expect("versioned source must have a version ID");
+        let expected_source_versions = store.pools[0]
+            .get_disks_by_key(object)
+            .load_file_info_versions_exact(bucket, object)
+            .await
+            .expect("source versions should be readable before migration")
+            .expect("source versions should exist before migration");
+        {
+            let mut pool_meta = store.pool_meta.write().await;
+            pool_meta.pools[0].decommission = Some(PoolDecommissionInfo {
+                start_time: Some(OffsetDateTime::now_utc()),
+                ..Default::default()
+            });
+        }
+
+        let barrier = crate::set_disk::PutObjectCommitBarrier::install(
+            bucket,
+            object,
+            crate::set_disk::PutObjectCommitPause::BeforeNamespace,
+        );
+        let migration_store = Arc::clone(store);
+        let migration_bucket = bucket.to_string();
+        let migration_object = object.to_string();
+        let migration = tokio::spawn(async move {
+            let source_reader = migration_store.pools[0]
+                .get_object_reader(
+                    &migration_bucket,
+                    &migration_object,
+                    None,
+                    HeaderMap::new(),
+                    &ObjectOptions {
+                        versioned: true,
+                        version_id: Some(source_version.to_string()),
+                        no_lock: true,
+                        data_movement: true,
+                        raw_data_movement_read: true,
+                        ..Default::default()
+                    },
+                )
+                .await?;
+            crate::data_movement::migrate_decommission_object(migration_store, 0, migration_bucket, source_reader, None, op_label)
+                .await
+        });
+        barrier.wait_until_paused().await;
+        barrier.release();
+        migration
+            .await
+            .expect("versioned decommission migration task should join")
+            .expect("versioned decommission migration should commit");
+
+        (source_version, expected_source_versions)
     }
 
     #[tokio::test]
@@ -2872,74 +2945,14 @@ mod tests {
             .make_bucket(&bucket, &MakeBucketOptions::default())
             .await
             .expect("create versioned decommission delete-fence bucket");
-        let mut source = PutObjReader::from_vec(b"source generation".to_vec());
-        let source_info = store.pools[0]
-            .put_object(
-                &bucket,
-                object,
-                &mut source,
-                &ObjectOptions {
-                    versioned: true,
-                    ..Default::default()
-                },
-            )
-            .await
-            .expect("write source version to the pool being decommissioned");
-        let source_version = source_info.version_id.expect("versioned source must have a version ID");
-        let expected_source_versions = store.pools[0]
-            .get_disks_by_key(object)
-            .load_file_info_versions_exact(&bucket, object)
-            .await
-            .expect("source versions should be readable before migration")
-            .expect("source versions should exist before migration");
-        {
-            let mut pool_meta = store.pool_meta.write().await;
-            pool_meta.pools[0].decommission = Some(PoolDecommissionInfo {
-                start_time: Some(OffsetDateTime::now_utc()),
-                ..Default::default()
-            });
-        }
-
-        let barrier = crate::set_disk::PutObjectCommitBarrier::install(
+        let (source_version, expected_source_versions) = migrate_versioned_decommission_test_object(
+            &store,
             &bucket,
             object,
-            crate::set_disk::PutObjectCommitPause::BeforeNamespace,
-        );
-        let migration_store = Arc::clone(&store);
-        let migration_bucket = bucket.clone();
-        let migration = tokio::spawn(async move {
-            let source_reader = migration_store.pools[0]
-                .get_object_reader(
-                    &migration_bucket,
-                    object,
-                    None,
-                    HeaderMap::new(),
-                    &ObjectOptions {
-                        versioned: true,
-                        version_id: Some(source_version.to_string()),
-                        no_lock: true,
-                        data_movement: true,
-                        raw_data_movement_read: true,
-                        ..Default::default()
-                    },
-                )
-                .await?;
-            crate::data_movement::migrate_decommission_object(
-                migration_store,
-                0,
-                migration_bucket,
-                source_reader,
-                None,
-                "test_versioned_decommission_delete_fence",
-            )
-            .await
-        });
-        barrier.wait_until_paused().await;
-        barrier.release();
-        migration
-            .await
-            .expect("versioned decommission migration task should join")
-            .expect("versioned decommission migration should commit before DELETE");
+            b"source generation",
+            "test_versioned_decommission_delete_fence",
+        )
+        .await;
 
         let delete_barrier = crate::store::object::VersionedDeleteMarkerCommitBarrier::install(&bucket, object);
         let delete_store = Arc::clone(&store);
@@ -3053,6 +3066,102 @@ mod tests {
             )
             .await
             .expect_err("source cleanup must remove the decommissioned source versions");
+
+        shutdown.cancel();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(storage_class_env)]
+    async fn versioned_batch_delete_marker_skips_decommission_source() {
+        let temp_dir = tempfile::tempdir().expect("create versioned batch decommission store dir");
+        let (_ctx, store, shutdown) = without_storage_class_env(build_isolated_test_store(
+            temp_dir.path(),
+            "versioned-batch-decommission-delete-fence",
+            &[4, 4, 4],
+        ))
+        .await;
+        crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
+
+        let bucket = format!("versioned-batch-decommission-delete-fence-{}", uuid::Uuid::new_v4());
+        let object = "batch-object.bin";
+        store
+            .make_bucket(&bucket, &MakeBucketOptions::default())
+            .await
+            .expect("create versioned batch decommission bucket");
+        let (_source_version, expected_source_versions) = migrate_versioned_decommission_test_object(
+            &store,
+            &bucket,
+            object,
+            b"batch source generation",
+            "test_versioned_batch_decommission_delete_fence",
+        )
+        .await;
+
+        let delete_config_snapshot =
+            Arc::new(crate::bucket::replication::DeleteReplicationConfigSnapshot::from_configs_for_test(
+                s3s::dto::VersioningConfiguration {
+                    status: Some(s3s::dto::BucketVersioningStatus::from_static(s3s::dto::BucketVersioningStatus::ENABLED)),
+                    ..Default::default()
+                },
+                None,
+            ));
+        let delete_barrier = crate::store::object::VersionedDeleteMarkerCommitBarrier::install(&bucket, object);
+        let delete_store = Arc::clone(&store);
+        let delete_bucket = bucket.clone();
+        let delete = tokio::spawn(async move {
+            delete_store
+                .delete_objects(
+                    &delete_bucket,
+                    vec![ObjectToDelete {
+                        object_name: object.to_string(),
+                        ..Default::default()
+                    }],
+                    ObjectOptions {
+                        delete_replication_config_snapshot: Some(delete_config_snapshot),
+                        ..Default::default()
+                    },
+                )
+                .await
+        });
+        delete_barrier.wait_until_paused().await;
+
+        let source_set = store.pools[0].get_disks_by_key(object);
+        crate::data_movement::ensure_source_cleanup_versions_unchanged(
+            source_set,
+            &bucket,
+            object,
+            &expected_source_versions,
+            &[],
+            "test_versioned_batch_decommission_delete_fence",
+        )
+        .await
+        .expect("batch DELETE must not publish a marker to the suspended source");
+
+        delete_barrier.release();
+        let (deleted, errors) = delete.await.expect("versioned batch DELETE task should join");
+        assert!(errors.iter().all(Option::is_none), "versioned batch DELETE should succeed: {errors:?}");
+        assert_eq!(deleted.len(), 1);
+        assert!(deleted[0].delete_marker, "versioned batch DELETE must return a marker");
+        assert!(
+            deleted[0]
+                .delete_marker_version_id
+                .is_some_and(|version_id| !version_id.is_nil()),
+            "versioned batch DELETE marker must have a non-nil version ID"
+        );
+
+        let mut active_marker_count = 0;
+        for pool in store.pools.iter().skip(1) {
+            let Some(versions) = pool
+                .get_disks_by_key(object)
+                .load_file_info_versions_exact(&bucket, object)
+                .await
+                .expect("active-pool versions should be readable")
+            else {
+                continue;
+            };
+            active_marker_count += versions.versions.iter().filter(|version| version.deleted).count();
+        }
+        assert_eq!(active_marker_count, 1, "batch DELETE must publish exactly one active-pool marker");
 
         shutdown.cancel();
     }

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -3538,7 +3538,7 @@ mod tests {
                 "the injected error pool must be the decommission source"
             );
 
-            let expected_errors = vec![
+            let expected_errors = [
                 StorageError::ErasureWriteQuorum,
                 StorageError::NamespaceLockQuorumUnavailable {
                     mode: "delete_objects_commit",

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -2843,12 +2843,11 @@ mod tests {
             .map(|index| format!("object-{index}.bin"))
             .find(|candidate| store.pools[0].get_disks_by_key(candidate).set_index == 1)
             .expect("the deterministic object search should select source set 1");
-        let source_body = b"source generation".to_vec();
         store
             .make_bucket(&bucket, &MakeBucketOptions::default())
             .await
             .expect("create decommission delete-fence bucket");
-        let mut source = PutObjReader::from_vec(source_body.clone());
+        let mut source = PutObjReader::from_vec(b"source generation".to_vec());
         store.pools[0]
             .put_object(&bucket, &object, &mut source, &ObjectOptions::default())
             .await
@@ -2903,14 +2902,6 @@ mod tests {
             !delete_barrier.namespace_acquired() && !delete.is_finished(),
             "DELETE must remain before namespace acquisition behind the decommission worker's target-commit mutation fence"
         );
-        delete.abort();
-        assert!(
-            delete
-                .await
-                .expect_err("the blocked DELETE should be canceled")
-                .is_cancelled(),
-            "the competing DELETE must remain cancelable while blocked"
-        );
 
         barrier.release();
         cleanup_barrier.wait_until_paused().await;
@@ -2951,22 +2942,29 @@ mod tests {
             .await
             .expect("decommission entry worker should join")
             .expect("decommission entry should migrate and clean its source");
+        delete
+            .await
+            .expect("DELETE task should join")
+            .expect("DELETE should remove the source and migrated target generations");
 
-        store.pools[0]
+        for pool in &store.pools {
+            let err = pool
+                .get_object_info(&bucket, &object, &ObjectOptions::default())
+                .await
+                .expect_err("DELETE must remove the source and migrated target copies");
+            assert!(
+                matches!(err, StorageError::ObjectNotFound(_, _)),
+                "unexpected post-delete pool result: {err:?}"
+            );
+        }
+        let err = store
             .get_object_info(&bucket, &object, &ObjectOptions::default())
             .await
-            .expect_err("the real decommission entry must clean the source generation");
-        let mut target = store.pools[1]
-            .get_object_reader(&bucket, &object, None, HeaderMap::new(), &ObjectOptions::default())
-            .await
-            .expect("the real decommission entry must commit the target generation");
-        let mut actual = Vec::new();
-        target
-            .stream
-            .read_to_end(&mut actual)
-            .await
-            .expect("read the migrated target generation");
-        assert_eq!(actual, source_body, "the decommission worker must preserve the migrated object body");
+            .expect_err("the deleted generation must not become visible again");
+        assert!(
+            matches!(err, StorageError::ObjectNotFound(_, _)),
+            "unexpected post-delete store result: {err:?}"
+        );
 
         shutdown.cancel();
     }

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -2932,6 +2932,110 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial(storage_class_env)]
+    async fn decommission_source_cleanup_holds_hashed_set_lock_across_preflight() {
+        let temp_dir = tempfile::tempdir().expect("create multi-set decommission cleanup store dir");
+        let (_ctx, store, shutdown) = without_storage_class_env(build_isolated_test_store_with_layout(
+            temp_dir.path(),
+            "multi-set-decommission-source-cleanup",
+            &[(2, 4)],
+            CancellationToken::new(),
+        ))
+        .await;
+        crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
+
+        let bucket = format!("multi-set-decommission-source-cleanup-{}", uuid::Uuid::new_v4());
+        let object = (0..128)
+            .map(|index| format!("object-{index}.bin"))
+            .find(|candidate| store.pools[0].get_disks_by_key(candidate).set_index == 1)
+            .expect("the deterministic object search should select source set 1");
+        store
+            .make_bucket(&bucket, &MakeBucketOptions::default())
+            .await
+            .expect("create multi-set decommission cleanup bucket");
+        let mut source = PutObjReader::from_vec(b"source generation".to_vec());
+        store.pools[0]
+            .put_object(&bucket, &object, &mut source, &ObjectOptions::default())
+            .await
+            .expect("write the source generation to set 1");
+        let source_set = store.pools[0].get_disks_by_key(&object);
+        assert_eq!(source_set.set_index, 1, "the source must not share the fixed set-0 namespace");
+        let expected_source_versions = source_set
+            .load_file_info_versions_exact(&bucket, &object)
+            .await
+            .expect("source versions should be readable")
+            .expect("the source generation should exist");
+
+        let cleanup_barrier = crate::data_movement::SourceCleanupDeleteBarrier::install(&bucket, &object);
+        let cleanup_store = Arc::clone(&store);
+        let cleanup_bucket = bucket.clone();
+        let cleanup_object = object.clone();
+        let cleanup = tokio::spawn(async move {
+            let mutation_fence = cleanup_store
+                .acquire_decommission_source_cleanup_fence(&cleanup_bucket, &cleanup_object, source_set.as_ref())
+                .await?;
+            crate::data_movement::cleanup_source_entry_if_unchanged(
+                source_set,
+                &cleanup_bucket,
+                &cleanup_object,
+                &expected_source_versions,
+                &[],
+                crate::data_movement::SourceCleanupBucketFence {
+                    object_mutation_fence: Some(&mutation_fence),
+                    ..Default::default()
+                },
+                "test_multi_set_decommission_source_cleanup",
+            )
+            .await
+        });
+        cleanup_barrier.wait_until_paused().await;
+
+        let put_barrier = crate::set_disk::PutObjectCommitBarrier::install(
+            &bucket,
+            &object,
+            crate::set_disk::PutObjectCommitPause::BeforeNamespace,
+        );
+        let mutation_pool = Arc::clone(&store.pools[0]);
+        let mutation_bucket = bucket.clone();
+        let mutation_object = object.clone();
+        let replacement = b"replacement generation".to_vec();
+        let expected_replacement = replacement.clone();
+        let mutation = tokio::spawn(async move {
+            let mut reader = PutObjReader::from_vec(replacement);
+            mutation_pool
+                .put_object(&mutation_bucket, &mutation_object, &mut reader, &ObjectOptions::default())
+                .await
+        });
+        put_barrier.wait_until_paused().await;
+        put_barrier.release_and_wait_until_namespace_pending().await;
+        assert!(!mutation.is_finished(), "a source mutation must wait behind cleanup's set-1 write lock");
+
+        cleanup_barrier.release();
+        cleanup
+            .await
+            .expect("source cleanup task should join")
+            .expect("source cleanup should remove only the preflight generation");
+        mutation
+            .await
+            .expect("source mutation task should join")
+            .expect("source mutation should commit after cleanup releases the set lock");
+
+        let mut reader = store.pools[0]
+            .get_object_reader(&bucket, &object, None, HeaderMap::new(), &ObjectOptions::default())
+            .await
+            .expect("the replacement generation must remain readable");
+        let mut actual = Vec::new();
+        reader
+            .stream
+            .read_to_end(&mut actual)
+            .await
+            .expect("read the replacement generation");
+        assert_eq!(actual, expected_replacement, "cleanup must not delete the replacement generation");
+
+        shutdown.cancel();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(storage_class_env)]
     async fn versioned_delete_marker_survives_decommission_source_cleanup() {
         let temp_dir = tempfile::tempdir().expect("create versioned decommission delete-fence store dir");
         let (_ctx, store, shutdown) =

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -2817,15 +2817,15 @@ mod tests {
         let delete_barrier = crate::store::object::DeleteAfterObjectLockSnapshotBarrier::install(&bucket);
         let delete_store = Arc::clone(&store);
         let delete_bucket = bucket.clone();
-        let mut delete = tokio::spawn(async move {
+        let delete = tokio::spawn(async move {
             delete_store
                 .delete_object(&delete_bucket, object, ObjectOptions::default())
                 .await
         });
         delete_barrier.wait_until_paused().await;
-        delete_barrier.release();
+        delete_barrier.release_and_wait_until_namespace_pending().await;
         assert!(
-            tokio::time::timeout(Duration::from_millis(100), &mut delete).await.is_err(),
+            !delete.is_finished(),
             "DELETE must wait while the decommission source generation is being committed"
         );
 
@@ -2853,6 +2853,147 @@ mod tests {
             .get_object_info(&bucket, object, &ObjectOptions::default())
             .await
             .expect_err("the migrated source generation must not become visible again");
+
+        shutdown.cancel();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(storage_class_env)]
+    async fn versioned_delete_waits_for_decommission_commit_then_publishes_marker() {
+        let temp_dir = tempfile::tempdir().expect("create versioned decommission delete-fence store dir");
+        let (_ctx, store, shutdown) =
+            without_storage_class_env(build_isolated_test_store(temp_dir.path(), "versioned-decommission-delete-fence", &[4, 4]))
+                .await;
+        crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
+
+        let bucket = format!("versioned-decommission-delete-fence-{}", uuid::Uuid::new_v4());
+        let object = "object.bin";
+        store
+            .make_bucket(&bucket, &MakeBucketOptions::default())
+            .await
+            .expect("create versioned decommission delete-fence bucket");
+        let mut source = PutObjReader::from_vec(b"source generation".to_vec());
+        let source_info = store.pools[0]
+            .put_object(
+                &bucket,
+                object,
+                &mut source,
+                &ObjectOptions {
+                    versioned: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("write source version to the pool being decommissioned");
+        let source_version = source_info.version_id.expect("versioned source must have a version ID");
+        {
+            let mut pool_meta = store.pool_meta.write().await;
+            pool_meta.pools[0].decommission = Some(PoolDecommissionInfo {
+                start_time: Some(OffsetDateTime::now_utc()),
+                ..Default::default()
+            });
+        }
+
+        let barrier = crate::set_disk::PutObjectCommitBarrier::install(
+            &bucket,
+            object,
+            crate::set_disk::PutObjectCommitPause::BeforeNamespace,
+        );
+        let migration_store = Arc::clone(&store);
+        let migration_bucket = bucket.clone();
+        let migration = tokio::spawn(async move {
+            let source_reader = migration_store.pools[0]
+                .get_object_reader(
+                    &migration_bucket,
+                    object,
+                    None,
+                    HeaderMap::new(),
+                    &ObjectOptions {
+                        versioned: true,
+                        version_id: Some(source_version.to_string()),
+                        no_lock: true,
+                        data_movement: true,
+                        raw_data_movement_read: true,
+                        ..Default::default()
+                    },
+                )
+                .await?;
+            crate::data_movement::migrate_decommission_object(
+                migration_store,
+                0,
+                migration_bucket,
+                source_reader,
+                None,
+                "test_versioned_decommission_delete_fence",
+            )
+            .await
+        });
+        barrier.wait_until_paused().await;
+
+        let delete_barrier = crate::store::object::DeleteAfterObjectLockSnapshotBarrier::install(&bucket);
+        let delete_store = Arc::clone(&store);
+        let delete_bucket = bucket.clone();
+        let delete = tokio::spawn(async move {
+            delete_store
+                .delete_object(
+                    &delete_bucket,
+                    object,
+                    ObjectOptions {
+                        versioned: true,
+                        ..Default::default()
+                    },
+                )
+                .await
+        });
+        delete_barrier.wait_until_paused().await;
+        delete_barrier.release_and_wait_until_namespace_pending().await;
+        assert!(
+            !delete.is_finished(),
+            "versioned DELETE must wait while the source version is being committed"
+        );
+
+        barrier.release();
+        migration
+            .await
+            .expect("versioned decommission migration task should join")
+            .expect("versioned decommission migration should commit before DELETE");
+        let marker = delete
+            .await
+            .expect("versioned DELETE task should join")
+            .expect("versioned DELETE should publish a delete marker after migration");
+        assert!(marker.delete_marker, "versioned DELETE must publish a delete marker");
+        assert!(
+            marker.version_id.is_some_and(|version_id| !version_id.is_nil()),
+            "the delete marker must have a non-nil version ID"
+        );
+
+        let err = store
+            .get_object_info(
+                &bucket,
+                object,
+                &ObjectOptions {
+                    versioned: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("the post-migration delete marker must hide the migrated version");
+        assert!(
+            matches!(err, StorageError::ObjectNotFound(_, _)),
+            "unexpected latest-version result: {err:?}"
+        );
+        store
+            .get_object_info(
+                &bucket,
+                object,
+                &ObjectOptions {
+                    versioned: true,
+                    version_id: Some(source_version.to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("the migrated source version must remain addressable below the delete marker");
 
         shutdown.cancel();
     }

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -2752,6 +2752,111 @@ mod tests {
             .expect_err("suspended delete must remove the requested UUID version");
     }
 
+    #[tokio::test]
+    #[serial_test::serial(storage_class_env)]
+    async fn delete_waits_for_decommission_commit_then_removes_every_copy() {
+        let temp_dir = tempfile::tempdir().expect("create decommission delete-fence store dir");
+        let (_ctx, store, shutdown) =
+            without_storage_class_env(build_isolated_test_store(temp_dir.path(), "decommission-delete-fence", &[4, 4])).await;
+        crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
+
+        let bucket = format!("decommission-delete-fence-{}", uuid::Uuid::new_v4());
+        let object = "object.bin";
+        store
+            .make_bucket(&bucket, &MakeBucketOptions::default())
+            .await
+            .expect("create decommission delete-fence bucket");
+        let mut source = PutObjReader::from_vec(b"source generation".to_vec());
+        store.pools[0]
+            .put_object(&bucket, object, &mut source, &ObjectOptions::default())
+            .await
+            .expect("write source object to the pool being decommissioned");
+        {
+            let mut pool_meta = store.pool_meta.write().await;
+            pool_meta.pools[0].decommission = Some(PoolDecommissionInfo {
+                start_time: Some(OffsetDateTime::now_utc()),
+                ..Default::default()
+            });
+        }
+        assert!(store.is_suspended(0).await, "pool 0 must be a suspended decommission source");
+
+        let barrier = crate::set_disk::PutObjectCommitBarrier::install(
+            &bucket,
+            object,
+            crate::set_disk::PutObjectCommitPause::BeforeNamespace,
+        );
+        let migration_store = Arc::clone(&store);
+        let migration_bucket = bucket.clone();
+        let migration = tokio::spawn(async move {
+            let source_reader = migration_store.pools[0]
+                .get_object_reader(
+                    &migration_bucket,
+                    object,
+                    None,
+                    HeaderMap::new(),
+                    &ObjectOptions {
+                        no_lock: true,
+                        data_movement: true,
+                        raw_data_movement_read: true,
+                        ..Default::default()
+                    },
+                )
+                .await?;
+            crate::data_movement::migrate_decommission_object(
+                migration_store,
+                0,
+                migration_bucket,
+                source_reader,
+                None,
+                "test_decommission_delete_fence",
+            )
+            .await
+        });
+        barrier.wait_until_paused().await;
+
+        let delete_barrier = crate::store::object::DeleteAfterObjectLockSnapshotBarrier::install(&bucket);
+        let delete_store = Arc::clone(&store);
+        let delete_bucket = bucket.clone();
+        let mut delete = tokio::spawn(async move {
+            delete_store
+                .delete_object(&delete_bucket, object, ObjectOptions::default())
+                .await
+        });
+        delete_barrier.wait_until_paused().await;
+        delete_barrier.release();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut delete).await.is_err(),
+            "DELETE must wait while the decommission source generation is being committed"
+        );
+
+        barrier.release();
+        migration
+            .await
+            .expect("decommission migration task should join")
+            .expect("decommission migration should commit before DELETE");
+        delete
+            .await
+            .expect("DELETE task should join")
+            .expect("DELETE should remove the committed migration generation");
+
+        for pool in &store.pools {
+            let err = pool
+                .get_object_info(&bucket, object, &ObjectOptions::default())
+                .await
+                .expect_err("DELETE must remove the source and migrated target copies");
+            assert!(
+                matches!(err, StorageError::ObjectNotFound(_, _)),
+                "unexpected post-delete pool result: {err:?}"
+            );
+        }
+        store
+            .get_object_info(&bucket, object, &ObjectOptions::default())
+            .await
+            .expect_err("the migrated source generation must not become visible again");
+
+        shutdown.cancel();
+    }
+
     #[cfg(feature = "test-util")]
     #[tokio::test]
     #[serial_test::serial(storage_class_env)]

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -1264,7 +1264,7 @@ mod tests {
         let barrier = crate::set_disk::PutObjectCommitBarrier::install(
             bucket,
             object,
-            crate::set_disk::PutObjectCommitPause::BeforeNamespace,
+            crate::set_disk::PutObjectCommitPause::AfterNamespace,
         );
         let migration_store = Arc::clone(store);
         let migration_bucket = bucket.to_string();
@@ -1365,7 +1365,7 @@ mod tests {
                 &mut reader,
                 &ObjectOptions {
                     version_suspended: true,
-                    mod_time: Some(OffsetDateTime::UNIX_EPOCH),
+                    mod_time: Some(OffsetDateTime::UNIX_EPOCH + time::Duration::SECOND),
                     ..Default::default()
                 },
             )
@@ -2997,7 +2997,7 @@ mod tests {
         let barrier = crate::set_disk::PutObjectCommitBarrier::install(
             &bucket,
             &object,
-            crate::set_disk::PutObjectCommitPause::BeforeNamespace,
+            crate::set_disk::PutObjectCommitPause::AfterNamespace,
         );
         let cleanup_barrier = crate::data_movement::SourceCleanupDeleteBarrier::install(&bucket, &object);
         let source_set = store.pools[0].get_disks_by_key(&object);
@@ -3266,7 +3266,7 @@ mod tests {
             object,
             crate::store::object::DecommissionMutationFenceTestPhase::SourceCleanup,
         );
-        let barrier = crate::set_disk::DeleteObjectCommitBarrier::install(&bucket, object);
+        let barrier = crate::data_movement::SourceCleanupDeleteBarrier::install(&bucket, object);
         let source_set = store.pools[0].get_disks_by_key(object);
         let worker_store = Arc::clone(&store);
         let worker_bucket = bucket.clone();
@@ -3376,7 +3376,7 @@ mod tests {
         let commit_barrier = crate::set_disk::PutObjectCommitBarrier::install(
             &bucket,
             object,
-            crate::set_disk::PutObjectCommitPause::BeforeNamespace,
+            crate::set_disk::PutObjectCommitPause::AfterNamespace,
         );
         let source_set = store.pools[1].get_disks_by_key(object);
         let worker_store = Arc::clone(&store);

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -2859,7 +2859,7 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial(storage_class_env)]
-    async fn versioned_delete_waits_for_decommission_commit_then_publishes_marker() {
+    async fn versioned_delete_marker_survives_decommission_source_cleanup() {
         let temp_dir = tempfile::tempdir().expect("create versioned decommission delete-fence store dir");
         let (_ctx, store, shutdown) =
             without_storage_class_env(build_isolated_test_store(temp_dir.path(), "versioned-decommission-delete-fence", &[4, 4]))
@@ -2886,6 +2886,12 @@ mod tests {
             .await
             .expect("write source version to the pool being decommissioned");
         let source_version = source_info.version_id.expect("versioned source must have a version ID");
+        let expected_source_versions = store.pools[0]
+            .get_disks_by_key(object)
+            .load_file_info_versions_exact(&bucket, object)
+            .await
+            .expect("source versions should be readable before migration")
+            .expect("source versions should exist before migration");
         {
             let mut pool_meta = store.pool_meta.write().await;
             pool_meta.pools[0].decommission = Some(PoolDecommissionInfo {
@@ -2929,8 +2935,13 @@ mod tests {
             .await
         });
         barrier.wait_until_paused().await;
+        barrier.release();
+        migration
+            .await
+            .expect("versioned decommission migration task should join")
+            .expect("versioned decommission migration should commit before DELETE");
 
-        let delete_barrier = crate::store::object::DeleteAfterObjectLockSnapshotBarrier::install(&bucket);
+        let delete_barrier = crate::store::object::VersionedDeleteMarkerCommitBarrier::install(&bucket, object);
         let delete_store = Arc::clone(&store);
         let delete_bucket = bucket.clone();
         let delete = tokio::spawn(async move {
@@ -2946,17 +2957,46 @@ mod tests {
                 .await
         });
         delete_barrier.wait_until_paused().await;
-        delete_barrier.release_and_wait_until_namespace_pending().await;
+        let cleanup_set = store.pools[0].get_disks_by_key(object);
+        crate::data_movement::ensure_source_cleanup_versions_unchanged(
+            Arc::clone(&cleanup_set),
+            &bucket,
+            object,
+            &expected_source_versions,
+            &[],
+            "test_versioned_decommission_delete_fence",
+        )
+        .await
+        .expect("the committed delete marker must not be published to the suspended source pool");
+
+        let cleanup_delete_barrier = crate::data_movement::SourceCleanupDeleteBarrier::install(&bucket, object);
+        let cleanup_store = Arc::clone(&store);
+        let cleanup_bucket = bucket.clone();
+        let cleanup = tokio::spawn(async move {
+            let mutation_fence = cleanup_store
+                .acquire_decommission_source_cleanup_fence(&cleanup_bucket, object, cleanup_set.as_ref())
+                .await?;
+            crate::data_movement::cleanup_source_entry_if_unchanged(
+                cleanup_set,
+                &cleanup_bucket,
+                object,
+                &expected_source_versions,
+                &[],
+                crate::data_movement::SourceCleanupBucketFence {
+                    object_mutation_fence: Some(&mutation_fence),
+                    ..Default::default()
+                },
+                "test_versioned_decommission_delete_fence",
+            )
+            .await
+        });
+        cleanup_delete_barrier.wait_until_fence_pending().await;
         assert!(
-            !delete.is_finished(),
-            "versioned DELETE must wait while the source version is being committed"
+            !cleanup_delete_barrier.is_paused(),
+            "source cleanup must wait for the versioned DELETE mutation fence"
         );
 
-        barrier.release();
-        migration
-            .await
-            .expect("versioned decommission migration task should join")
-            .expect("versioned decommission migration should commit before DELETE");
+        delete_barrier.release();
         let marker = delete
             .await
             .expect("versioned DELETE task should join")
@@ -2966,6 +3006,13 @@ mod tests {
             marker.version_id.is_some_and(|version_id| !version_id.is_nil()),
             "the delete marker must have a non-nil version ID"
         );
+
+        cleanup_delete_barrier.wait_until_paused().await;
+        cleanup_delete_barrier.release();
+        cleanup
+            .await
+            .expect("source cleanup task should join")
+            .expect("source cleanup should preserve the active-pool delete marker");
 
         let err = store
             .get_object_info(
@@ -2994,6 +3041,18 @@ mod tests {
             )
             .await
             .expect("the migrated source version must remain addressable below the delete marker");
+        store.pools[0]
+            .get_object_info(
+                &bucket,
+                object,
+                &ObjectOptions {
+                    versioned: true,
+                    version_id: Some(source_version.to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("source cleanup must remove the decommissioned source versions");
 
         shutdown.cancel();
     }

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -1299,6 +1299,139 @@ mod tests {
         (source_version, expected_source_versions)
     }
 
+    async fn mark_test_pool_decommissioning(store: &Arc<crate::store::ECStore>, pool_idx: usize) {
+        let mut pool_meta = store.pool_meta.write().await;
+        pool_meta.pools[pool_idx].decommission = Some(PoolDecommissionInfo {
+            start_time: Some(OffsetDateTime::now_utc()),
+            ..Default::default()
+        });
+    }
+
+    async fn write_decommission_test_multipart_source(
+        store: &Arc<crate::store::ECStore>,
+        pool_idx: usize,
+        bucket: &str,
+        object: &str,
+    ) {
+        let pool = &store.pools[pool_idx];
+        let upload = pool
+            .new_multipart_upload(bucket, object, &ObjectOptions::default())
+            .await
+            .expect("create decommission multipart source upload");
+        let first_part = vec![b'm'; 5 * 1024 * 1024];
+        let second_part = b"decommission multipart tail".to_vec();
+        let mut completed_parts = Vec::with_capacity(2);
+        for (part_number, body) in [(1, first_part), (2, second_part)] {
+            let mut reader = PutObjReader::from_vec(body);
+            let part = pool
+                .put_object_part(bucket, object, &upload.upload_id, part_number, &mut reader, &ObjectOptions::default())
+                .await
+                .expect("write decommission multipart source part");
+            completed_parts.push(crate::storage_api_contracts::multipart::CompletePart {
+                part_num: part.part_num,
+                etag: part.etag,
+                ..Default::default()
+            });
+        }
+        pool.clone()
+            .complete_multipart_upload(bucket, object, &upload.upload_id, completed_parts, &ObjectOptions::default())
+            .await
+            .expect("complete decommission multipart source object");
+    }
+
+    async fn assert_pool_object_present(pool: &Arc<crate::core::sets::Sets>, bucket: &str, object: &str) {
+        pool.get_object_info(bucket, object, &ObjectOptions::default())
+            .await
+            .expect("expected object generation must remain present");
+    }
+
+    async fn assert_pool_object_absent(pool: &Arc<crate::core::sets::Sets>, bucket: &str, object: &str) {
+        let err = pool
+            .get_object_info(bucket, object, &ObjectOptions::default())
+            .await
+            .expect_err("fenced decommission target must remain absent");
+        assert!(
+            matches!(err, StorageError::ObjectNotFound(_, _) | StorageError::VersionNotFound(_, _, _)),
+            "unexpected fenced target result: {err:?}"
+        );
+    }
+
+    async fn write_suspended_decommission_source(store: &Arc<crate::store::ECStore>, bucket: &str, object: &str) {
+        let mut reader = PutObjReader::from_vec(b"suspended source generation".to_vec());
+        let source = store.pools[0]
+            .put_object(
+                bucket,
+                object,
+                &mut reader,
+                &ObjectOptions {
+                    version_suspended: true,
+                    mod_time: Some(OffsetDateTime::UNIX_EPOCH),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("write suspended null source version");
+        assert!(
+            source.version_id.is_none_or(|version_id| version_id.is_nil()),
+            "suspended source must use the null version identity"
+        );
+    }
+
+    async fn assert_suspended_null_source_present(store: &Arc<crate::store::ECStore>, bucket: &str, object: &str) {
+        let versions = store.pools[0]
+            .get_disks_by_key(object)
+            .load_file_info_versions_exact(bucket, object)
+            .await
+            .expect("suspended source versions should be readable")
+            .expect("suspended source must exist before worker convergence");
+        assert!(
+            versions
+                .versions
+                .iter()
+                .any(|version| !version.deleted && version.version_id.is_none_or(|version_id| version_id.is_nil())),
+            "the source pool must retain its null data version while DELETE owns the fixed fence"
+        );
+    }
+
+    async fn assert_suspended_decommission_converged(store: &Arc<crate::store::ECStore>, bucket: &str, object: &str) {
+        let source_versions = store.pools[0]
+            .get_disks_by_key(object)
+            .load_file_info_versions_exact(bucket, object)
+            .await
+            .expect("source versions should remain readable after suspended convergence");
+        assert!(
+            source_versions.is_none_or(|versions| versions.versions.is_empty()),
+            "worker convergence must remove only the decommissioned source null version"
+        );
+
+        let target_versions = store.pools[1]
+            .get_disks_by_key(object)
+            .load_file_info_versions_exact(bucket, object)
+            .await
+            .expect("active target versions should be readable")
+            .expect("active target must retain the suspended DELETE marker");
+        assert!(
+            matches!(target_versions.versions.as_slice(), [marker] if marker.deleted && marker.version_id.is_none_or(|version_id| version_id.is_nil())),
+            "active target must contain only its null delete marker: {target_versions:?}"
+        );
+
+        let err = store
+            .get_object_info(
+                bucket,
+                object,
+                &ObjectOptions {
+                    version_suspended: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("the active null delete marker must hide the migrated source generation");
+        assert!(
+            matches!(err, StorageError::ObjectNotFound(_, _)),
+            "unexpected suspended latest-object result: {err:?}"
+        );
+    }
+
     #[tokio::test]
     #[serial_test::serial(storage_class_env)]
     async fn tag_updates_skip_active_rebalance_source_pool() {
@@ -2971,6 +3104,206 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial(storage_class_env)]
+    async fn decommission_outer_fence_loss_blocks_target_put_commit() {
+        let temp_dir = tempfile::tempdir().expect("create decommission PUT fence-loss store dir");
+        let (_ctx, store, shutdown) =
+            without_storage_class_env(build_isolated_test_store(temp_dir.path(), "decommission-put-fence-loss", &[4, 4])).await;
+        crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
+
+        let bucket = format!("decommission-put-fence-loss-{}", uuid::Uuid::new_v4());
+        let object = "ordinary.bin";
+        store
+            .make_bucket(&bucket, &MakeBucketOptions::default())
+            .await
+            .expect("create decommission PUT fence-loss bucket");
+        let mut source = PutObjReader::from_vec(b"source generation".to_vec());
+        store.pools[0]
+            .put_object(&bucket, object, &mut source, &ObjectOptions::default())
+            .await
+            .expect("write decommission PUT source");
+        mark_test_pool_decommissioning(&store, 0).await;
+
+        let loss_hook = crate::store::object::DecommissionMutationFenceLossHook::install(
+            &bucket,
+            object,
+            crate::store::object::DecommissionMutationFenceTestPhase::Migration,
+        );
+        let barrier = crate::set_disk::PutObjectCommitBarrier::install(
+            &bucket,
+            object,
+            crate::set_disk::PutObjectCommitPause::BeforeQuotaRename,
+        );
+        let source_set = store.pools[0].get_disks_by_key(object);
+        let worker_store = Arc::clone(&store);
+        let worker_bucket = bucket.clone();
+        let worker = tokio::spawn(async move {
+            worker_store
+                .decommission_entry_for_test(
+                    0,
+                    MetaCacheEntry {
+                        name: object.to_string(),
+                        ..Default::default()
+                    },
+                    worker_bucket,
+                    source_set,
+                )
+                .await
+        });
+
+        barrier.wait_until_paused().await;
+        loss_hook.mark_lost();
+        barrier.release();
+        drop(barrier);
+        worker
+            .await
+            .expect("decommission PUT fence-loss worker should join")
+            .expect("a fenced migration failure should remain retryable at entry scope");
+
+        assert_pool_object_absent(&store.pools[1], &bucket, object).await;
+        assert_pool_object_present(&store.pools[0], &bucket, object).await;
+        shutdown.cancel();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(storage_class_env)]
+    async fn decommission_outer_fence_loss_blocks_multipart_commits() {
+        let temp_dir = tempfile::tempdir().expect("create decommission multipart fence-loss store dir");
+        let (_ctx, store, shutdown) =
+            without_storage_class_env(build_isolated_test_store(temp_dir.path(), "decommission-multipart-fence-loss", &[4, 4]))
+                .await;
+        crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
+
+        let bucket = format!("decommission-multipart-fence-loss-{}", uuid::Uuid::new_v4());
+        store
+            .make_bucket(&bucket, &MakeBucketOptions::default())
+            .await
+            .expect("create decommission multipart fence-loss bucket");
+        for object in ["new-upload.bin", "complete.bin"] {
+            write_decommission_test_multipart_source(&store, 0, &bucket, object).await;
+        }
+        mark_test_pool_decommissioning(&store, 0).await;
+
+        for (object, pause) in [
+            ("new-upload.bin", crate::set_disk::MultipartCommitPause::NewUploadBeforeLockLost),
+            ("complete.bin", crate::set_disk::MultipartCommitPause::BeforeLockLost),
+        ] {
+            let loss_hook = crate::store::object::DecommissionMutationFenceLossHook::install(
+                &bucket,
+                object,
+                crate::store::object::DecommissionMutationFenceTestPhase::Migration,
+            );
+            let commit_observation = (pause == crate::set_disk::MultipartCommitPause::NewUploadBeforeLockLost)
+                .then(|| crate::set_disk::NewMultipartUploadCommitObservation::install(&bucket, object));
+            let barrier = crate::set_disk::MultipartCommitBarrier::install(&bucket, object, pause);
+            let source_set = store.pools[0].get_disks_by_key(object);
+            let worker_store = Arc::clone(&store);
+            let worker_bucket = bucket.clone();
+            let worker = tokio::spawn(async move {
+                worker_store
+                    .decommission_entry_for_test(
+                        0,
+                        MetaCacheEntry {
+                            name: object.to_string(),
+                            ..Default::default()
+                        },
+                        worker_bucket,
+                        source_set,
+                    )
+                    .await
+            });
+
+            barrier.wait_until_paused().await;
+            loss_hook.mark_lost();
+            barrier.release();
+            drop(barrier);
+            worker
+                .await
+                .expect("decommission multipart fence-loss worker should join")
+                .expect("a fenced multipart migration failure should remain retryable at entry scope");
+
+            if let Some(commit_observation) = commit_observation {
+                assert!(
+                    !commit_observation.committed(),
+                    "new multipart upload metadata must not commit after the outer fence is lost"
+                );
+            }
+            assert_pool_object_absent(&store.pools[1], &bucket, object).await;
+            assert_pool_object_present(&store.pools[0], &bucket, object).await;
+            let uploads = store.pools[1]
+                .list_multipart_uploads(&bucket, object, None, None, None, 100)
+                .await
+                .expect("list target multipart uploads after fenced migration");
+            assert!(uploads.uploads.is_empty(), "fenced multipart migration must not retain target staging");
+        }
+
+        shutdown.cancel();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(storage_class_env)]
+    async fn decommission_outer_fence_loss_blocks_source_cleanup_delete_commit() {
+        let temp_dir = tempfile::tempdir().expect("create decommission cleanup fence-loss store dir");
+        let (_ctx, store, shutdown) =
+            without_storage_class_env(build_isolated_test_store(temp_dir.path(), "decommission-cleanup-fence-loss", &[4, 4]))
+                .await;
+        crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
+
+        let bucket = format!("decommission-cleanup-fence-loss-{}", uuid::Uuid::new_v4());
+        let object = "cleanup.bin";
+        store
+            .make_bucket(&bucket, &MakeBucketOptions::default())
+            .await
+            .expect("create decommission cleanup fence-loss bucket");
+        let mut source = PutObjReader::from_vec(b"source generation".to_vec());
+        store.pools[0]
+            .put_object(&bucket, object, &mut source, &ObjectOptions::default())
+            .await
+            .expect("write decommission cleanup source");
+        mark_test_pool_decommissioning(&store, 0).await;
+
+        let loss_hook = crate::store::object::DecommissionMutationFenceLossHook::install(
+            &bucket,
+            object,
+            crate::store::object::DecommissionMutationFenceTestPhase::SourceCleanup,
+        );
+        let barrier = crate::set_disk::DeleteObjectCommitBarrier::install(&bucket, object);
+        let source_set = store.pools[0].get_disks_by_key(object);
+        let worker_store = Arc::clone(&store);
+        let worker_bucket = bucket.clone();
+        let worker = tokio::spawn(async move {
+            worker_store
+                .decommission_entry_for_test(
+                    0,
+                    MetaCacheEntry {
+                        name: object.to_string(),
+                        ..Default::default()
+                    },
+                    worker_bucket,
+                    source_set,
+                )
+                .await
+        });
+
+        barrier.wait_until_paused().await;
+        loss_hook.mark_lost();
+        barrier.release();
+        drop(barrier);
+        let err = worker
+            .await
+            .expect("decommission cleanup fence-loss worker should join")
+            .expect_err("source cleanup must fail after its outer fence is lost");
+        assert!(
+            err.to_string().contains("delete_object_commit"),
+            "cleanup failure must come from the delete commit fence: {err:?}"
+        );
+
+        assert_pool_object_present(&store.pools[0], &bucket, object).await;
+        assert_pool_object_present(&store.pools[1], &bucket, object).await;
+        shutdown.cancel();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(storage_class_env)]
     async fn reverse_decommission_reuses_fixed_target_fence_for_put_and_multipart() {
         let temp_dir = tempfile::tempdir().expect("create reverse decommission store dir");
         let (_ctx, store, shutdown) = without_storage_class_env(build_isolated_test_store_with_layout(
@@ -3606,6 +3939,166 @@ mod tests {
         }
         assert_eq!(active_marker_count, 1, "batch DELETE must publish exactly one active-pool marker");
 
+        shutdown.cancel();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(storage_class_env)]
+    async fn suspended_delete_marker_then_decommission_worker_converges_null_source() {
+        let temp_dir = tempfile::tempdir().expect("create suspended decommission DELETE store dir");
+        let (_ctx, store, shutdown) = without_storage_class_env(build_isolated_test_store(
+            temp_dir.path(),
+            "suspended-decommission-delete-convergence",
+            &[4, 4],
+        ))
+        .await;
+        crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
+
+        let bucket = format!("suspended-decommission-delete-convergence-{}", uuid::Uuid::new_v4());
+        let object = "single.bin";
+        store
+            .make_bucket(&bucket, &MakeBucketOptions::default())
+            .await
+            .expect("create suspended decommission DELETE bucket");
+        write_suspended_decommission_source(&store, &bucket, object).await;
+        mark_test_pool_decommissioning(&store, 0).await;
+
+        let delete_barrier = crate::store::object::VersionedDeleteMarkerCommitBarrier::install(&bucket, object);
+        let delete_store = Arc::clone(&store);
+        let delete_bucket = bucket.clone();
+        let delete = tokio::spawn(async move {
+            delete_store
+                .delete_object(
+                    &delete_bucket,
+                    object,
+                    ObjectOptions {
+                        version_suspended: true,
+                        ..Default::default()
+                    },
+                )
+                .await
+        });
+        delete_barrier.wait_until_paused().await;
+        assert_suspended_null_source_present(&store, &bucket, object).await;
+
+        let source_set = store.pools[0].get_disks_by_key(object);
+        let worker_store = Arc::clone(&store);
+        let worker_bucket = bucket.clone();
+        let worker = tokio::spawn(async move {
+            worker_store
+                .decommission_entry_for_test(
+                    0,
+                    MetaCacheEntry {
+                        name: object.to_string(),
+                        ..Default::default()
+                    },
+                    worker_bucket,
+                    source_set,
+                )
+                .await
+        });
+
+        delete_barrier.release();
+        let marker = delete
+            .await
+            .expect("suspended DELETE task should join")
+            .expect("suspended DELETE should commit its active-pool marker");
+        drop(delete_barrier);
+        assert!(marker.delete_marker, "suspended DELETE must create a marker");
+        assert!(
+            marker.version_id.is_none_or(|version_id| version_id.is_nil()),
+            "suspended DELETE marker must keep the null version identity"
+        );
+        worker
+            .await
+            .expect("suspended decommission worker should join")
+            .expect("worker must treat the newer active null marker as a completed migration");
+
+        assert_suspended_decommission_converged(&store, &bucket, object).await;
+        shutdown.cancel();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(storage_class_env)]
+    async fn suspended_batch_delete_marker_then_decommission_worker_converges_null_source() {
+        let temp_dir = tempfile::tempdir().expect("create suspended batch decommission DELETE store dir");
+        let (_ctx, store, shutdown) = without_storage_class_env(build_isolated_test_store(
+            temp_dir.path(),
+            "suspended-batch-decommission-delete-convergence",
+            &[4, 4],
+        ))
+        .await;
+        crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
+
+        let bucket = format!("suspended-batch-decommission-delete-convergence-{}", uuid::Uuid::new_v4());
+        let object = "batch.bin";
+        store
+            .make_bucket(&bucket, &MakeBucketOptions::default())
+            .await
+            .expect("create suspended batch decommission DELETE bucket");
+        write_suspended_decommission_source(&store, &bucket, object).await;
+        mark_test_pool_decommissioning(&store, 0).await;
+
+        let delete_config_snapshot =
+            Arc::new(crate::bucket::replication::DeleteReplicationConfigSnapshot::from_configs_for_test(
+                s3s::dto::VersioningConfiguration {
+                    status: Some(s3s::dto::BucketVersioningStatus::from_static(s3s::dto::BucketVersioningStatus::SUSPENDED)),
+                    ..Default::default()
+                },
+                None,
+            ));
+        let delete_barrier = crate::store::object::VersionedDeleteMarkerCommitBarrier::install(&bucket, object);
+        let delete_store = Arc::clone(&store);
+        let delete_bucket = bucket.clone();
+        let delete = tokio::spawn(async move {
+            delete_store
+                .delete_objects(
+                    &delete_bucket,
+                    vec![ObjectToDelete {
+                        object_name: object.to_string(),
+                        ..Default::default()
+                    }],
+                    ObjectOptions {
+                        delete_replication_config_snapshot: Some(delete_config_snapshot),
+                        ..Default::default()
+                    },
+                )
+                .await
+        });
+        delete_barrier.wait_until_paused().await;
+        assert_suspended_null_source_present(&store, &bucket, object).await;
+
+        let source_set = store.pools[0].get_disks_by_key(object);
+        let worker_store = Arc::clone(&store);
+        let worker_bucket = bucket.clone();
+        let worker = tokio::spawn(async move {
+            worker_store
+                .decommission_entry_for_test(
+                    0,
+                    MetaCacheEntry {
+                        name: object.to_string(),
+                        ..Default::default()
+                    },
+                    worker_bucket,
+                    source_set,
+                )
+                .await
+        });
+
+        delete_barrier.release();
+        let (deleted, errors) = delete.await.expect("suspended batch DELETE task should join");
+        drop(delete_barrier);
+        assert!(errors.iter().all(Option::is_none), "suspended batch DELETE should succeed: {errors:?}");
+        assert!(
+            matches!(deleted.as_slice(), [marker] if marker.delete_marker && marker.delete_marker_version_id.is_none_or(|version_id| version_id.is_nil())),
+            "suspended batch DELETE must create one null marker: {deleted:?}"
+        );
+        worker
+            .await
+            .expect("suspended batch decommission worker should join")
+            .expect("worker must treat the newer batch null marker as a completed migration");
+
+        assert_suspended_decommission_converged(&store, &bucket, object).await;
         shutdown.cancel();
     }
 

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -2958,7 +2958,7 @@ mod tests {
             .expect_err("suspended delete must remove the requested UUID version");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[serial_test::serial(storage_class_env)]
     async fn decommission_entry_carries_migration_and_cleanup_mutation_fences() {
         let temp_dir = tempfile::tempdir().expect("create decommission delete-fence store dir");
@@ -2971,7 +2971,7 @@ mod tests {
         .await;
         crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
 
-        let bucket = format!("decommission-delete-fence-{}", uuid::Uuid::new_v4());
+        let bucket = format!("decom-delete-fence-{}", uuid::Uuid::new_v4());
         let object = (0..128)
             .map(|index| format!("object-{index}.bin"))
             .find(|candidate| store.pools[0].get_disks_by_key(candidate).set_index == 1)
@@ -3102,7 +3102,7 @@ mod tests {
         shutdown.cancel();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[serial_test::serial(storage_class_env)]
     async fn decommission_outer_fence_loss_blocks_target_put_commit() {
         let temp_dir = tempfile::tempdir().expect("create decommission PUT fence-loss store dir");
@@ -3110,7 +3110,7 @@ mod tests {
             without_storage_class_env(build_isolated_test_store(temp_dir.path(), "decommission-put-fence-loss", &[4, 4])).await;
         crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
 
-        let bucket = format!("decommission-put-fence-loss-{}", uuid::Uuid::new_v4());
+        let bucket = format!("decom-put-fence-loss-{}", uuid::Uuid::new_v4());
         let object = "ordinary.bin";
         store
             .make_bucket(&bucket, &MakeBucketOptions::default())
@@ -3164,7 +3164,7 @@ mod tests {
         shutdown.cancel();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[serial_test::serial(storage_class_env)]
     async fn decommission_outer_fence_loss_blocks_multipart_commits() {
         let temp_dir = tempfile::tempdir().expect("create decommission multipart fence-loss store dir");
@@ -3173,7 +3173,7 @@ mod tests {
                 .await;
         crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
 
-        let bucket = format!("decommission-multipart-fence-loss-{}", uuid::Uuid::new_v4());
+        let bucket = format!("decom-mpu-fence-loss-{}", uuid::Uuid::new_v4());
         store
             .make_bucket(&bucket, &MakeBucketOptions::default())
             .await
@@ -3239,7 +3239,7 @@ mod tests {
         shutdown.cancel();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[serial_test::serial(storage_class_env)]
     async fn decommission_outer_fence_loss_blocks_source_cleanup_delete_commit() {
         let temp_dir = tempfile::tempdir().expect("create decommission cleanup fence-loss store dir");
@@ -3248,7 +3248,7 @@ mod tests {
                 .await;
         crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
 
-        let bucket = format!("decommission-cleanup-fence-loss-{}", uuid::Uuid::new_v4());
+        let bucket = format!("decom-cleanup-fence-loss-{}", uuid::Uuid::new_v4());
         let object = "cleanup.bin";
         store
             .make_bucket(&bucket, &MakeBucketOptions::default())
@@ -3302,7 +3302,7 @@ mod tests {
         shutdown.cancel();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[serial_test::serial(storage_class_env)]
     async fn reverse_decommission_reuses_fixed_target_fence_for_put_and_multipart() {
         let temp_dir = tempfile::tempdir().expect("create reverse decommission store dir");
@@ -3315,7 +3315,7 @@ mod tests {
         .await;
         crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
 
-        let bucket = format!("reverse-decommission-fixed-target-{}", uuid::Uuid::new_v4());
+        let bucket = format!("reverse-decom-fixed-target-{}", uuid::Uuid::new_v4());
         let object = "ordinary.bin";
         let object_body = b"reverse ordinary generation".to_vec();
         let multipart_object = "multipart.bin";
@@ -3508,7 +3508,7 @@ mod tests {
                 }
             }
 
-            let bucket = format!("batch-delete-pool-errors-{source_pool_idx}-{}", uuid::Uuid::new_v4());
+            let bucket = format!("batch-del-pool-error-{source_pool_idx}-{}", uuid::Uuid::new_v4());
             let object_names = vec![
                 format!("third-{source_pool_idx}.bin"),
                 format!("first-{source_pool_idx}.bin"),
@@ -3615,7 +3615,7 @@ mod tests {
         .await;
         crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
 
-        let bucket = format!("multi-set-decommission-source-cleanup-{}", uuid::Uuid::new_v4());
+        let bucket = format!("decom-source-cleanup-lock-{}", uuid::Uuid::new_v4());
         let object = (0..128)
             .map(|index| format!("object-{index}.bin"))
             .find(|candidate| store.pools[0].get_disks_by_key(candidate).set_index == 1)
@@ -3706,7 +3706,7 @@ mod tests {
         shutdown.cancel();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[serial_test::serial(storage_class_env)]
     async fn versioned_delete_marker_survives_decommission_source_cleanup() {
         let temp_dir = tempfile::tempdir().expect("create versioned decommission delete-fence store dir");
@@ -3715,7 +3715,7 @@ mod tests {
                 .await;
         crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
 
-        let bucket = format!("versioned-decommission-delete-fence-{}", uuid::Uuid::new_v4());
+        let bucket = format!("versioned-decom-delete-{}", uuid::Uuid::new_v4());
         let object = "object.bin";
         store
             .make_bucket(&bucket, &MakeBucketOptions::default())
@@ -3846,7 +3846,7 @@ mod tests {
         shutdown.cancel();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[serial_test::serial(storage_class_env)]
     async fn versioned_batch_delete_marker_skips_decommission_source() {
         let temp_dir = tempfile::tempdir().expect("create versioned batch decommission store dir");
@@ -3858,7 +3858,7 @@ mod tests {
         .await;
         crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
 
-        let bucket = format!("versioned-batch-decommission-delete-fence-{}", uuid::Uuid::new_v4());
+        let bucket = format!("vbatch-decom-delete-{}", uuid::Uuid::new_v4());
         let object = "batch-object.bin";
         store
             .make_bucket(&bucket, &MakeBucketOptions::default())
@@ -3942,7 +3942,7 @@ mod tests {
         shutdown.cancel();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[serial_test::serial(storage_class_env)]
     async fn suspended_delete_marker_then_decommission_worker_converges_null_source() {
         let temp_dir = tempfile::tempdir().expect("create suspended decommission DELETE store dir");
@@ -3954,7 +3954,7 @@ mod tests {
         .await;
         crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
 
-        let bucket = format!("suspended-decommission-delete-convergence-{}", uuid::Uuid::new_v4());
+        let bucket = format!("suspended-decom-delete-{}", uuid::Uuid::new_v4());
         let object = "single.bin";
         store
             .make_bucket(&bucket, &MakeBucketOptions::default())
@@ -4018,7 +4018,7 @@ mod tests {
         shutdown.cancel();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[serial_test::serial(storage_class_env)]
     async fn suspended_batch_delete_marker_then_decommission_worker_converges_null_source() {
         let temp_dir = tempfile::tempdir().expect("create suspended batch decommission DELETE store dir");
@@ -4030,7 +4030,7 @@ mod tests {
         .await;
         crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
 
-        let bucket = format!("suspended-batch-decommission-delete-convergence-{}", uuid::Uuid::new_v4());
+        let bucket = format!("susp-batch-decom-delete-{}", uuid::Uuid::new_v4());
         let object = "batch.bin";
         store
             .make_bucket(&bucket, &MakeBucketOptions::default())

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -2971,6 +2971,196 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial(storage_class_env)]
+    async fn reverse_decommission_reuses_fixed_target_fence_for_put_and_multipart() {
+        let temp_dir = tempfile::tempdir().expect("create reverse decommission store dir");
+        let (_ctx, store, shutdown) = without_storage_class_env(build_isolated_test_store_with_layout(
+            temp_dir.path(),
+            "reverse-decommission-fixed-target",
+            &[(1, 4), (1, 4)],
+            CancellationToken::new(),
+        ))
+        .await;
+        crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
+
+        let bucket = format!("reverse-decommission-fixed-target-{}", uuid::Uuid::new_v4());
+        let object = "ordinary.bin";
+        let object_body = b"reverse ordinary generation".to_vec();
+        let multipart_object = "multipart.bin";
+        let first_part = vec![b'm'; 5 * 1024 * 1024];
+        let second_part = b"reverse multipart tail".to_vec();
+        let mut multipart_body = first_part.clone();
+        multipart_body.extend_from_slice(&second_part);
+
+        store
+            .make_bucket(&bucket, &MakeBucketOptions::default())
+            .await
+            .expect("create reverse decommission bucket");
+        let mut source = PutObjReader::from_vec(object_body.clone());
+        store.pools[1]
+            .put_object(&bucket, object, &mut source, &ObjectOptions::default())
+            .await
+            .expect("write ordinary source object to pool 1");
+
+        let upload = store.pools[1]
+            .new_multipart_upload(&bucket, multipart_object, &ObjectOptions::default())
+            .await
+            .expect("create source multipart upload in pool 1");
+        let mut completed_parts = Vec::with_capacity(2);
+        for (part_number, bytes) in [(1, first_part.as_slice()), (2, second_part.as_slice())] {
+            let mut reader = PutObjReader::from_vec(bytes.to_vec());
+            let part = store.pools[1]
+                .put_object_part(
+                    &bucket,
+                    multipart_object,
+                    &upload.upload_id,
+                    part_number,
+                    &mut reader,
+                    &ObjectOptions::default(),
+                )
+                .await
+                .expect("write source multipart part");
+            completed_parts.push(crate::storage_api_contracts::multipart::CompletePart {
+                part_num: part.part_num,
+                etag: part.etag,
+                ..Default::default()
+            });
+        }
+        store.pools[1]
+            .clone()
+            .complete_multipart_upload(&bucket, multipart_object, &upload.upload_id, completed_parts, &ObjectOptions::default())
+            .await
+            .expect("complete source multipart object in pool 1");
+
+        {
+            let mut pool_meta = store.pool_meta.write().await;
+            pool_meta.pools[1].decommission = Some(PoolDecommissionInfo {
+                start_time: Some(OffsetDateTime::now_utc()),
+                ..Default::default()
+            });
+        }
+        assert!(store.is_suspended(1).await, "pool 1 must be the reverse decommission source");
+
+        let commit_barrier = crate::set_disk::PutObjectCommitBarrier::install(
+            &bucket,
+            object,
+            crate::set_disk::PutObjectCommitPause::BeforeNamespace,
+        );
+        let source_set = store.pools[1].get_disks_by_key(object);
+        let worker_store = Arc::clone(&store);
+        let worker_bucket = bucket.clone();
+        let worker = tokio::spawn(async move {
+            worker_store
+                .decommission_entry_for_test(
+                    1,
+                    MetaCacheEntry {
+                        name: object.to_string(),
+                        ..Default::default()
+                    },
+                    worker_bucket,
+                    source_set,
+                )
+                .await
+        });
+        commit_barrier.wait_until_paused().await;
+
+        let delete_barrier = crate::store::object::DeleteAfterObjectLockSnapshotBarrier::install(&bucket);
+        let delete_store = Arc::clone(&store);
+        let delete_bucket = bucket.clone();
+        let delete = tokio::spawn(async move {
+            delete_store
+                .delete_object(&delete_bucket, object, ObjectOptions::default())
+                .await
+        });
+        delete_barrier.wait_until_paused().await;
+        delete_barrier.release_and_wait_until_namespace_pending().await;
+        assert!(
+            !delete_barrier.namespace_acquired() && !delete.is_finished(),
+            "the reverse target commit must keep DELETE behind the fixed read fence"
+        );
+        delete.abort();
+        assert!(
+            delete
+                .await
+                .expect_err("the blocked DELETE should be canceled")
+                .is_cancelled(),
+            "canceling the blocked DELETE must not mutate either pool"
+        );
+        drop(delete_barrier);
+
+        commit_barrier.release();
+        drop(commit_barrier);
+        tokio::time::timeout(Duration::from_secs(60), worker)
+            .await
+            .expect("reverse ordinary decommission must not self-deadlock on the fixed target set")
+            .expect("reverse ordinary decommission worker should join")
+            .expect("reverse ordinary decommission should complete");
+
+        let mut ordinary_reader = store.pools[0]
+            .get_object_reader(&bucket, object, None, HeaderMap::new(), &ObjectOptions::default())
+            .await
+            .expect("read the ordinary object from the fixed target set");
+        let mut ordinary_target_body = Vec::new();
+        ordinary_reader
+            .stream
+            .read_to_end(&mut ordinary_target_body)
+            .await
+            .expect("drain the ordinary target body");
+        assert_eq!(ordinary_target_body, object_body, "ordinary migration must preserve the full body");
+        let ordinary_source_err = store.pools[1]
+            .get_object_info(&bucket, object, &ObjectOptions::default())
+            .await
+            .expect_err("ordinary source generation must be cleaned after migration");
+        assert!(matches!(ordinary_source_err, StorageError::ObjectNotFound(_, _)));
+
+        let multipart_source_set = store.pools[1].get_disks_by_key(multipart_object);
+        let multipart_store = Arc::clone(&store);
+        let multipart_bucket = bucket.clone();
+        let multipart_worker = tokio::spawn(async move {
+            multipart_store
+                .decommission_entry_for_test(
+                    1,
+                    MetaCacheEntry {
+                        name: multipart_object.to_string(),
+                        ..Default::default()
+                    },
+                    multipart_bucket,
+                    multipart_source_set,
+                )
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(60), multipart_worker)
+            .await
+            .expect("reverse multipart decommission must not self-deadlock on new or complete")
+            .expect("reverse multipart decommission worker should join")
+            .expect("reverse multipart decommission should complete");
+
+        let target_info = store.pools[0]
+            .get_object_info(&bucket, multipart_object, &ObjectOptions::default())
+            .await
+            .expect("read migrated multipart metadata from the fixed target set");
+        assert!(target_info.is_multipart(), "migration must retain multipart identity");
+        let mut multipart_reader = store.pools[0]
+            .get_object_reader(&bucket, multipart_object, None, HeaderMap::new(), &ObjectOptions::default())
+            .await
+            .expect("read migrated multipart object from the fixed target set");
+        let mut multipart_target_body = Vec::new();
+        multipart_reader
+            .stream
+            .read_to_end(&mut multipart_target_body)
+            .await
+            .expect("drain the multipart target body");
+        assert_eq!(multipart_target_body, multipart_body, "multipart migration must preserve the full body");
+        let multipart_source_err = store.pools[1]
+            .get_object_info(&bucket, multipart_object, &ObjectOptions::default())
+            .await
+            .expect_err("multipart source generation must be cleaned after migration");
+        assert!(matches!(multipart_source_err, StorageError::ObjectNotFound(_, _)));
+
+        shutdown.cancel();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(storage_class_env)]
     async fn batch_delete_real_path_preserves_source_pool_errors_in_any_pool_order() {
         let temp_dir = tempfile::tempdir().expect("create batch delete pool-error store dir");
         let (_ctx, store, shutdown) =

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -612,7 +612,7 @@ mod tests {
     use rustfs_config::server_config::KVS;
     #[cfg(feature = "test-util")]
     use rustfs_filemeta::{FileInfo, FileMeta};
-    use rustfs_filemeta::{FileInfoVersions, ObjectPartInfo};
+    use rustfs_filemeta::{FileInfoVersions, MetaCacheEntry, ObjectPartInfo};
     #[cfg(feature = "test-util")]
     use rustfs_protos::{TIER_MUTATION_RPC_PROTOCOL_VERSION, TierMutationRpcPhase};
     use rustfs_rio::{Checksum, ChecksumType};
@@ -2827,21 +2827,30 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial(storage_class_env)]
-    async fn delete_waits_for_decommission_commit_then_removes_every_copy() {
+    async fn decommission_entry_carries_migration_and_cleanup_mutation_fences() {
         let temp_dir = tempfile::tempdir().expect("create decommission delete-fence store dir");
-        let (_ctx, store, shutdown) =
-            without_storage_class_env(build_isolated_test_store(temp_dir.path(), "decommission-delete-fence", &[4, 4])).await;
+        let (_ctx, store, shutdown) = without_storage_class_env(build_isolated_test_store_with_layout(
+            temp_dir.path(),
+            "decommission-delete-fence",
+            &[(2, 4), (1, 4)],
+            CancellationToken::new(),
+        ))
+        .await;
         crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
 
         let bucket = format!("decommission-delete-fence-{}", uuid::Uuid::new_v4());
-        let object = "object.bin";
+        let object = (0..128)
+            .map(|index| format!("object-{index}.bin"))
+            .find(|candidate| store.pools[0].get_disks_by_key(candidate).set_index == 1)
+            .expect("the deterministic object search should select source set 1");
+        let source_body = b"source generation".to_vec();
         store
             .make_bucket(&bucket, &MakeBucketOptions::default())
             .await
             .expect("create decommission delete-fence bucket");
-        let mut source = PutObjReader::from_vec(b"source generation".to_vec());
+        let mut source = PutObjReader::from_vec(source_body.clone());
         store.pools[0]
-            .put_object(&bucket, object, &mut source, &ObjectOptions::default())
+            .put_object(&bucket, &object, &mut source, &ObjectOptions::default())
             .await
             .expect("write source object to the pool being decommissioned");
         {
@@ -2855,77 +2864,219 @@ mod tests {
 
         let barrier = crate::set_disk::PutObjectCommitBarrier::install(
             &bucket,
-            object,
+            &object,
             crate::set_disk::PutObjectCommitPause::BeforeNamespace,
         );
-        let migration_store = Arc::clone(&store);
-        let migration_bucket = bucket.clone();
-        let migration = tokio::spawn(async move {
-            let source_reader = migration_store.pools[0]
-                .get_object_reader(
-                    &migration_bucket,
-                    object,
-                    None,
-                    HeaderMap::new(),
-                    &ObjectOptions {
-                        no_lock: true,
-                        data_movement: true,
-                        raw_data_movement_read: true,
+        let cleanup_barrier = crate::data_movement::SourceCleanupDeleteBarrier::install(&bucket, &object);
+        let source_set = store.pools[0].get_disks_by_key(&object);
+        assert_eq!(source_set.set_index, 1, "the source entry must exercise the non-fixed set cleanup lock");
+        let worker_store = Arc::clone(&store);
+        let worker_bucket = bucket.clone();
+        let worker_object = object.clone();
+        let worker = tokio::spawn(async move {
+            worker_store
+                .decommission_entry_for_test(
+                    0,
+                    MetaCacheEntry {
+                        name: worker_object,
                         ..Default::default()
                     },
+                    worker_bucket,
+                    source_set,
                 )
-                .await?;
-            crate::data_movement::migrate_decommission_object(
-                migration_store,
-                0,
-                migration_bucket,
-                source_reader,
-                None,
-                "test_decommission_delete_fence",
-            )
-            .await
+                .await
         });
         barrier.wait_until_paused().await;
 
         let delete_barrier = crate::store::object::DeleteAfterObjectLockSnapshotBarrier::install(&bucket);
         let delete_store = Arc::clone(&store);
         let delete_bucket = bucket.clone();
+        let delete_object = object.clone();
         let delete = tokio::spawn(async move {
             delete_store
-                .delete_object(&delete_bucket, object, ObjectOptions::default())
+                .delete_object(&delete_bucket, &delete_object, ObjectOptions::default())
                 .await
         });
         delete_barrier.wait_until_paused().await;
         delete_barrier.release_and_wait_until_namespace_pending().await;
         assert!(
-            !delete.is_finished(),
-            "DELETE must wait while the decommission source generation is being committed"
+            !delete_barrier.namespace_acquired() && !delete.is_finished(),
+            "DELETE must remain before namespace acquisition behind the decommission worker's target-commit mutation fence"
+        );
+        delete.abort();
+        assert!(
+            delete
+                .await
+                .expect_err("the blocked DELETE should be canceled")
+                .is_cancelled(),
+            "the competing DELETE must remain cancelable while blocked"
         );
 
         barrier.release();
-        migration
-            .await
-            .expect("decommission migration task should join")
-            .expect("decommission migration should commit before DELETE");
-        delete
-            .await
-            .expect("DELETE task should join")
-            .expect("DELETE should remove the committed migration generation");
+        cleanup_barrier.wait_until_paused().await;
+        drop(barrier);
 
-        for pool in &store.pools {
-            let err = pool
-                .get_object_info(&bucket, object, &ObjectOptions::default())
+        let fixed_set = Arc::clone(&store.pools[0].disk_set[0]);
+        let fixed_mutation_barrier = crate::set_disk::PutObjectCommitBarrier::install(
+            &bucket,
+            &object,
+            crate::set_disk::PutObjectCommitPause::BeforeNamespace,
+        );
+        let mutation_bucket = bucket.clone();
+        let mutation_object = object.clone();
+        let fixed_mutation = tokio::spawn(async move {
+            let mut reader = PutObjReader::from_vec(b"fixed-domain replacement".to_vec());
+            fixed_set
+                .put_object(&mutation_bucket, &mutation_object, &mut reader, &ObjectOptions::default())
                 .await
-                .expect_err("DELETE must remove the source and migrated target copies");
-            assert!(
-                matches!(err, StorageError::ObjectNotFound(_, _)),
-                "unexpected post-delete pool result: {err:?}"
-            );
-        }
-        store
-            .get_object_info(&bucket, object, &ObjectOptions::default())
+        });
+        fixed_mutation_barrier.wait_until_paused().await;
+        fixed_mutation_barrier.release_and_wait_until_namespace_pending().await;
+        assert!(
+            !fixed_mutation_barrier.namespace_acquired() && !fixed_mutation.is_finished(),
+            "the source cleanup must retain the fixed mutation fence before the set-0 mutation acquires its namespace"
+        );
+        fixed_mutation.abort();
+        assert!(
+            fixed_mutation
+                .await
+                .expect_err("the fixed-domain mutation should be canceled")
+                .is_cancelled(),
+            "the competing fixed-domain mutation must remain cancelable while blocked"
+        );
+        drop(fixed_mutation_barrier);
+
+        cleanup_barrier.release();
+        worker
             .await
-            .expect_err("the migrated source generation must not become visible again");
+            .expect("decommission entry worker should join")
+            .expect("decommission entry should migrate and clean its source");
+
+        store.pools[0]
+            .get_object_info(&bucket, &object, &ObjectOptions::default())
+            .await
+            .expect_err("the real decommission entry must clean the source generation");
+        let mut target = store.pools[1]
+            .get_object_reader(&bucket, &object, None, HeaderMap::new(), &ObjectOptions::default())
+            .await
+            .expect("the real decommission entry must commit the target generation");
+        let mut actual = Vec::new();
+        target
+            .stream
+            .read_to_end(&mut actual)
+            .await
+            .expect("read the migrated target generation");
+        assert_eq!(actual, source_body, "the decommission worker must preserve the migrated object body");
+
+        shutdown.cancel();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(storage_class_env)]
+    async fn batch_delete_real_path_preserves_source_pool_errors_in_any_pool_order() {
+        let temp_dir = tempfile::tempdir().expect("create batch delete pool-error store dir");
+        let (_ctx, store, shutdown) =
+            without_storage_class_env(build_isolated_test_store(temp_dir.path(), "batch-delete-pool-errors", &[4, 4])).await;
+        crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
+
+        for source_pool_idx in [0, 1] {
+            {
+                let mut pool_meta = store.pool_meta.write().await;
+                for pool in &mut pool_meta.pools {
+                    pool.decommission = None;
+                }
+            }
+
+            let bucket = format!("batch-delete-pool-errors-{source_pool_idx}-{}", uuid::Uuid::new_v4());
+            let object_names = vec![
+                format!("third-{source_pool_idx}.bin"),
+                format!("first-{source_pool_idx}.bin"),
+                format!("second-{source_pool_idx}.bin"),
+            ];
+            store
+                .make_bucket(&bucket, &MakeBucketOptions::default())
+                .await
+                .expect("create batch delete pool-error bucket");
+            for pool in &store.pools {
+                for object_name in &object_names {
+                    let mut reader = PutObjReader::from_vec(format!("pool {} {object_name}", pool.pool_idx).into_bytes());
+                    pool.put_object(&bucket, object_name, &mut reader, &ObjectOptions::default())
+                        .await
+                        .expect("seed each object in both the source and active pools");
+                }
+            }
+            {
+                let mut pool_meta = store.pool_meta.write().await;
+                pool_meta.pools[source_pool_idx].decommission = Some(PoolDecommissionInfo {
+                    start_time: Some(OffsetDateTime::now_utc()),
+                    ..Default::default()
+                });
+            }
+            assert!(
+                store.is_suspended(source_pool_idx).await,
+                "the injected error pool must be the decommission source"
+            );
+
+            let expected_errors = vec![
+                StorageError::ErasureWriteQuorum,
+                StorageError::NamespaceLockQuorumUnavailable {
+                    mode: "delete_objects_commit",
+                    bucket: bucket.clone(),
+                    object: object_names[1].clone(),
+                    required: 3,
+                    achieved: 2,
+                },
+                StorageError::ErasureWriteQuorum,
+            ];
+            let injection = crate::store::object::BatchDeletePoolErrorInjection::install(
+                &bucket,
+                source_pool_idx,
+                object_names.iter().cloned().zip(expected_errors.iter().cloned()).collect(),
+            );
+            let requests = object_names
+                .iter()
+                .map(|object_name| ObjectToDelete {
+                    object_name: object_name.clone(),
+                    ..Default::default()
+                })
+                .collect();
+
+            let (deleted, errors) = store.delete_objects(&bucket, requests, ObjectOptions::default()).await;
+
+            assert_eq!(
+                injection.observed(),
+                object_names.len(),
+                "the source pool must first complete every real delete"
+            );
+            assert_eq!(
+                errors,
+                expected_errors.iter().cloned().map(Some).collect::<Vec<_>>(),
+                "a successful pool must not clear a source pool failure at any request index"
+            );
+            assert_eq!(
+                deleted.iter().map(|object| object.object_name.as_str()).collect::<Vec<_>>(),
+                object_names.iter().map(String::as_str).collect::<Vec<_>>(),
+                "DeleteObjects must preserve request index mapping while aggregating pool failures"
+            );
+            assert!(
+                deleted.iter().all(|object| object.found),
+                "the injected source results must retain real delete success data"
+            );
+
+            for pool in &store.pools {
+                for object_name in &object_names {
+                    let error = pool
+                        .get_object_info(&bucket, object_name, &ObjectOptions::default())
+                        .await
+                        .expect_err("both the active and source pool delete calls must execute");
+                    assert!(
+                        matches!(error, StorageError::ObjectNotFound(_, _)),
+                        "unexpected residual object: {error:?}"
+                    );
+                }
+            }
+            drop(injection);
+        }
 
         shutdown.cancel();
     }

--- a/crates/ecstore/src/store/mod.rs
+++ b/crates/ecstore/src/store/mod.rs
@@ -151,7 +151,7 @@ pub(crate) mod init_format;
 pub(crate) mod list_objects;
 mod multipart;
 mod object;
-pub(crate) use object::ObjectLockDiagGuard;
+pub(crate) use object::{ObjectLockDiagGuard, SourceCleanupMutationFence};
 pub use object::{
     PrepareSelectObjectSnapshotError, PreparedGetObjectReader, SelectObjectSnapshot, SelectObjectSnapshotReadError,
     SnapshotConsistencyError,

--- a/crates/ecstore/src/store/multipart.rs
+++ b/crates/ecstore/src/store/multipart.rs
@@ -712,14 +712,14 @@ impl ECStore {
 
     pub(crate) async fn complete_multipart_upload_for_data_movement(
         self: Arc<Self>,
-        target_pool_idx: usize,
+        target: (usize, Option<&ObjectLockDiagGuard>),
         bucket: &str,
         object: &str,
         upload_id: &str,
         uploaded_parts: Vec<CompletePart>,
         opts: &ObjectOptions,
-        mutation_fence: Option<&ObjectLockDiagGuard>,
     ) -> Result<ObjectInfo> {
+        let (target_pool_idx, mutation_fence) = target;
         check_complete_multipart_args(bucket, object, upload_id)?;
         if !opts.data_movement {
             return Err(Error::other("targeted multipart completion requires data_movement options"));

--- a/crates/ecstore/src/store/multipart.rs
+++ b/crates/ecstore/src/store/multipart.rs
@@ -400,7 +400,7 @@ impl ECStore {
         object: &str,
         opts: &ObjectOptions,
     ) -> Result<MultipartUploadResult> {
-        self.handle_new_multipart_upload_with_pool_idx(bucket, object, opts)
+        self.handle_new_multipart_upload_with_pool_idx(bucket, object, opts, None)
             .await
             .map(|(res, _, _)| res)
     }
@@ -410,20 +410,21 @@ impl ECStore {
         bucket: &str,
         object: &str,
         opts: &ObjectOptions,
+        mutation_fence: Option<&ObjectLockDiagGuard>,
     ) -> Result<(MultipartUploadResult, usize, Option<Uuid>)> {
         check_new_multipart_args(bucket, object)?;
-        let (opts, _bucket_lifecycle_guard) = self.guard_multipart_bucket_incarnation(bucket, opts).await?;
-        let opts = &opts;
+        let (mut opts, _bucket_lifecycle_guard) = self.guard_multipart_bucket_incarnation(bucket, opts).await?;
 
         if self.single_pool() {
+            self.apply_decommission_target_mutation_fence(0, object, &mut opts, mutation_fence);
             return self.pools[0]
-                .new_multipart_upload(bucket, object, opts)
+                .new_multipart_upload(bucket, object, &opts)
                 .await
                 .map(|res| (res, 0, opts.expected_bucket_incarnation_id));
         }
 
         if opts.data_movement && opts.version_id.is_some() {
-            let idx = self.select_data_movement_pool_idx(bucket, object, -1, opts, false).await?;
+            let idx = self.select_data_movement_pool_idx(bucket, object, -1, &opts, false).await?;
             if idx == opts.src_pool_idx {
                 return Err(StorageError::DataMovementOverwriteErr(
                     bucket.to_owned(),
@@ -431,7 +432,8 @@ impl ECStore {
                     opts.version_id.clone().unwrap_or_default(),
                 ));
             }
-            let res = self.pools[idx].new_multipart_upload(bucket, object, opts).await?;
+            self.apply_decommission_target_mutation_fence(idx, object, &mut opts, mutation_fence);
+            let res = self.pools[idx].new_multipart_upload(bucket, object, &opts).await?;
             return Ok((res, idx, opts.expected_bucket_incarnation_id));
         }
 
@@ -454,7 +456,8 @@ impl ECStore {
             .await?;
 
             if !res.uploads.is_empty() {
-                let res = self.pools[idx].new_multipart_upload(bucket, object, opts).await?;
+                self.apply_decommission_target_mutation_fence(idx, object, &mut opts, mutation_fence);
+                let res = self.pools[idx].new_multipart_upload(bucket, object, &opts).await?;
                 return Ok((res, idx, opts.expected_bucket_incarnation_id));
             }
         }
@@ -467,7 +470,8 @@ impl ECStore {
             ));
         }
 
-        let res = self.pools[idx].new_multipart_upload(bucket, object, opts).await?;
+        self.apply_decommission_target_mutation_fence(idx, object, &mut opts, mutation_fence);
+        let res = self.pools[idx].new_multipart_upload(bucket, object, &opts).await?;
         Ok((res, idx, opts.expected_bucket_incarnation_id))
     }
 
@@ -710,6 +714,7 @@ impl ECStore {
         upload_id: &str,
         uploaded_parts: Vec<CompletePart>,
         opts: &ObjectOptions,
+        mutation_fence: Option<&ObjectLockDiagGuard>,
     ) -> Result<ObjectInfo> {
         check_complete_multipart_args(bucket, object, upload_id)?;
         if !opts.data_movement {
@@ -739,6 +744,7 @@ impl ECStore {
             snapshot.add_lock_fences(&mut opts);
             opts.object_lock_config_snapshot = Some(snapshot);
         }
+        self.apply_decommission_target_mutation_fence(target_pool_idx, object, &mut opts, mutation_fence);
         #[cfg(test)]
         pause_data_movement_multipart_before_selected_completion(bucket).await;
         let pool = self

--- a/crates/ecstore/src/store/multipart.rs
+++ b/crates/ecstore/src/store/multipart.rs
@@ -416,7 +416,8 @@ impl ECStore {
         let (mut opts, _bucket_lifecycle_guard) = self.guard_multipart_bucket_incarnation(bucket, opts).await?;
 
         if self.single_pool() {
-            self.apply_decommission_target_mutation_fence(0, object, &mut opts, mutation_fence);
+            self.apply_decommission_target_mutation_fence(0, object, &mut opts, mutation_fence)
+                .await;
             return self.pools[0]
                 .new_multipart_upload(bucket, object, &opts)
                 .await
@@ -432,7 +433,8 @@ impl ECStore {
                     opts.version_id.clone().unwrap_or_default(),
                 ));
             }
-            self.apply_decommission_target_mutation_fence(idx, object, &mut opts, mutation_fence);
+            self.apply_decommission_target_mutation_fence(idx, object, &mut opts, mutation_fence)
+                .await;
             let res = self.pools[idx].new_multipart_upload(bucket, object, &opts).await?;
             return Ok((res, idx, opts.expected_bucket_incarnation_id));
         }
@@ -456,7 +458,8 @@ impl ECStore {
             .await?;
 
             if !res.uploads.is_empty() {
-                self.apply_decommission_target_mutation_fence(idx, object, &mut opts, mutation_fence);
+                self.apply_decommission_target_mutation_fence(idx, object, &mut opts, mutation_fence)
+                    .await;
                 let res = self.pools[idx].new_multipart_upload(bucket, object, &opts).await?;
                 return Ok((res, idx, opts.expected_bucket_incarnation_id));
             }
@@ -470,7 +473,8 @@ impl ECStore {
             ));
         }
 
-        self.apply_decommission_target_mutation_fence(idx, object, &mut opts, mutation_fence);
+        self.apply_decommission_target_mutation_fence(idx, object, &mut opts, mutation_fence)
+            .await;
         let res = self.pools[idx].new_multipart_upload(bucket, object, &opts).await?;
         Ok((res, idx, opts.expected_bucket_incarnation_id))
     }
@@ -744,7 +748,8 @@ impl ECStore {
             snapshot.add_lock_fences(&mut opts);
             opts.object_lock_config_snapshot = Some(snapshot);
         }
-        self.apply_decommission_target_mutation_fence(target_pool_idx, object, &mut opts, mutation_fence);
+        self.apply_decommission_target_mutation_fence(target_pool_idx, object, &mut opts, mutation_fence)
+            .await;
         #[cfg(test)]
         pause_data_movement_multipart_before_selected_completion(bucket).await;
         let pool = self

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -353,6 +353,8 @@ impl fmt::Display for ObjectLockDiagMode {
 
 pub(crate) struct ObjectLockDiagGuard {
     guard: rustfs_lock::NamespaceLockGuard,
+    #[cfg(test)]
+    test_namespace_lock_fence: Option<NamespaceLockFence>,
     enabled: bool,
     op: &'static str,
     bucket: Option<String>,
@@ -374,6 +376,8 @@ impl ObjectLockDiagGuard {
     ) -> Self {
         Self {
             guard,
+            #[cfg(test)]
+            test_namespace_lock_fence: None,
             enabled,
             op,
             bucket,
@@ -400,7 +404,90 @@ impl ObjectLockDiagGuard {
         if let Some(signal) = self.lock_lost_signal() {
             opts.add_namespace_lock_lost_signal(signal);
         }
+        #[cfg(test)]
+        if let Some(fence) = self.test_namespace_lock_fence.as_ref() {
+            opts.add_namespace_lock_fence_for_test(fence);
+        }
     }
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DecommissionMutationFenceTestPhase {
+    Migration,
+    SourceCleanup,
+}
+
+#[cfg(test)]
+struct DecommissionMutationFenceLossState {
+    bucket: String,
+    object: String,
+    phase: DecommissionMutationFenceTestPhase,
+    fence: NamespaceLockFence,
+    loss_handle: Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[cfg(test)]
+pub(crate) struct DecommissionMutationFenceLossHook {
+    state: Arc<DecommissionMutationFenceLossState>,
+}
+
+#[cfg(test)]
+static DECOMMISSION_MUTATION_FENCE_LOSS_HOOK: std::sync::OnceLock<
+    std::sync::Mutex<Option<Arc<DecommissionMutationFenceLossState>>>,
+> = std::sync::OnceLock::new();
+
+#[cfg(test)]
+impl DecommissionMutationFenceLossHook {
+    pub(crate) fn install(bucket: &str, object: &str, phase: DecommissionMutationFenceTestPhase) -> Self {
+        let (fence, loss_handle) = NamespaceLockFence::loss_handle_for_test();
+        let state = Arc::new(DecommissionMutationFenceLossState {
+            bucket: bucket.to_string(),
+            object: object.to_string(),
+            phase,
+            fence,
+            loss_handle,
+        });
+        let mut slot = DECOMMISSION_MUTATION_FENCE_LOSS_HOOK
+            .get_or_init(|| std::sync::Mutex::new(None))
+            .lock()
+            .expect("decommission mutation fence loss hooks should not poison");
+        assert!(slot.is_none(), "decommission mutation fence loss hook must be unique");
+        *slot = Some(Arc::clone(&state));
+        Self { state }
+    }
+
+    pub(crate) fn mark_lost(&self) {
+        self.state.loss_handle.store(true, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+impl Drop for DecommissionMutationFenceLossHook {
+    fn drop(&mut self) {
+        let mut slot = DECOMMISSION_MUTATION_FENCE_LOSS_HOOK
+            .get_or_init(|| std::sync::Mutex::new(None))
+            .lock()
+            .expect("decommission mutation fence loss hooks should not poison");
+        if slot.as_ref().is_some_and(|hook| Arc::ptr_eq(hook, &self.state)) {
+            *slot = None;
+        }
+    }
+}
+
+#[cfg(test)]
+fn decommission_mutation_fence_for_test(
+    bucket: &str,
+    object: &str,
+    phase: DecommissionMutationFenceTestPhase,
+) -> Option<NamespaceLockFence> {
+    DECOMMISSION_MUTATION_FENCE_LOSS_HOOK
+        .get_or_init(|| std::sync::Mutex::new(None))
+        .lock()
+        .expect("decommission mutation fence loss hooks should not poison")
+        .as_ref()
+        .filter(|hook| hook.bucket == bucket && hook.object == object && hook.phase == phase)
+        .map(|hook| hook.fence.clone())
 }
 
 pub(crate) struct SourceCleanupMutationFence {
@@ -1835,11 +1922,22 @@ impl ECStore {
             return Err(Error::other("decommission object migration requires namespace locking"));
         }
 
+        #[cfg(test)]
+        let test_namespace_lock_fence =
+            decommission_mutation_fence_for_test(bucket, object, DecommissionMutationFenceTestPhase::Migration);
         let object = encode_dir_object(object);
         let mut opts = ObjectOptions::default();
-        self.acquire_object_read_lock_if_needed("decommission_object", bucket, &object, &mut opts)
+        let guard = self
+            .acquire_object_read_lock_if_needed("decommission_object", bucket, &object, &mut opts)
             .await?
-            .ok_or_else(|| Error::other("decommission object migration failed to acquire its namespace fence"))
+            .ok_or_else(|| Error::other("decommission object migration failed to acquire its namespace fence"))?;
+        #[cfg(test)]
+        let guard = {
+            let mut guard = guard;
+            guard.test_namespace_lock_fence = test_namespace_lock_fence;
+            guard
+        };
+        Ok(guard)
     }
 
     pub(super) fn apply_decommission_target_mutation_fence(
@@ -1873,6 +1971,9 @@ impl ECStore {
 
         #[cfg(test)]
         crate::data_movement::notify_source_cleanup_mutation_fence_pending(bucket, object);
+        #[cfg(test)]
+        let test_namespace_lock_fence =
+            decommission_mutation_fence_for_test(bucket, object, DecommissionMutationFenceTestPhase::SourceCleanup);
         let object = encode_dir_object(object);
         let fixed_set = Arc::clone(&self.pools[0].disk_set[0]);
         // SetDisks namespaces include pool/set identity, so only the canonical
@@ -1883,6 +1984,12 @@ impl ECStore {
         let guard = self
             .acquire_object_write_lock("decommission_source_cleanup", bucket, &object)
             .await?;
+        #[cfg(test)]
+        let guard = {
+            let mut guard = guard;
+            guard.test_namespace_lock_fence = test_namespace_lock_fence;
+            guard
+        };
 
         Ok(SourceCleanupMutationFence {
             guard,

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -1753,9 +1753,10 @@ impl ECStore {
         #[cfg(test)]
         crate::data_movement::notify_source_cleanup_mutation_fence_pending(bucket, object);
         let object = encode_dir_object(object);
-        let distributed = self.ctx.is_dist_erasure().await;
         let fixed_set = Arc::clone(&self.pools[0].disk_set[0]);
-        let source_lock_covered = !distributed || same_distributed_lock_domain(&fixed_set.lockers, &source_set.lockers);
+        // SetDisks namespaces include pool/set identity, so only the canonical
+        // fixed set is covered by the fixed mutation guard.
+        let source_lock_covered = std::ptr::eq(fixed_set.as_ref(), source_set);
         // Lock order: fixed store mutation domain first; source cleanup takes its
         // hashed source-domain lock second only when this guard does not cover it.
         let guard = self

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -38,7 +38,7 @@ use crate::disk::OldCurrentSize;
 use crate::object_api::{NamespaceLockFence, ObjectLockConfigSnapshot};
 use crate::set_disk::{
     SetDisks, get_lock_acquire_timeout, get_object_lock_diag_slow_acquire_threshold, get_object_lock_diag_slow_hold_threshold,
-    is_lock_optimization_enabled, is_object_lock_diag_enabled,
+    is_lock_optimization_enabled, is_object_lock_diag_enabled, same_distributed_lock_domain,
 };
 use crate::storage_api_contracts::{
     namespace::NamespaceLocking as _,
@@ -799,16 +799,6 @@ impl SelectObjectSnapshotLockLossWake {
             }
         }
     }
-}
-
-// LockRegistry clones its canonical client Arc for each endpoint host, so an
-// exact Arc set identifies one distributed namespace-lock quorum domain.
-fn same_distributed_lock_domain(left: &[Arc<dyn rustfs_lock::LockClient>], right: &[Arc<dyn rustfs_lock::LockClient>]) -> bool {
-    left.iter()
-        .all(|left_client| right.iter().any(|right_client| Arc::ptr_eq(left_client, right_client)))
-        && right
-            .iter()
-            .all(|right_client| left.iter().any(|left_client| Arc::ptr_eq(left_client, right_client)))
 }
 
 impl AsyncRead for SelectObjectSnapshotReader {
@@ -3954,7 +3944,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn decommission_fence_keeps_dist_set_locks_when_clients_match_but_namespaces_differ() {
+    async fn decommission_fence_covers_dist_sets_with_same_clients_despite_different_namespaces() {
         let ctx = Arc::new(crate::runtime::instance::InstanceContext::new());
         let (_dirs, original_sets) = make_local_two_set_sets_with_ctx(Arc::clone(&ctx)).await;
         let mut second_set = (*original_sets.disk_set[1]).clone();
@@ -3984,18 +3974,27 @@ mod tests {
             .acquire_decommission_object_mutation_fence("bucket", &object)
             .await
             .expect("the fixed distributed mutation fence should be acquired");
+        let target_lock = sets.disk_set[1]
+            .new_ns_lock("bucket", &object)
+            .await
+            .expect("the hashed-set namespace lock should be created");
+        let target_err = target_lock
+            .get_write_lock(Duration::from_millis(50))
+            .await
+            .expect_err("the fixed read fence must conflict through the shared clients");
+        assert!(matches!(target_err, rustfs_lock::LockError::Timeout { .. }));
 
         let mut put_opts = ObjectOptions::default();
         store
             .apply_decommission_target_mutation_fence(0, &object, &mut put_opts, Some(&mutation_fence))
             .await;
-        assert!(!put_opts.no_lock, "migration target PUT must retain the hashed-set lock");
+        assert!(put_opts.no_lock, "migration target PUT must reuse the covering fixed fence");
 
         let mut multipart_opts = ObjectOptions::default();
         store
             .apply_decommission_target_mutation_fence(0, &object, &mut multipart_opts, Some(&mutation_fence))
             .await;
-        assert!(!multipart_opts.no_lock, "migration target multipart must retain the hashed-set lock");
+        assert!(multipart_opts.no_lock, "migration target multipart must reuse the covering fixed fence");
         drop(mutation_fence);
 
         let cleanup_object = (0..1_000)
@@ -4006,10 +4005,16 @@ mod tests {
             .acquire_decommission_source_cleanup_fence("bucket", &cleanup_object, sets.disk_set[1].as_ref())
             .await
             .expect("the fixed distributed cleanup fence should be acquired");
-        assert!(
-            !source_fence.source_lock_covered(),
-            "source cleanup must retain its distinct distributed set lock"
-        );
+        assert!(source_fence.source_lock_covered(), "source cleanup must reuse the covering fixed fence");
+        let source_lock = sets.disk_set[1]
+            .new_ns_lock("bucket", &cleanup_object)
+            .await
+            .expect("the source-set namespace lock should be created");
+        let source_err = source_lock
+            .get_read_lock(Duration::from_millis(50))
+            .await
+            .expect_err("the fixed write fence must conflict through the shared clients");
+        assert!(matches!(source_err, rustfs_lock::LockError::Timeout { .. }));
     }
 
     #[test]

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -1048,6 +1048,54 @@ fn batch_delete_targets_pool(creates_latest_marker: bool, marker_target_pool_idx
     !creates_latest_marker || marker_target_pool_idx == Some(pool_idx)
 }
 
+fn resolve_batch_delete_pool_results<'a>(
+    initial_error: Option<Error>,
+    pool_results: impl IntoIterator<Item = (&'a DeletedObject, &'a Option<Error>)>,
+) -> (Option<DeletedObject>, Option<Error>, bool) {
+    let mut failure = initial_error.map(|err| (None, err));
+    let mut deleted = None;
+    let mut fallback = None;
+    let mut attempted = false;
+
+    for (pool_delete, pool_error) in pool_results {
+        attempted = true;
+        match pool_error {
+            Some(err) if is_err_object_not_found(err) || is_err_version_not_found(err) => {
+                if fallback.as_ref().is_none_or(|(_, error)| error.is_none()) {
+                    fallback = Some(((*pool_delete).clone(), Some(err.clone())));
+                }
+            }
+            Some(err) => {
+                if failure.is_none() {
+                    failure = Some((Some((*pool_delete).clone()), err.clone()));
+                }
+            }
+            None if pool_delete.found => {
+                if deleted.is_none() {
+                    deleted = Some((*pool_delete).clone());
+                }
+            }
+            None => {
+                if fallback.is_none() {
+                    fallback = Some(((*pool_delete).clone(), None));
+                }
+            }
+        }
+    }
+
+    if let Some((failed_delete, err)) = failure {
+        return (failed_delete, Some(err), attempted);
+    }
+    if let Some(deleted) = deleted {
+        return (Some(deleted), None, attempted);
+    }
+    if let Some((deleted, err)) = fallback {
+        return (Some(deleted), err, attempted);
+    }
+
+    (None, None, attempted)
+}
+
 fn transition_restore_pool_opts(opts: &ObjectOptions) -> ObjectOptions {
     let mut lookup_opts = opts.clone();
     lookup_opts.skip_decommissioned = true;
@@ -3056,27 +3104,18 @@ impl ECStore {
 
         let results = join_all(futures).await;
 
-        let mut attempted = vec![false; del_objects.len()];
         for idx in 0..del_objects.len() {
-            for (object_indices, (dels, errs)) in results.iter() {
-                let Ok(pool_object_idx) = object_indices.binary_search(&idx) else {
-                    continue;
-                };
-                attempted[idx] = true;
-
-                if errs[pool_object_idx].is_none() && dels[pool_object_idx].found {
-                    del_errs[idx] = None;
-                    del_objects[idx] = dels[pool_object_idx].clone();
-                    break;
-                }
-
-                if del_errs[idx].is_none() {
-                    del_errs[idx] = errs[pool_object_idx].clone();
-                    del_objects[idx] = dels[pool_object_idx].clone();
-                }
+            let pool_results = results.iter().filter_map(|(object_indices, (dels, errs))| {
+                let pool_object_idx = object_indices.binary_search(&idx).ok()?;
+                Some((&dels[pool_object_idx], &errs[pool_object_idx]))
+            });
+            let (deleted, error, attempted) = resolve_batch_delete_pool_results(del_errs[idx].take(), pool_results);
+            if let Some(deleted) = deleted {
+                del_objects[idx] = deleted;
             }
+            del_errs[idx] = error;
 
-            if !attempted[idx] && del_errs[idx].is_none() && latest_marker_objects[idx] {
+            if !attempted && del_errs[idx].is_none() && latest_marker_objects[idx] {
                 del_objects[idx] = DeletedObject {
                     object_name: objects[idx].object_name.clone(),
                     version_id: objects[idx].version_id,
@@ -4792,6 +4831,88 @@ mod tests {
         let unversioned = DeleteReplicationConfigSnapshot::default();
         assert!(!batch_delete_creates_latest_marker(&latest, &unversioned));
         assert!(batch_delete_targets_pool(false, None, 0));
+    }
+
+    #[test]
+    fn batch_delete_pool_failures_override_success_in_any_pool_order() {
+        let success = DeletedObject {
+            object_name: "object".to_string(),
+            found: true,
+            ..Default::default()
+        };
+        let source_errors = [
+            StorageError::ErasureWriteQuorum,
+            StorageError::NamespaceLockQuorumUnavailable {
+                mode: "delete_objects_commit",
+                bucket: "bucket".to_string(),
+                object: "object".to_string(),
+                required: 1,
+                achieved: 0,
+            },
+        ];
+
+        for source_error in source_errors {
+            for source_first in [true, false] {
+                let failed = (DeletedObject::default(), Some(source_error.clone()));
+                let succeeded = (success.clone(), None);
+                let pool_results = if source_first {
+                    vec![failed, succeeded]
+                } else {
+                    vec![succeeded, failed]
+                };
+
+                let (_, error, attempted) =
+                    resolve_batch_delete_pool_results(None, pool_results.iter().map(|(deleted, error)| (deleted, error)));
+
+                assert!(attempted);
+                assert_eq!(error, Some(source_error.clone()));
+            }
+        }
+    }
+
+    #[test]
+    fn batch_delete_ignores_missing_pool_only_after_another_pool_succeeds() {
+        let success = DeletedObject {
+            object_name: "object".to_string(),
+            found: true,
+            ..Default::default()
+        };
+        let missing_errors = [
+            StorageError::ObjectNotFound("bucket".to_string(), "object".to_string()),
+            StorageError::VersionNotFound("bucket".to_string(), "object".to_string(), "version".to_string()),
+        ];
+
+        for missing_error in missing_errors {
+            let missing = (DeletedObject::default(), Some(missing_error.clone()));
+            for missing_first in [true, false] {
+                let succeeded = (success.clone(), None);
+                let pool_results = if missing_first {
+                    vec![missing.clone(), succeeded]
+                } else {
+                    vec![succeeded, missing.clone()]
+                };
+                let (deleted, error, attempted) =
+                    resolve_batch_delete_pool_results(None, pool_results.iter().map(|(deleted, error)| (deleted, error)));
+
+                assert!(attempted);
+                let deleted = deleted.expect("successful pool result should be retained");
+                assert!(deleted.found);
+                assert_eq!(deleted.object_name, success.object_name.as_str());
+                assert!(error.is_none());
+            }
+
+            let missing_only = [missing];
+            let (_, error, attempted) =
+                resolve_batch_delete_pool_results(None, missing_only.iter().map(|(deleted, error)| (deleted, error)));
+            assert!(attempted);
+            assert_eq!(error, Some(missing_error));
+        }
+
+        let silent_missing = [(DeletedObject::default(), None)];
+        let (_, error, attempted) =
+            resolve_batch_delete_pool_results(None, silent_missing.iter().map(|(deleted, error)| (deleted, error)));
+        assert!(attempted);
+        assert!(error.is_none());
     }
 
     #[test]

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -1952,16 +1952,12 @@ impl ECStore {
         };
 
         mutation_fence.add_namespace_lock_fence(opts);
-        let distributed = self.ctx.is_dist_erasure().await;
         let fixed_set = self.pools.first().and_then(|pool| pool.disk_set.first());
         let target_set = self.pools.get(target_pool_idx).map(|pool| pool.get_disks_by_key(object));
-        // Local locks share one manager without set-qualified resource keys.
-        // Distributed locks overlap when both sets use the same client domain.
-        opts.no_lock = matches!(
-            (fixed_set, target_set),
-            (Some(fixed), Some(target))
-                if !distributed || same_distributed_lock_domain(&fixed.lockers, &target.lockers)
-        );
+        opts.no_lock = match (fixed_set, target_set) {
+            (Some(fixed), Some(target)) => fixed.shares_namespace_lock_domain(&target).await,
+            _ => false,
+        };
     }
 
     pub(crate) async fn acquire_decommission_source_cleanup_fence(
@@ -1980,9 +1976,8 @@ impl ECStore {
         let test_namespace_lock_fence =
             decommission_mutation_fence_for_test(bucket, object, DecommissionMutationFenceTestPhase::SourceCleanup);
         let object = encode_dir_object(object);
-        let distributed = self.ctx.is_dist_erasure().await;
         let fixed_set = Arc::clone(&self.pools[0].disk_set[0]);
-        let source_lock_covered = !distributed || same_distributed_lock_domain(&fixed_set.lockers, &source_set.lockers);
+        let source_lock_covered = fixed_set.shares_namespace_lock_domain(source_set).await;
         // Lock order: fixed store mutation domain first; source cleanup takes its
         // hashed source-domain lock second only when this guard does not cover it.
         let guard = self
@@ -3956,6 +3951,65 @@ mod tests {
             &[Arc::clone(&second), Arc::clone(&first)]
         ));
         assert!(!same_distributed_lock_domain(&[first, second], &[other]));
+    }
+
+    #[tokio::test]
+    async fn decommission_fence_keeps_dist_set_locks_when_clients_match_but_namespaces_differ() {
+        let ctx = Arc::new(crate::runtime::instance::InstanceContext::new());
+        let (_dirs, original_sets) = make_local_two_set_sets_with_ctx(Arc::clone(&ctx)).await;
+        let mut second_set = (*original_sets.disk_set[1]).clone();
+        second_set.lockers = original_sets.disk_set[0].lockers.clone();
+        let mut sets = (*original_sets).clone();
+        sets.disk_set[1] = Arc::new(second_set);
+        let sets = Arc::new(sets);
+        ctx.update_erasure_type(SetupType::DistErasure).await;
+
+        assert!(
+            sets.disk_set[0]
+                .lockers
+                .iter()
+                .zip(&sets.disk_set[1].lockers)
+                .all(|(fixed, hashed)| Arc::ptr_eq(fixed, hashed)),
+            "the regression requires identical distributed lock clients"
+        );
+        assert_ne!(sets.disk_set[0].set_index, sets.disk_set[1].set_index);
+
+        let pool_config = sets.endpoints.clone();
+        let store = new_prepared_reader_test_store_from_pools(vec![Arc::clone(&sets)], vec![pool_config], ctx);
+        let object = (0..1_000)
+            .map(|index| format!("decommission-dist-domain-{index}.bin"))
+            .find(|candidate| Arc::ptr_eq(&sets.get_disks_by_key(candidate), &sets.disk_set[1]))
+            .expect("a key should hash to the second set namespace");
+        let mutation_fence = store
+            .acquire_decommission_object_mutation_fence("bucket", &object)
+            .await
+            .expect("the fixed distributed mutation fence should be acquired");
+
+        let mut put_opts = ObjectOptions::default();
+        store
+            .apply_decommission_target_mutation_fence(0, &object, &mut put_opts, Some(&mutation_fence))
+            .await;
+        assert!(!put_opts.no_lock, "migration target PUT must retain the hashed-set lock");
+
+        let mut multipart_opts = ObjectOptions::default();
+        store
+            .apply_decommission_target_mutation_fence(0, &object, &mut multipart_opts, Some(&mutation_fence))
+            .await;
+        assert!(!multipart_opts.no_lock, "migration target multipart must retain the hashed-set lock");
+        drop(mutation_fence);
+
+        let cleanup_object = (0..1_000)
+            .map(|index| format!("decommission-dist-cleanup-{index}.bin"))
+            .find(|candidate| Arc::ptr_eq(&sets.get_disks_by_key(candidate), &sets.disk_set[1]))
+            .expect("a cleanup key should hash to the second set namespace");
+        let source_fence = store
+            .acquire_decommission_source_cleanup_fence("bucket", &cleanup_object, sets.disk_set[1].as_ref())
+            .await
+            .expect("the fixed distributed cleanup fence should be acquired");
+        assert!(
+            !source_fence.source_lock_covered(),
+            "source cleanup must retain its distinct distributed set lock"
+        );
     }
 
     #[test]

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -916,7 +916,7 @@ fn resolve_latest_object_access(
 }
 
 fn should_create_delete_marker_for_missing_object(opts: &ObjectOptions) -> bool {
-    opts.versioned && opts.version_id.is_none() && !opts.delete_marker && !opts.data_movement
+    (opts.versioned || opts.version_suspended) && opts.version_id.is_none() && !opts.delete_marker && !opts.data_movement
 }
 
 #[cfg(test)]
@@ -1940,7 +1940,7 @@ impl ECStore {
         Ok(guard)
     }
 
-    pub(super) fn apply_decommission_target_mutation_fence(
+    pub(super) async fn apply_decommission_target_mutation_fence(
         &self,
         target_pool_idx: usize,
         object: &str,
@@ -1952,11 +1952,16 @@ impl ECStore {
         };
 
         mutation_fence.add_namespace_lock_fence(opts);
+        let distributed = self.ctx.is_dist_erasure().await;
         let fixed_set = self.pools.first().and_then(|pool| pool.disk_set.first());
         let target_set = self.pools.get(target_pool_idx).map(|pool| pool.get_disks_by_key(object));
-        // The fixed read fence can replace the target write acquisition only
-        // when both names resolve to the exact same SetDisks namespace.
-        opts.no_lock = matches!((fixed_set, target_set), (Some(fixed), Some(target)) if Arc::ptr_eq(fixed, &target));
+        // Local locks share one manager without set-qualified resource keys.
+        // Distributed locks overlap when both sets use the same client domain.
+        opts.no_lock = matches!(
+            (fixed_set, target_set),
+            (Some(fixed), Some(target))
+                if !distributed || same_distributed_lock_domain(&fixed.lockers, &target.lockers)
+        );
     }
 
     pub(crate) async fn acquire_decommission_source_cleanup_fence(
@@ -1975,10 +1980,9 @@ impl ECStore {
         let test_namespace_lock_fence =
             decommission_mutation_fence_for_test(bucket, object, DecommissionMutationFenceTestPhase::SourceCleanup);
         let object = encode_dir_object(object);
+        let distributed = self.ctx.is_dist_erasure().await;
         let fixed_set = Arc::clone(&self.pools[0].disk_set[0]);
-        // SetDisks namespaces include pool/set identity, so only the canonical
-        // fixed set is covered by the fixed mutation guard.
-        let source_lock_covered = std::ptr::eq(fixed_set.as_ref(), source_set);
+        let source_lock_covered = !distributed || same_distributed_lock_domain(&fixed_set.lockers, &source_set.lockers);
         // Lock order: fixed store mutation domain first; source cleanup takes its
         // hashed source-domain lock second only when this guard does not cover it.
         let guard = self
@@ -2459,7 +2463,8 @@ impl ECStore {
         let idx = self
             .select_put_object_pool_idx(bucket, object.as_str(), data.size(), &opts)
             .await?;
-        self.apply_decommission_target_mutation_fence(idx, object.as_str(), &mut opts, mutation_fence);
+        self.apply_decommission_target_mutation_fence(idx, object.as_str(), &mut opts, mutation_fence)
+            .await;
         let result = self.pools[idx]
             .put_object_with_old_current_size(bucket, &object, data, &opts)
             .await

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -32,7 +32,8 @@ use crate::bucket::metadata_sys::{
 use crate::bucket::object_lock::objectlock_sys::{
     check_object_lock_for_deletion_with_state, ensure_recursive_force_delete_allowed_for_state,
 };
-use crate::bucket::replication::ReplicationObjectBridge;
+use crate::bucket::replication::{DeleteReplicationConfigSnapshot, ReplicationObjectBridge};
+use crate::bucket::versioning::VersioningApi;
 use crate::disk::OldCurrentSize;
 use crate::object_api::{NamespaceLockFence, ObjectLockConfigSnapshot};
 use crate::set_disk::{
@@ -1031,6 +1032,20 @@ fn delete_pool_lookup_opts(opts: &ObjectOptions, no_lock: bool) -> ObjectOptions
 
 fn should_delete_from_all_pools(opts: &ObjectOptions, pool_count: usize) -> bool {
     pool_count > 0 && (!opts.versioned && !opts.version_suspended || opts.version_id.is_some())
+}
+
+fn batch_delete_creates_latest_marker(object: &ObjectToDelete, delete_config_snapshot: &DeleteReplicationConfigSnapshot) -> bool {
+    if object.version_id.is_some() {
+        return false;
+    }
+
+    let object_name = decode_dir_object(&object.object_name);
+    let (versioned, version_suspended) = delete_config_snapshot.versioning_config().delete_state(&object_name);
+    versioned || version_suspended
+}
+
+fn batch_delete_targets_pool(creates_latest_marker: bool, marker_target_pool_idx: Option<usize>, pool_idx: usize) -> bool {
+    !creates_latest_marker || marker_target_pool_idx == Some(pool_idx)
 }
 
 fn transition_restore_pool_opts(opts: &ObjectOptions) -> ObjectOptions {
@@ -2984,31 +2999,97 @@ impl ECStore {
             Err(err) => return return_batch_delete_lock_error_with_accounting(objects.as_slice(), err),
         };
 
-        let mut futures = Vec::with_capacity(self.pools.len());
+        let delete_config_snapshot = opts
+            .delete_replication_config_snapshot
+            .as_deref()
+            .expect("batch delete replication config snapshot should be loaded");
+        let latest_marker_objects = objects
+            .iter()
+            .map(|object| batch_delete_creates_latest_marker(object, delete_config_snapshot))
+            .collect::<Vec<_>>();
+        let marker_target_results = join_all(objects.iter().zip(&latest_marker_objects).map(
+            |(object, creates_marker)| async move {
+                if *creates_marker {
+                    Some(self.get_pool_idx_no_lock(bucket, &object.object_name, 0).await)
+                } else {
+                    None
+                }
+            },
+        ))
+        .await;
+        let mut marker_target_pool_indices = Vec::with_capacity(objects.len());
+        for (idx, target_result) in marker_target_results.into_iter().enumerate() {
+            match target_result {
+                Some(Ok(pool_idx)) => marker_target_pool_indices.push(Some(pool_idx)),
+                Some(Err(err)) => {
+                    del_errs[idx] = Some(err);
+                    marker_target_pool_indices.push(None);
+                }
+                None => marker_target_pool_indices.push(None),
+            }
+        }
 
+        let mut futures = Vec::with_capacity(self.pools.len());
         for pool in self.pools.iter() {
             if self.is_pool_rebalancing(pool.pool_idx).await {
                 continue;
             }
-            futures.push(pool.delete_objects_with_accounting(bucket, objects.clone(), opts.clone()));
+
+            let (object_indices, pool_objects): (Vec<_>, Vec<_>) = objects
+                .iter()
+                .enumerate()
+                .filter(|(idx, _)| {
+                    batch_delete_targets_pool(latest_marker_objects[*idx], marker_target_pool_indices[*idx], pool.pool_idx)
+                })
+                .map(|(idx, object)| (idx, object.clone()))
+                .unzip();
+            if pool_objects.is_empty() {
+                continue;
+            }
+
+            let pool_opts = opts.clone();
+            futures.push(async move {
+                let result = pool.delete_objects(bucket, pool_objects, pool_opts).await;
+                (object_indices, result)
+            });
         }
 
         let results = join_all(futures).await;
 
+        let mut attempted = vec![false; del_objects.len()];
         for idx in 0..del_objects.len() {
-            for (dels, errs, pool_accounting) in results.iter() {
-                if errs[idx].is_none() && dels[idx].found {
+            for (object_indices, (dels, errs)) in results.iter() {
+                let Ok(pool_object_idx) = object_indices.binary_search(&idx) else {
+                    continue;
+                };
+                attempted[idx] = true;
+
+                if errs[pool_object_idx].is_none() && dels[pool_object_idx].found {
                     del_errs[idx] = None;
-                    del_objects[idx] = dels[idx].clone();
-                    accounting[idx] = pool_accounting[idx].clone();
+                    del_objects[idx] = dels[pool_object_idx].clone();
                     break;
                 }
 
                 if del_errs[idx].is_none() {
-                    del_errs[idx] = errs[idx].clone();
-                    del_objects[idx] = dels[idx].clone();
-                    accounting[idx] = pool_accounting[idx].clone();
+                    del_errs[idx] = errs[pool_object_idx].clone();
+                    del_objects[idx] = dels[pool_object_idx].clone();
                 }
+            }
+
+            if !attempted[idx] && del_errs[idx].is_none() && latest_marker_objects[idx] {
+                del_objects[idx] = DeletedObject {
+                    object_name: objects[idx].object_name.clone(),
+                    version_id: objects[idx].version_id,
+                    ..Default::default()
+                };
+                del_errs[idx] = Some(StorageError::ObjectNotFound(bucket.to_owned(), objects[idx].object_name.clone()));
+            }
+        }
+
+        #[cfg(test)]
+        for (idx, object) in objects.iter().enumerate() {
+            if del_errs[idx].is_none() && del_objects[idx].delete_marker {
+                pause_versioned_delete_marker_after_commit(bucket, &object.object_name).await;
             }
         }
 
@@ -4680,6 +4761,37 @@ mod tests {
             1,
         ));
         assert!(!should_delete_from_all_pools(&ObjectOptions::default(), 0));
+    }
+
+    #[test]
+    fn batch_delete_identifies_only_latest_versioned_markers() {
+        let versioned = DeleteReplicationConfigSnapshot::from_configs_for_test(
+            s3s::dto::VersioningConfiguration {
+                status: Some(s3s::dto::BucketVersioningStatus::from_static(s3s::dto::BucketVersioningStatus::ENABLED)),
+                ..Default::default()
+            },
+            None,
+        );
+        let latest = ObjectToDelete {
+            object_name: "latest".to_string(),
+            ..Default::default()
+        };
+        assert!(batch_delete_creates_latest_marker(&latest, &versioned));
+        assert!(!batch_delete_targets_pool(true, Some(1), 0));
+        assert!(batch_delete_targets_pool(true, Some(1), 1));
+        assert!(!batch_delete_targets_pool(true, Some(1), 2));
+
+        let explicit = ObjectToDelete {
+            object_name: "explicit".to_string(),
+            version_id: Some(uuid::Uuid::new_v4()),
+            ..Default::default()
+        };
+        assert!(!batch_delete_creates_latest_marker(&explicit, &versioned));
+        assert!(batch_delete_targets_pool(false, Some(1), 0));
+
+        let unversioned = DeleteReplicationConfigSnapshot::default();
+        assert!(!batch_delete_creates_latest_marker(&latest, &unversioned));
+        assert!(batch_delete_targets_pool(false, None, 0));
     }
 
     #[test]

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -838,6 +838,7 @@ struct DeleteAfterObjectLockSnapshotBarrierState {
     arrived: tokio::sync::Notify,
     release: tokio::sync::Notify,
     namespace_pending: tokio::sync::Notify,
+    namespace_acquired: AtomicBool,
 }
 
 #[cfg(test)]
@@ -858,6 +859,7 @@ impl DeleteAfterObjectLockSnapshotBarrier {
             arrived: tokio::sync::Notify::new(),
             release: tokio::sync::Notify::new(),
             namespace_pending: tokio::sync::Notify::new(),
+            namespace_acquired: AtomicBool::new(false),
         });
         let mut slot = DELETE_AFTER_OBJECT_LOCK_SNAPSHOT_BARRIER
             .get_or_init(|| std::sync::Mutex::new(None))
@@ -882,6 +884,10 @@ impl DeleteAfterObjectLockSnapshotBarrier {
         tokio::time::timeout(Duration::from_secs(5), namespace_pending)
             .await
             .expect("delete should proceed to its namespace lock after leaving the snapshot barrier");
+    }
+
+    pub(crate) fn namespace_acquired(&self) -> bool {
+        self.state.namespace_acquired.load(Ordering::Acquire)
     }
 }
 
@@ -911,6 +917,20 @@ async fn pause_delete_after_object_lock_snapshot(bucket: &str) {
         state.arrived.notify_one();
         state.release.notified().await;
         state.namespace_pending.notify_one();
+    }
+}
+
+#[cfg(test)]
+fn notify_delete_namespace_acquired(bucket: &str) {
+    let state = DELETE_AFTER_OBJECT_LOCK_SNAPSHOT_BARRIER
+        .get_or_init(|| std::sync::Mutex::new(None))
+        .lock()
+        .expect("delete snapshot barrier mutex should not poison")
+        .as_ref()
+        .filter(|state| state.bucket == bucket)
+        .cloned();
+    if let Some(state) = state {
+        state.namespace_acquired.store(true, Ordering::Release);
     }
 }
 
@@ -1046,6 +1066,88 @@ fn batch_delete_creates_latest_marker(object: &ObjectToDelete, delete_config_sna
 
 fn batch_delete_targets_pool(creates_latest_marker: bool, marker_target_pool_idx: Option<usize>, pool_idx: usize) -> bool {
     !creates_latest_marker || marker_target_pool_idx == Some(pool_idx)
+}
+
+#[cfg(test)]
+struct BatchDeletePoolErrorInjectionState {
+    bucket: String,
+    pool_idx: usize,
+    errors: std::collections::HashMap<String, Error>,
+    observed: std::sync::atomic::AtomicUsize,
+}
+
+#[cfg(test)]
+pub(crate) struct BatchDeletePoolErrorInjection {
+    state: Arc<BatchDeletePoolErrorInjectionState>,
+}
+
+#[cfg(test)]
+static BATCH_DELETE_POOL_ERROR_INJECTION: std::sync::OnceLock<std::sync::Mutex<Option<Arc<BatchDeletePoolErrorInjectionState>>>> =
+    std::sync::OnceLock::new();
+
+#[cfg(test)]
+impl BatchDeletePoolErrorInjection {
+    pub(crate) fn install(bucket: &str, pool_idx: usize, errors: Vec<(String, Error)>) -> Self {
+        let state = Arc::new(BatchDeletePoolErrorInjectionState {
+            bucket: bucket.to_string(),
+            pool_idx,
+            errors: errors.into_iter().collect(),
+            observed: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let mut slot = BATCH_DELETE_POOL_ERROR_INJECTION
+            .get_or_init(|| std::sync::Mutex::new(None))
+            .lock()
+            .expect("batch delete pool error injection mutex should not poison");
+        assert!(slot.is_none(), "batch delete pool error injection must be unique");
+        *slot = Some(Arc::clone(&state));
+        Self { state }
+    }
+
+    pub(crate) fn observed(&self) -> usize {
+        self.state.observed.load(Ordering::Acquire)
+    }
+}
+
+#[cfg(test)]
+impl Drop for BatchDeletePoolErrorInjection {
+    fn drop(&mut self) {
+        let mut slot = BATCH_DELETE_POOL_ERROR_INJECTION
+            .get_or_init(|| std::sync::Mutex::new(None))
+            .lock()
+            .expect("batch delete pool error injection mutex should not poison");
+        if slot.as_ref().is_some_and(|state| Arc::ptr_eq(state, &self.state)) {
+            *slot = None;
+        }
+    }
+}
+
+#[cfg(test)]
+fn inject_batch_delete_pool_errors(
+    bucket: &str,
+    pool_idx: usize,
+    object_names: &[String],
+    result: &mut (Vec<DeletedObject>, Vec<Option<Error>>),
+) {
+    let state = BATCH_DELETE_POOL_ERROR_INJECTION
+        .get_or_init(|| std::sync::Mutex::new(None))
+        .lock()
+        .expect("batch delete pool error injection mutex should not poison")
+        .as_ref()
+        .filter(|state| state.bucket == bucket && state.pool_idx == pool_idx)
+        .cloned();
+    let Some(state) = state else {
+        return;
+    };
+
+    for (idx, object_name) in object_names.iter().enumerate() {
+        let Some(error) = state.errors.get(object_name) else {
+            continue;
+        };
+        if result.1[idx].is_none() && result.0[idx].found {
+            result.1[idx] = Some(error.clone());
+            state.observed.fetch_add(1, Ordering::AcqRel);
+        }
+    }
 }
 
 fn resolve_batch_delete_pool_results<'a>(
@@ -2698,6 +2800,10 @@ impl ECStore {
         } else {
             None
         };
+        #[cfg(test)]
+        if _object_lock_guard.is_some() {
+            notify_delete_namespace_acquired(bucket);
+        }
         if let Some(trigger) = opts.lifecycle_delete_all.as_ref() {
             let configs = delete_all_configs.as_ref().ok_or(StorageError::PreconditionFailed)?;
             let expected_bucket_incarnation_id = opts.expected_bucket_incarnation_id.ok_or(StorageError::PreconditionFailed)?;
@@ -3047,6 +3153,10 @@ impl ECStore {
             Ok(guards) => guards,
             Err(err) => return return_batch_delete_lock_error_with_accounting(objects.as_slice(), err),
         };
+        #[cfg(test)]
+        if !_object_lock_guards.is_empty() {
+            notify_delete_namespace_acquired(bucket);
+        }
 
         let delete_config_snapshot = opts
             .delete_replication_config_snapshot
@@ -3098,7 +3208,18 @@ impl ECStore {
 
             let pool_opts = opts.clone();
             futures.push(async move {
+                #[cfg(test)]
+                let pool_object_names = pool_objects
+                    .iter()
+                    .map(|object| object.object_name.clone())
+                    .collect::<Vec<_>>();
                 let result = pool.delete_objects(bucket, pool_objects, pool_opts).await;
+                #[cfg(test)]
+                let result = {
+                    let mut result = result;
+                    inject_batch_delete_pool_errors(bucket, pool.pool_idx, &pool_object_names, &mut result);
+                    result
+                };
                 (object_indices, result)
             });
         }

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -3060,6 +3060,8 @@ impl ECStore {
             Err(err) if is_err_object_not_found(&err) && should_create_delete_marker_for_missing_object(&opts) => {
                 let target_pool_idx = self.get_pool_idx_no_lock(bucket, object, 0).await?;
                 let mut obj = self.pools[target_pool_idx].delete_object(bucket, object, opts).await?;
+                #[cfg(test)]
+                pause_versioned_delete_marker_after_commit(bucket, object).await;
                 obj.name = decode_dir_object(object);
                 return Ok(obj);
             }

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -395,7 +395,6 @@ impl ObjectLockDiagGuard {
     }
 
     pub(crate) fn add_namespace_lock_fence(&self, opts: &mut ObjectOptions) {
-        opts.no_lock = true;
         opts.ensure_namespace_lock_fence();
         if let Some(signal) = self.lock_lost_signal() {
             opts.add_namespace_lock_lost_signal(signal);
@@ -818,6 +817,7 @@ struct DeleteAfterObjectLockSnapshotBarrierState {
     bucket: String,
     arrived: tokio::sync::Notify,
     release: tokio::sync::Notify,
+    namespace_pending: tokio::sync::Notify,
 }
 
 #[cfg(test)]
@@ -837,6 +837,7 @@ impl DeleteAfterObjectLockSnapshotBarrier {
             bucket: bucket.to_string(),
             arrived: tokio::sync::Notify::new(),
             release: tokio::sync::Notify::new(),
+            namespace_pending: tokio::sync::Notify::new(),
         });
         let mut slot = DELETE_AFTER_OBJECT_LOCK_SNAPSHOT_BARRIER
             .get_or_init(|| std::sync::Mutex::new(None))
@@ -853,6 +854,14 @@ impl DeleteAfterObjectLockSnapshotBarrier {
 
     pub(crate) fn release(&self) {
         self.state.release.notify_one();
+    }
+
+    pub(crate) async fn release_and_wait_until_namespace_pending(&self) {
+        let namespace_pending = self.state.namespace_pending.notified();
+        self.release();
+        tokio::time::timeout(Duration::from_secs(5), namespace_pending)
+            .await
+            .expect("delete should proceed to its namespace lock after leaving the snapshot barrier");
     }
 }
 
@@ -881,6 +890,7 @@ async fn pause_delete_after_object_lock_snapshot(bucket: &str) {
     if let Some(state) = state {
         state.arrived.notify_one();
         state.release.notified().await;
+        state.namespace_pending.notify_one();
     }
 }
 

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -1243,7 +1243,7 @@ fn resolve_batch_delete_pool_results<'a>(
 ) -> (Option<DeletedObject>, Option<Error>, bool) {
     let mut failure = initial_error.map(|err| (None, err));
     let mut deleted = None;
-    let mut fallback = None;
+    let mut fallback: Option<(DeletedObject, Option<Error>)> = None;
     let mut attempted = false;
 
     for (pool_delete, pool_error) in pool_results {

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -36,7 +36,7 @@ use crate::bucket::replication::ReplicationObjectBridge;
 use crate::disk::OldCurrentSize;
 use crate::object_api::{NamespaceLockFence, ObjectLockConfigSnapshot};
 use crate::set_disk::{
-    get_lock_acquire_timeout, get_object_lock_diag_slow_acquire_threshold, get_object_lock_diag_slow_hold_threshold,
+    SetDisks, get_lock_acquire_timeout, get_object_lock_diag_slow_acquire_threshold, get_object_lock_diag_slow_hold_threshold,
     is_lock_optimization_enabled, is_object_lock_diag_enabled,
 };
 use crate::storage_api_contracts::{
@@ -399,6 +399,25 @@ impl ObjectLockDiagGuard {
         if let Some(signal) = self.lock_lost_signal() {
             opts.add_namespace_lock_lost_signal(signal);
         }
+    }
+}
+
+pub(crate) struct SourceCleanupMutationFence {
+    guard: ObjectLockDiagGuard,
+    source_lock_covered: bool,
+}
+
+impl SourceCleanupMutationFence {
+    pub(crate) fn source_lock_covered(&self) -> bool {
+        self.source_lock_covered
+    }
+
+    pub(crate) fn is_lock_lost(&self) -> bool {
+        self.guard.is_lock_lost()
+    }
+
+    pub(crate) fn add_namespace_lock_fence(&self, opts: &mut ObjectOptions) {
+        self.guard.add_namespace_lock_fence(opts);
     }
 }
 
@@ -891,6 +910,82 @@ async fn pause_delete_after_object_lock_snapshot(bucket: &str) {
         state.arrived.notify_one();
         state.release.notified().await;
         state.namespace_pending.notify_one();
+    }
+}
+
+#[cfg(test)]
+struct VersionedDeleteMarkerCommitBarrierState {
+    bucket: String,
+    object: String,
+    arrived: tokio::sync::Notify,
+    release: tokio::sync::Notify,
+}
+
+#[cfg(test)]
+pub(crate) struct VersionedDeleteMarkerCommitBarrier {
+    state: Arc<VersionedDeleteMarkerCommitBarrierState>,
+}
+
+#[cfg(test)]
+static VERSIONED_DELETE_MARKER_COMMIT_BARRIER: std::sync::OnceLock<
+    std::sync::Mutex<Option<Arc<VersionedDeleteMarkerCommitBarrierState>>>,
+> = std::sync::OnceLock::new();
+
+#[cfg(test)]
+impl VersionedDeleteMarkerCommitBarrier {
+    pub(crate) fn install(bucket: &str, object: &str) -> Self {
+        let state = Arc::new(VersionedDeleteMarkerCommitBarrierState {
+            bucket: bucket.to_string(),
+            object: object.to_string(),
+            arrived: tokio::sync::Notify::new(),
+            release: tokio::sync::Notify::new(),
+        });
+        let mut slot = VERSIONED_DELETE_MARKER_COMMIT_BARRIER
+            .get_or_init(|| std::sync::Mutex::new(None))
+            .lock()
+            .expect("versioned delete-marker commit barrier mutex should not poison");
+        assert!(slot.is_none(), "versioned delete-marker commit barrier must be unique");
+        *slot = Some(Arc::clone(&state));
+        Self { state }
+    }
+
+    pub(crate) async fn wait_until_paused(&self) {
+        tokio::time::timeout(Duration::from_secs(30), self.state.arrived.notified())
+            .await
+            .expect("versioned DELETE should reach the post-marker-commit barrier");
+    }
+
+    pub(crate) fn release(&self) {
+        self.state.release.notify_one();
+    }
+}
+
+#[cfg(test)]
+impl Drop for VersionedDeleteMarkerCommitBarrier {
+    fn drop(&mut self) {
+        self.state.release.notify_one();
+        let mut slot = VERSIONED_DELETE_MARKER_COMMIT_BARRIER
+            .get_or_init(|| std::sync::Mutex::new(None))
+            .lock()
+            .expect("versioned delete-marker commit barrier mutex should not poison");
+        if slot.as_ref().is_some_and(|state| Arc::ptr_eq(state, &self.state)) {
+            *slot = None;
+        }
+    }
+}
+
+#[cfg(test)]
+async fn pause_versioned_delete_marker_after_commit(bucket: &str, object: &str) {
+    let state = VERSIONED_DELETE_MARKER_COMMIT_BARRIER
+        .get_or_init(|| std::sync::Mutex::new(None))
+        .lock()
+        .expect("versioned delete-marker commit barrier mutex should not poison")
+        .as_ref()
+        .filter(|state| state.bucket == bucket && state.object == object)
+        .cloned();
+    if let Some(state) = state {
+        state.arrived.notify_one();
+        state.release.notified().await;
     }
 }
 
@@ -1580,6 +1675,34 @@ impl ECStore {
         self.acquire_object_read_lock_if_needed("decommission_object", bucket, &object, &mut opts)
             .await?
             .ok_or_else(|| Error::other("decommission object migration failed to acquire its namespace fence"))
+    }
+
+    pub(crate) async fn acquire_decommission_source_cleanup_fence(
+        &self,
+        bucket: &str,
+        object: &str,
+        source_set: &SetDisks,
+    ) -> Result<SourceCleanupMutationFence> {
+        if self.ctx.lock_manager().is_disabled() {
+            return Err(Error::other("decommission source cleanup requires namespace locking"));
+        }
+
+        #[cfg(test)]
+        crate::data_movement::notify_source_cleanup_mutation_fence_pending(bucket, object);
+        let object = encode_dir_object(object);
+        let distributed = self.ctx.is_dist_erasure().await;
+        let fixed_set = Arc::clone(&self.pools[0].disk_set[0]);
+        let source_lock_covered = !distributed || same_distributed_lock_domain(&fixed_set.lockers, &source_set.lockers);
+        // Lock order: fixed store mutation domain first; source cleanup takes its
+        // hashed source-domain lock second only when this guard does not cover it.
+        let guard = self
+            .acquire_object_write_lock("decommission_source_cleanup", bucket, &object)
+            .await?;
+
+        Ok(SourceCleanupMutationFence {
+            guard,
+            source_lock_covered,
+        })
     }
 
     pub(crate) async fn acquire_all_object_read_locks(
@@ -2705,12 +2828,14 @@ impl ECStore {
         }
 
         for pool in self.pools.iter() {
-            if self.is_pool_rebalancing(pool.pool_idx).await {
+            if self.is_suspended(pool.pool_idx).await || self.is_pool_rebalancing(pool.pool_idx).await {
                 continue;
             }
 
             match pool.delete_object(bucket, object, opts.clone()).await {
                 Ok(res) => {
+                    #[cfg(test)]
+                    pause_versioned_delete_marker_after_commit(bucket, object).await;
                     if let (Some(api), Some(je)) = (tier_journal_api.as_ref(), journal_entry.as_ref()) {
                         commit_prepared_tier_delete_journal_entry(api, je).await;
                     }
@@ -4524,6 +4649,16 @@ mod tests {
         assert!(lookup_opts.no_lock);
         assert!(!lookup_opts.skip_decommissioned);
         assert!(lookup_opts.skip_rebalancing);
+
+        let explicit_version = delete_pool_lookup_opts(
+            &ObjectOptions {
+                versioned: true,
+                version_id: Some(uuid::Uuid::new_v4().to_string()),
+                ..Default::default()
+            },
+            true,
+        );
+        assert!(!explicit_version.skip_decommissioned);
     }
 
     #[test]

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -1842,6 +1842,25 @@ impl ECStore {
             .ok_or_else(|| Error::other("decommission object migration failed to acquire its namespace fence"))
     }
 
+    pub(super) fn apply_decommission_target_mutation_fence(
+        &self,
+        target_pool_idx: usize,
+        object: &str,
+        opts: &mut ObjectOptions,
+        mutation_fence: Option<&ObjectLockDiagGuard>,
+    ) {
+        let Some(mutation_fence) = mutation_fence else {
+            return;
+        };
+
+        mutation_fence.add_namespace_lock_fence(opts);
+        let fixed_set = self.pools.first().and_then(|pool| pool.disk_set.first());
+        let target_set = self.pools.get(target_pool_idx).map(|pool| pool.get_disks_by_key(object));
+        // The fixed read fence can replace the target write acquisition only
+        // when both names resolve to the exact same SetDisks namespace.
+        opts.no_lock = matches!((fixed_set, target_set), (Some(fixed), Some(target)) if Arc::ptr_eq(fixed, &target));
+    }
+
     pub(crate) async fn acquire_decommission_source_cleanup_fence(
         &self,
         bucket: &str,
@@ -2324,14 +2343,16 @@ impl ECStore {
         object: &str,
         data: &mut PutObjReader,
         opts: &ObjectOptions,
+        mutation_fence: Option<&ObjectLockDiagGuard>,
     ) -> Result<(usize, Result<ObjectInfo>)> {
         if !opts.data_movement {
             return Err(Error::other("data movement PUT requires data_movement options"));
         }
-        let (object, opts) = self.prepare_put_object(bucket, object, opts).await?;
+        let (object, mut opts) = self.prepare_put_object(bucket, object, opts).await?;
         let idx = self
             .select_put_object_pool_idx(bucket, object.as_str(), data.size(), &opts)
             .await?;
+        self.apply_decommission_target_mutation_fence(idx, object.as_str(), &mut opts, mutation_fence);
         let result = self.pools[idx]
             .put_object_with_old_current_size(bucket, &object, data, &opts)
             .await

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -393,6 +393,14 @@ impl ObjectLockDiagGuard {
     pub(crate) fn is_lock_lost(&self) -> bool {
         self.guard.is_lock_lost()
     }
+
+    pub(crate) fn add_namespace_lock_fence(&self, opts: &mut ObjectOptions) {
+        opts.no_lock = true;
+        opts.ensure_namespace_lock_fence();
+        if let Some(signal) = self.lock_lost_signal() {
+            opts.add_namespace_lock_lost_signal(signal);
+        }
+    }
 }
 
 /// Opaque write-lock guard for the RestoreObject accept path; see
@@ -410,10 +418,7 @@ impl RestoreAcceptGuard {
     }
 
     pub fn add_namespace_lock_fence(&self, opts: &mut ObjectOptions) {
-        opts.ensure_namespace_lock_fence();
-        if let Some(signal) = self.0.lock_lost_signal() {
-            opts.add_namespace_lock_lost_signal(signal);
-        }
+        self.0.add_namespace_lock_fence(opts);
     }
 }
 
@@ -911,6 +916,16 @@ fn writer_pool_lookup_opts(opts: &ObjectOptions, no_lock: bool) -> ObjectOptions
     lookup_opts.skip_rebalancing = true;
 
     lookup_opts
+}
+
+fn delete_pool_lookup_opts(opts: &ObjectOptions, no_lock: bool) -> ObjectOptions {
+    let mut lookup_opts = writer_pool_lookup_opts(opts, no_lock);
+    lookup_opts.skip_decommissioned = opts.data_movement;
+    lookup_opts
+}
+
+fn should_delete_from_all_pools(opts: &ObjectOptions, pool_count: usize) -> bool {
+    pool_count > 0 && (!opts.versioned && !opts.version_suspended || opts.version_id.is_some())
 }
 
 fn transition_restore_pool_opts(opts: &ObjectOptions) -> ObjectOptions {
@@ -1539,6 +1554,22 @@ impl ECStore {
             owner,
             ObjectLockDiagMode::Read,
         )))
+    }
+
+    pub(crate) async fn acquire_decommission_object_mutation_fence(
+        &self,
+        bucket: &str,
+        object: &str,
+    ) -> Result<ObjectLockDiagGuard> {
+        if self.ctx.lock_manager().is_disabled() {
+            return Err(Error::other("decommission object migration requires namespace locking"));
+        }
+
+        let object = encode_dir_object(object);
+        let mut opts = ObjectOptions::default();
+        self.acquire_object_read_lock_if_needed("decommission_object", bucket, &object, &mut opts)
+            .await?
+            .ok_or_else(|| Error::other("decommission object migration failed to acquire its namespace fence"))
     }
 
     pub(crate) async fn acquire_all_object_read_locks(
@@ -2503,7 +2534,7 @@ impl ECStore {
             return Ok(ObjectInfo::default());
         }
 
-        let gopts = writer_pool_lookup_opts(&opts, true);
+        let gopts = delete_pool_lookup_opts(&opts, true);
 
         if opts.data_movement {
             let existing_pool_info = self.get_pool_info_existing_with_opts(bucket, object, &gopts).await;
@@ -2646,7 +2677,7 @@ impl ECStore {
             None
         };
 
-        if !errs.is_empty() && !opts.versioned && !opts.version_suspended {
+        if should_delete_from_all_pools(&opts, errs.len()) {
             let mut obj = match self.delete_object_from_all_pools(bucket, object, &opts, errs).await {
                 Ok(obj) => obj,
                 Err(err) => {
@@ -2664,7 +2695,7 @@ impl ECStore {
         }
 
         for pool in self.pools.iter() {
-            if self.is_suspended(pool.pool_idx).await || self.is_pool_rebalancing(pool.pool_idx).await {
+            if self.is_pool_rebalancing(pool.pool_idx).await {
                 continue;
             }
 
@@ -4474,6 +4505,36 @@ mod tests {
         assert!(lookup_opts.skip_decommissioned);
         assert!(lookup_opts.skip_rebalancing);
         assert_eq!(lookup_opts.version_id.as_deref(), Some("vid-1"));
+    }
+
+    #[test]
+    fn ordinary_delete_lookup_includes_decommission_source_and_skips_rebalance_source() {
+        let lookup_opts = delete_pool_lookup_opts(&ObjectOptions::default(), true);
+
+        assert!(lookup_opts.no_lock);
+        assert!(!lookup_opts.skip_decommissioned);
+        assert!(lookup_opts.skip_rebalancing);
+    }
+
+    #[test]
+    fn delete_fans_out_for_unversioned_and_explicit_version_mutations() {
+        assert!(should_delete_from_all_pools(&ObjectOptions::default(), 1));
+        assert!(should_delete_from_all_pools(
+            &ObjectOptions {
+                versioned: true,
+                version_id: Some(uuid::Uuid::new_v4().to_string()),
+                ..Default::default()
+            },
+            2,
+        ));
+        assert!(!should_delete_from_all_pools(
+            &ObjectOptions {
+                versioned: true,
+                ..Default::default()
+            },
+            1,
+        ));
+        assert!(!should_delete_from_all_pools(&ObjectOptions::default(), 0));
     }
 
     #[test]

--- a/crates/ecstore/src/store/rebalance/support.rs
+++ b/crates/ecstore/src/store/rebalance/support.rs
@@ -73,7 +73,7 @@ pub(super) fn resolve_rebalance_delete_from_all_pools_result(
     object: &str,
 ) -> Result<ObjectInfo> {
     result.map_err(|err| {
-        if err == Error::PreconditionFailed {
+        if matches!(&err, Error::PreconditionFailed | Error::PrefixAccessDenied(_, _)) {
             err
         } else {
             Error::other(format!("failed to delete rebalance source object {bucket}/{object}: {err}"))
@@ -86,7 +86,7 @@ fn is_ignorable_rebalance_delete_error(err: &Error) -> bool {
 }
 
 fn rebalance_delete_pool_error(pool_idx: usize, bucket: &str, object: &str, err: Error) -> Error {
-    if err == Error::PreconditionFailed {
+    if matches!(&err, Error::PreconditionFailed | Error::PrefixAccessDenied(_, _)) {
         err
     } else {
         Error::other(format!("pool {pool_idx} delete failed for {bucket}/{object}: {err}"))
@@ -192,6 +192,18 @@ mod tests {
     }
 
     #[test]
+    fn rebalance_delete_result_preserves_prefix_access_denied() {
+        let err = resolve_rebalance_delete_from_all_pools_result(
+            Err(Error::PrefixAccessDenied("bucket".to_owned(), "object".to_owned())),
+            "bucket",
+            "object",
+        )
+        .expect_err("prefix access denial should remain structured");
+
+        assert_eq!(err, Error::PrefixAccessDenied("bucket".to_owned(), "object".to_owned()));
+    }
+
+    #[test]
     fn rebalance_delete_pool_result_preserves_precondition_failed() {
         let err = resolve_rebalance_delete_from_all_pools_results(
             vec![RebalanceDeletePoolResult {
@@ -204,5 +216,20 @@ mod tests {
         .expect_err("precondition failure should remain structured");
 
         assert_eq!(err, Error::PreconditionFailed);
+    }
+
+    #[test]
+    fn rebalance_delete_pool_result_preserves_prefix_access_denied() {
+        let err = resolve_rebalance_delete_from_all_pools_results(
+            vec![RebalanceDeletePoolResult {
+                pool_idx: 0,
+                result: Err(Error::PrefixAccessDenied("bucket".to_owned(), "object".to_owned())),
+            }],
+            "bucket",
+            "object",
+        )
+        .expect_err("prefix access denial should remain structured");
+
+        assert_eq!(err, Error::PrefixAccessDenied("bucket".to_owned(), "object".to_owned()));
     }
 }


### PR DESCRIPTION
## Related Issues

Closes rustfs/backlog#1910.

## Summary of Changes

- Fence decommission PUT, multipart, delete, and source-cleanup commits against namespace-lock loss.
- Preserve versioned and suspended delete-marker semantics while routing batch deletes away from decommission sources.
- Retain source-set locks through cleanup preflight and preserve per-pool batch delete errors.
- Add focused race, lock-domain, delete-marker, and error-aggregation regression coverage.

## Verification

- `cargo fmt --all --check`
- `make clippy-check`
- `cargo nextest run -p rustfs-ecstore -E '<12 focused decommission fence and delete-marker tests>'` — 12 passed
- Correctness and test-coverage adversary — APPROVE, no blocking findings
- Simplicity adversary — APPROVE, no blocking findings

## Impact

Decommission now fails closed when its mutation fence is lost and no longer removes valid delete markers or hides source-pool delete errors. No public API or persisted-format changes.

## Additional Notes

Draft while the full workspace test phase completes in CI. Local `make pre-pr` passed formatting, repository guard scripts, script tests, and Clippy; its full workspace test phase was stopped at the disk-safety threshold after the focused tests had passed.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
