### PR TITLE
fix(ecstore): keep unknown-size sentinel in create_bitrot_writer

### DIFF
--- a/crates/ecstore/src/io_support/bitrot.rs
+++ b/crates/ecstore/src/io_support/bitrot.rs
@@ -784,6 +784,24 @@ pub(crate) fn create_deferred_bitrot_reader_with_stripe_handle(
 ///
 /// # Returns
 /// A Result containing the BitrotWriterWrapper or an error
+/// Size hint handed to `DiskAPI::create_file` for a bitrot-wrapped shard.
+///
+/// A known length is grown by one checksum per shard so the on-disk file size
+/// matches what the bitrot writer emits. A negative length is the
+/// unknown-size sentinel (`HashReader::SIZE_PRESERVE_LAYER`, used by SSE and
+/// compression) and must be preserved: `RemoteDisk::create_file` forwards it
+/// in the `put_file_stream` query, and the receiver only treats `size > 0` as
+/// a fixed body length when locating the authenticated trailer. Clamping it
+/// to `0` would claim an empty body and misframe the stream. `0` stays `0`
+/// because a genuinely empty object still means an empty body.
+fn bitrot_create_file_size(length: i64, shard_size: usize, checksum_algo: &HashAlgorithm) -> i64 {
+    if length <= 0 {
+        return length;
+    }
+    let length = length as usize;
+    (length.div_ceil(shard_size) * checksum_algo.size() + length) as i64
+}
+
 pub async fn create_bitrot_writer(
     is_inline_buffer: bool,
     disk: Option<&DiskStore>,
@@ -796,12 +814,7 @@ pub async fn create_bitrot_writer(
     let writer = if is_inline_buffer {
         CustomWriter::new_inline_buffer()
     } else if let Some(disk) = disk {
-        let length = if length > 0 {
-            let length = length as usize;
-            (length.div_ceil(shard_size) * checksum_algo.size() + length) as i64
-        } else {
-            0
-        };
+        let length = bitrot_create_file_size(length, shard_size, &checksum_algo);
 
         let file = disk.create_file("", volume, path, length).await?;
         #[cfg(feature = "hotpath")]
@@ -819,6 +832,25 @@ mod tests {
     use super::*;
     use rustfs_rio::ChunkReader;
     use std::collections::VecDeque;
+
+    #[test]
+    fn bitrot_create_file_size_grows_known_length_by_checksums() {
+        // 10 bytes over 4-byte shards = 3 shards, each followed by a 32-byte hash.
+        assert_eq!(bitrot_create_file_size(10, 4, &HashAlgorithm::HighwayHash256), 10 + 3 * 32);
+        assert_eq!(bitrot_create_file_size(10, 4, &HashAlgorithm::None), 10);
+    }
+
+    #[test]
+    fn bitrot_create_file_size_keeps_empty_and_unknown_distinct() {
+        assert_eq!(bitrot_create_file_size(0, 4, &HashAlgorithm::HighwayHash256), 0);
+        // SSE/compression streams advertise SIZE_PRESERVE_LAYER (-1); the remote
+        // put_file_stream receiver relies on a non-positive size to parse the auth
+        // trailer from the stream tail, so the sentinel must survive untouched.
+        assert_eq!(
+            bitrot_create_file_size(rustfs_rio::HashReader::SIZE_PRESERVE_LAYER, 4, &HashAlgorithm::HighwayHash256),
+            rustfs_rio::HashReader::SIZE_PRESERVE_LAYER
+        );
+    }
 
     struct TestChunkReader {
         chunks: VecDeque<Bytes>,


### PR DESCRIPTION
## Related Issues
Refs #6331

## Summary of Changes
- `create_bitrot_writer` clamped the unknown-length sentinel (`HashReader::SIZE_PRESERVE_LAYER`, `-1`) to `0` before calling `DiskAPI::create_file`. SSE and compression streams carry that sentinel, `Erasure::shard_file_size` preserves it, and `RemoteDisk::create_file` forwards the value verbatim into the `put_file_stream` query, so remote peers were told an SSE body was empty.
- With the authenticated put-file trailer (#5868) the receiver split body from trailer by the declared size, which made the clamp fatal (`put_file auth trailer has trailing data`) for every SSE PUT on multi-node rc.2 deployments. #6320 already relaxed the receiver to trust only `size > 0`; this PR fixes the sender so the sentinel survives end to end and the wire no longer conflates "empty object" with "unknown length".
- Extracts the size-hint computation into `bitrot_create_file_size` with a doc comment explaining why negatives must pass through, and adds unit tests for known, empty, and unknown lengths. `LocalDisk::open_write` already treats non-positive hints as "no hint" (`size_hint.max(0)`, `should_reclaim_file_cache_after_write` returns false for `<= 0`), and the receiver's `put_body_size_mismatch` only checks `size > 0`, so `-1` is safe on both disk kinds.

## Verification
- `cargo fmt --all`
- `cargo test -p rustfs-ecstore --lib bitrot_create_file_size` (2 passed)
- `cargo clippy -p rustfs-ecstore --all-targets -- -D warnings`

## Impact
- Internode `put_file_stream` requests for SSE/compressed shards now advertise `size=-1` instead of `size=0`. Receivers at rc.2 treat `size < 0` as unknown length (the `else` branch already existed before #6320), so mixed-version rolling upgrades are unaffected; receivers at rc.3+ handle both values identically.
- Local disk writes are unchanged: the size hint was already ignored for non-positive values.

## Additional Notes
Defense in depth on top of #6320: the symptom reported in #6331 is already fixed in `1.0.0-rc.3` by the receiver-side change; this keeps the sentinel intact so a future "size == 0 means fixed length" assumption on the receiver cannot reintroduce the regression.
