### PR TITLE
fix(rpc): bound internode concurrency under multipart load

### DIFF
--- a/crates/protos/src/lib.rs
+++ b/crates/protos/src/lib.rs
@@ -2106,6 +2106,9 @@ pub enum ChannelClass {
     Bulk,
 }
 
+// Keep multiplexed unary RPCs below h2's per-connection small-frame budget.
+const INTERNODE_RPC_CONCURRENCY_LIMIT: usize = 64;
+
 /// Whether control/bulk channel isolation is enabled (env-gated, default off for safe rollout).
 fn channel_isolation_enabled() -> bool {
     rustfs_utils::get_env_bool(
@@ -2188,6 +2191,7 @@ async fn build_channel(dial_addr: &str, cache_key: &str) -> Result<Channel, Box<
     let mut connector = Endpoint::from_shared(dial_addr.to_string())?
         // Fast connection timeout for dead peer detection
         .connect_timeout(connect_timeout)
+        .concurrency_limit(INTERNODE_RPC_CONCURRENCY_LIMIT)
         // TCP-level keepalive - OS will probe connection
         .tcp_keepalive(Some(tcp_keepalive))
         // Disable Nagle so latency-sensitive control-plane RPCs (locks/health) are not batched


### PR DESCRIPTION
## Related Issues

Fixes #6350

## Summary of Changes

Limit each cached internode gRPC channel to 64 active requests. Excess RPCs now wait in the existing channel buffer instead of exhausting h2's per-connection small-DATA-frame budget and tearing down unrelated lock and disk RPCs during highly concurrent multipart uploads.

The failure first appears with the dependency refresh at `84bd76a3`, which moved h2 from 0.4.15 to 0.4.16. The quorum path itself is unchanged; the reported write-quorum error is downstream of the shared RPC connection closing under load.

## Verification

- `cargo fmt --all --check`
- `cargo zigbuild -p rustfs-protos --release --target aarch64-unknown-linux-musl --locked`
- `cargo zigbuild -p rustfs --release --target aarch64-unknown-linux-musl --locked`
- 3-node × 4-disk cluster, 8 concurrent 200 MiB multipart uploads, 16 part workers: rc.2 `8/8`, rc.3 `0/8`, pre-fix main `0/8`, patched main `8/8` twice

## Impact

Internode RPCs above 64 active requests per channel are queued. There are no S3 API, configuration, authentication, or wire-format changes.

## Additional Notes

- Correctness: exercised the original 128-part-worker pressure case twice; all uploads completed and no quorum errors surfaced.
- Simplicity: one shared channel limit covers control and optional bulk channels without changing quorum or multipart code.
- Security: authentication, request signing, deserialization, and secrets are untouched.
- Concurrency/durability: the Tower limit queues at channel readiness; it does not drop requests or alter commit ordering.
- Compatibility: the gRPC protocol and cached-channel keys are unchanged.
- Performance: the repeated patched run averaged 25.8 seconds per upload versus 27.9 seconds on rc.2 in the same setup.
- Test coverage: removing the limit reproduces the pre-fix `0/8`; the patched build completed `8/8` in both fresh-cluster runs.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
