### PR TITLE
fix(admin): expose per-target disableProxy through remote target admin API

### DIFF
--- a/crates/ecstore/src/bucket/bucket_target_sys.rs
+++ b/crates/ecstore/src/bucket/bucket_target_sys.rs
@@ -3425,6 +3425,44 @@ mod tests {
         assert!(mutexes.contains_key("second"));
     }
 
+    #[tokio::test]
+    async fn update_all_targets_publishes_disable_proxy_on_target_client() {
+        // The read-proxy selector (replication_proxy::get_proxy_targets) skips
+        // targets whose TargetClient carries disable_proxy — the persisted
+        // per-target opt-out must survive client publication.
+        let sys = BucketTargetSys::default();
+        let target = |arn: &str, disable_proxy: bool| BucketTarget {
+            arn: arn.to_string(),
+            endpoint: "192.168.1.10:9000".to_string(),
+            target_bucket: "target-bucket".to_string(),
+            region: "us-east-1".to_string(),
+            disable_proxy,
+            credentials: Some(Credentials {
+                access_key: "access".to_string(),
+                secret_key: "secret".to_string(),
+                session_token: None,
+                expiration: None,
+            }),
+            ..Default::default()
+        };
+        let targets = BucketTargets {
+            targets: vec![target("arn:proxied", false), target("arn:opted-out", true)],
+        };
+
+        sys.update_all_targets("bucket", Some(&targets)).await;
+
+        let proxied = sys
+            .get_remote_target_client("bucket", "arn:proxied")
+            .await
+            .expect("client should be published");
+        assert!(!proxied.disable_proxy);
+        let opted_out = sys
+            .get_remote_target_client("bucket", "arn:opted-out")
+            .await
+            .expect("client should be published");
+        assert!(opted_out.disable_proxy, "disable_proxy must reach the published TargetClient");
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn target_updates_serialize_client_build_through_publication_per_bucket() {
         let sys = Arc::new(BucketTargetSys::default());

--- a/crates/replication/src/config.rs
+++ b/crates/replication/src/config.rs
@@ -60,7 +60,9 @@ pub const REPLICATION_READ_ONLY_HISTORICAL_FIELDS: &[&str] = &[
     "Destination.ReplicationTime",
 ];
 
-pub const REMOTE_TARGET_CAPABILITY_CONTRACT_VERSION: u32 = 1;
+// v2: disableProxy moved from unsupported to writable (per-target read-proxy
+// opt-out is accepted by set-remote-target and the `proxy` update op).
+pub const REMOTE_TARGET_CAPABILITY_CONTRACT_VERSION: u32 = 2;
 
 pub const REMOTE_TARGET_WRITABLE_FIELDS: &[&str] = &[
     "sourcebucket",
@@ -83,9 +85,12 @@ pub const REMOTE_TARGET_WRITABLE_FIELDS: &[&str] = &[
     // madmin default of 60s); the per-target health-check interval is not
     // yet applied — the heartbeat keeps its global env-configured interval.
     "healthCheckDuration",
+    // Per-target read-proxy opt-out, consumed by the proxy-target selector
+    // (contract v2; previously only importable via MinIO bucket-targets.json).
+    "disableProxy",
 ];
 
-pub const REMOTE_TARGET_UNSUPPORTED_FIELDS: &[&str] = &["disableProxy", "edge", "edgeSyncBeforeExpiry"];
+pub const REMOTE_TARGET_UNSUPPORTED_FIELDS: &[&str] = &["edge", "edgeSyncBeforeExpiry"];
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ObjectOpts {

--- a/rustfs/src/admin/handlers/replication.rs
+++ b/rustfs/src/admin/handlers/replication.rs
@@ -73,6 +73,8 @@ enum TargetUpdateOp {
     /// Connection group: credentials plus endpoint, target bucket, and TLS settings.
     Credentials,
     Sync,
+    /// Per-target read-proxy opt-out (`disableProxy`).
+    Proxy,
     Bandwidth,
     Path,
 }
@@ -81,12 +83,13 @@ fn parse_remote_target_update_ops(queries: &HashMap<String, String>) -> S3Result
     const SUPPORTED_OPS: &[(&str, TargetUpdateOp)] = &[
         ("creds", TargetUpdateOp::Credentials),
         ("sync", TargetUpdateOp::Sync),
+        ("proxy", TargetUpdateOp::Proxy),
         ("bandwidth", TargetUpdateOp::Bandwidth),
         ("path", TargetUpdateOp::Path),
     ];
     // Present in the MinIO wire contract, but they drive target fields this
     // version rejects as unsupported — fail loudly instead of silently ignoring.
-    const UNSUPPORTED_OPS: &[&str] = &["proxy", "healthcheck", "edge", "edgeSyncBeforeExpiry"];
+    const UNSUPPORTED_OPS: &[&str] = &["healthcheck", "edge", "edgeSyncBeforeExpiry"];
 
     for key in UNSUPPORTED_OPS {
         if queries.get(*key).is_some_and(|value| value == "true") {
@@ -312,11 +315,10 @@ impl RemoteTargetRequest {
             ));
         }
 
-        for (unsupported, configured) in
-            REMOTE_TARGET_UNSUPPORTED_FIELDS
-                .iter()
-                .copied()
-                .zip([self.disable_proxy, self.edge, self.edge_sync_before_expiry])
+        for (unsupported, configured) in REMOTE_TARGET_UNSUPPORTED_FIELDS
+            .iter()
+            .copied()
+            .zip([self.edge, self.edge_sync_before_expiry])
         {
             if configured {
                 return Err(s3_error!(
@@ -702,6 +704,7 @@ impl Operation for SetRemoteTargetHandler {
                         target.deployment_id = remote_target.deployment_id.clone();
                     }
                     TargetUpdateOp::Sync => target.replication_sync = remote_target.replication_sync,
+                    TargetUpdateOp::Proxy => target.disable_proxy = remote_target.disable_proxy,
                     TargetUpdateOp::Bandwidth => target.bandwidth_limit = remote_target.bandwidth_limit,
                     TargetUpdateOp::Path => target.path = remote_target.path.clone(),
                 }
@@ -1520,6 +1523,7 @@ mod tests {
             ("update", "true"),
             ("creds", "true"),
             ("sync", "true"),
+            ("proxy", "true"),
             ("bandwidth", "true"),
             ("path", "true"),
         ]))
@@ -1529,6 +1533,7 @@ mod tests {
             vec![
                 TargetUpdateOp::Credentials,
                 TargetUpdateOp::Sync,
+                TargetUpdateOp::Proxy,
                 TargetUpdateOp::Bandwidth,
                 TargetUpdateOp::Path
             ]
@@ -2070,7 +2075,6 @@ mod tests {
             ("credentials.session_token", serde_json::json!("session-token")),
             ("credentials.expiration", serde_json::json!("2026-01-01T00:00:00Z")),
             ("api", serde_json::json!("s3v2")),
-            ("disableProxy", serde_json::json!(true)),
             ("edge", serde_json::json!(true)),
             ("edgeSyncBeforeExpiry", serde_json::json!(true)),
         ] {
@@ -2298,6 +2302,44 @@ mod tests {
     fn remote_target_health_check_duration_is_declared_writable() {
         assert!(REMOTE_TARGET_WRITABLE_FIELDS.contains(&"healthCheckDuration"));
         assert!(!REMOTE_TARGET_UNSUPPORTED_FIELDS.contains(&"healthCheckDuration"));
+    }
+
+    #[test]
+    fn remote_target_disable_proxy_is_declared_writable_edge_stays_unsupported() {
+        assert!(REMOTE_TARGET_WRITABLE_FIELDS.contains(&"disableProxy"));
+        assert!(!REMOTE_TARGET_UNSUPPORTED_FIELDS.contains(&"disableProxy"));
+        // edge sync has no implementation behind it — it must stay rejected.
+        assert!(REMOTE_TARGET_UNSUPPORTED_FIELDS.contains(&"edge"));
+        assert!(REMOTE_TARGET_UNSUPPORTED_FIELDS.contains(&"edgeSyncBeforeExpiry"));
+    }
+
+    #[test]
+    fn remote_target_create_accepts_disable_proxy() {
+        let mut request = valid_remote_target_request();
+        request["disableProxy"] = serde_json::json!(true);
+
+        let target = serde_json::from_value::<RemoteTargetRequest>(request)
+            .expect("request should deserialize")
+            .into_bucket_target()
+            .expect("disableProxy is a supported per-target read-proxy opt-out");
+
+        assert!(target.disable_proxy);
+    }
+
+    #[test]
+    fn update_body_with_proxy_op_toggles_disable_proxy_without_credentials() {
+        // Mirrors the other partial-update groups: a proxy-only update body may
+        // omit the connection fields entirely.
+        let body = serde_json::json!({
+            "arn": "arn:rustfs:replication:us-east-1:dep:target",
+            "type": "replication",
+            "disableProxy": true
+        });
+        let request: RemoteTargetRequest = serde_json::from_value(body).expect("partial update body should deserialize");
+        let target = request
+            .into_update_bucket_target(&[TargetUpdateOp::Proxy])
+            .expect("proxy-only update must not require credentials");
+        assert!(target.disable_proxy);
     }
 
     #[test]

--- a/rustfs/src/admin/handlers/system.rs
+++ b/rustfs/src/admin/handlers/system.rs
@@ -1262,7 +1262,9 @@ mod tests {
         assert_eq!(response.summary.manual_transition_jobs.state, CapabilityState::Supported);
         assert_eq!(response.replication.contract_version, 1);
         assert_eq!(response.replication.bucket_replication.contract_version, 1);
-        assert_eq!(response.replication.remote_targets.contract_version, 1);
+        // v2: disableProxy moved from unsupported to writable (per-target
+        // read-proxy opt-out reached the admin API).
+        assert_eq!(response.replication.remote_targets.contract_version, 2);
         assert_eq!(response.replication.bucket_replication.status.state, CapabilityState::Supported);
         assert_eq!(response.replication.remote_targets.status.state, CapabilityState::Supported);
         assert_eq!(
@@ -1293,7 +1295,15 @@ mod tests {
                 .remote_targets
                 .fields
                 .iter()
-                .any(|field| field.name == "disableProxy" && field.state == super::ReplicationFieldState::Unsupported)
+                .any(|field| field.name == "disableProxy" && field.state == super::ReplicationFieldState::Supported)
+        );
+        assert!(
+            response
+                .replication
+                .remote_targets
+                .fields
+                .iter()
+                .any(|field| field.name == "edge" && field.state == super::ReplicationFieldState::Unsupported)
         );
         assert!(
             response
@@ -1364,7 +1374,7 @@ mod tests {
         assert_eq!(value["summary"]["manual_transition_jobs"]["state"], "supported");
         assert_eq!(value["replication"]["contract_version"], 1);
         assert_eq!(value["replication"]["bucket_replication"]["contract_version"], 1);
-        assert_eq!(value["replication"]["remote_targets"]["contract_version"], 1);
+        assert_eq!(value["replication"]["remote_targets"]["contract_version"], 2);
         assert_eq!(value["replication"]["bucket_replication"]["status"]["state"], "supported");
         assert_eq!(value["replication"]["remote_targets"]["status"]["state"], "supported");
         assert_eq!(
@@ -1383,7 +1393,14 @@ mod tests {
                 .as_array()
                 .expect("remote target fields should be an array")
                 .iter()
-                .any(|field| field["name"] == "disableProxy" && field["state"] == "unsupported")
+                .any(|field| field["name"] == "disableProxy" && field["state"] == "supported")
+        );
+        assert!(
+            value["replication"]["remote_targets"]["fields"]
+                .as_array()
+                .expect("remote target fields should be an array")
+                .iter()
+                .any(|field| field["name"] == "edge" && field["state"] == "unsupported")
         );
         assert!(
             value["replication"]["remote_targets"]["fields"]


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#1950 (B5-rc T3, audit item A2/P2-10; spec rustfs/backlog#1946, parent rustfs/backlog#1675). Inconsistency disclosed in #6170.

## Summary of Changes

#6172 (P1-5) wired the read-proxy consumer for `disable_proxy`: `get_proxy_targets` skips targets whose `TargetClient` carries the flag, and the field is persisted/loaded via bucket-targets.json. But the admin API still rejected it: `REMOTE_TARGET_UNSUPPORTED_FIELDS` listed `disableProxy`, and the update path rejected the `proxy` op. The per-target read-proxy opt-out therefore worked in code but did not exist on the API — the only way to enable it was importing a MinIO-written bucket-targets.json.

- Move `disableProxy` from `REMOTE_TARGET_UNSUPPORTED_FIELDS` to `REMOTE_TARGET_WRITABLE_FIELDS`; `set-remote-target` (create) now accepts it.
- Add `TargetUpdateOp::Proxy`: `set-remote-target?update=true&proxy=true` overlays only the proxy group onto the stored target (MinIO `TargetUpdateType` parity, same per-group overlay mechanism as #5715); a proxy-only update body may omit credentials like the other non-creds groups.
- Bump `REMOTE_TARGET_CAPABILITY_CONTRACT_VERSION` 1 → 2; the runtime-capabilities endpoint now reports `disableProxy` as supported under `remote_targets`.
- `edge` / `edgeSyncBeforeExpiry` (fields and update ops) remain rejected — nothing implements them.
- New regression test pins that a published `TargetClient` carries `disable_proxy`, the field the proxy-target selector consults.

## Verification

- TDD: compile-level red for `TargetUpdateOp::Proxy`; assertion-level red on the contract-version pin before the bump (55 passed / 1 failed — the pin), then green.
- `cargo nextest run -p rustfs --lib -E 'test(/admin::handlers::(replication|system)::tests/)'` — 56/56
- `cargo nextest run -p rustfs-ecstore` proxy/target tests — 5/5 (incl. new `update_all_targets_publishes_disable_proxy_on_target_client`)
- `cargo test -p rustfs-replication` — all green
- `cargo fmt --all`; `make pre-commit`
- Note: under same-process `cargo test`, two pre-existing topology tests (`runtime_capabilities_response_reports_missing_topology_before_storage_init`, `server_info_response_carries_pool_topology`) share global state and can interfere; reproduced on the unmodified baseline, not under nextest process isolation. Unrelated to this change and left alone (rc scope discipline).

## Impact

Admin API: `disableProxy` becomes writable on create and via the new `proxy` update op. Capability contract version 1 → 2.

Mixed-version / rolling-upgrade behavior (the remote-target capability contract is version-locked on the client side; declared policy is `fail_closed_when_capability_unknown_or_unsupported`):

- **Old node (contract v1) receiving the new field/op**: rejected with `InvalidRequest` ("not supported by this RustFS version") — fail-closed, no silent drop. In a mixed cluster a client can see the toggle succeed or fail depending on which node serves the admin call; clients honoring the capability contract will not offer the toggle against a v1 node.
- **New node reading old metadata**: `disableProxy` has always been part of the persisted bucket-targets format (defaults to false); no migration.
- **Flag set on a new node, read by an old node**: nodes at ≥ #6172 honor `disable_proxy` in the read-proxy selector; nodes older than #6172 ignore the flag and keep proxying reads to that target until upgraded (same degradation shape as the P1-7 disclosure).

## Additional Notes

N/A
