### PR TITLE
ci: let feature validation jobs finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,7 +400,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.action != 'closed'
     needs: [ quick-checks ]
     runs-on: sm-standard-4
-    timeout-minutes: 45
+    timeout-minutes: 90
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
@@ -440,7 +440,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.action != 'closed'
     needs: [ quick-checks ]
     runs-on: sm-standard-4
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
@@ -470,7 +470,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.action != 'closed'
     needs: [ quick-checks ]
     runs-on: sm-standard-4
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       # On a PR, one failing protocol leg is enough to know the PR is not ready,
       # so stop the sibling leg instead of paying another ~40 minutes for it.


### PR DESCRIPTION
## Related Issues

rustfs/backlog#1897

## Summary of Changes

- Raise the ILM serial validation timeout from 45 to 90 minutes.
- Raise the rio-v2 and protocol feature validation timeouts from 60 to 90 minutes.
- Keep every job bounded while allowing cold-cache test builds to reach actual test execution.

## Verification

- `actionlint .github/workflows/ci.yml`
- `scripts/security/check_job_timeouts.sh`
- `cargo fmt --all --check`
- `git diff --check`

## Impact

No runtime or product behavior changes. Cold-cache CI jobs may occupy a runner for up to 90 minutes instead of being canceled after spending the previous budget compiling test binaries.

## Additional Notes

[ILM serial validation](https://github.com/rustfs/rustfs/actions/runs/32543162194/job/96957009462) was canceled after 47 minutes before any test completed. [Swift feature validation](https://github.com/rustfs/rustfs/actions/runs/32543162194/job/96957009425) also reached its test step after Clippy passed, then was canceled by the 60-minute budget. A warm-cache main run completed the same ILM, protocol, and rio-v2 jobs within 51 minutes, so 90 minutes preserves a finite watchdog while covering the observed cold-cache cost.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
