### PR TITLE
ci(s3tests): stabilize HAProxy request handling

### DIFF
--- a/.github/workflows/e2e-s3tests.yml
+++ b/.github/workflows/e2e-s3tests.yml
@@ -90,6 +90,10 @@ on:
         description: "Optional pytest -m expression"
         required: false
         default: ""
+      testexpr:
+        description: "Optional pytest -k expression"
+        required: false
+        default: ""
   schedule:
     # Weekly full sweep (Sunday 02:00 UTC): full suite, run against BOTH the
     # single-node and the 4-node distributed topologies (matrix below).
@@ -116,6 +120,7 @@ env:
   XDIST: ${{ github.event.inputs.xdist || '4' }}
   MAXFAIL: ${{ github.event.inputs.maxfail || '0' }}
   MARKEXPR: ${{ github.event.inputs.markexpr || '' }}
+  TESTEXPR: ${{ github.event.inputs.testexpr || '' }}
   S3_SHARD_COUNT: ${{ github.event_name == 'schedule' && '4' || github.event.inputs.shard-count || '1' }}
   TEST_TIMEOUT: "300"
 
@@ -269,8 +274,13 @@ jobs:
           EOF
 
           cat > haproxy.cfg <<'EOF'
+          global
+            log stdout format raw local0 info
+
           defaults
             mode http
+            log global
+            option httplog
             timeout connect 5s
             timeout client  30s
             timeout server  30s
@@ -314,6 +324,7 @@ jobs:
           XDIST="${XDIST}" \
           MAXFAIL="${MAXFAIL}" \
           MARKEXPR="${MARKEXPR}" \
+          TESTEXPR="${TESTEXPR}" \
           ./scripts/s3-tests/run.sh
 
       - name: Publish compatibility report

--- a/.github/workflows/e2e-s3tests.yml
+++ b/.github/workflows/e2e-s3tests.yml
@@ -287,6 +287,7 @@ jobs:
 
           frontend fe_s3
             bind *:9000
+            option http-buffer-request
             default_backend be_s3
 
           backend be_s3

--- a/.github/workflows/e2e-s3tests.yml
+++ b/.github/workflows/e2e-s3tests.yml
@@ -280,7 +280,7 @@ jobs:
           defaults
             mode http
             log global
-            option httplog
+            log-format '%ci:%cp [%tr] %ft %b/%s %TR/%Tw/%Tc/%Tr/%Ta %ST %B %tsc %HM %HP'
             timeout connect 5s
             timeout client  30s
             timeout server  30s


### PR DESCRIPTION
## Related Issues

rustfs/backlog#1897

## Summary of Changes

- expose the existing `TESTEXPR` pytest filter through manual S3 compatibility runs so one failing case can be reproduced directly
- record HAProxy status, selected backend, timing, termination state, method, and path in multi-node artifacts
- omit query strings from proxy logs so presigned request signatures are not persisted
- buffer request bodies in the CI HAProxy before forwarding them to RustFS

## Verification

- `actionlint .github/workflows/e2e-s3tests.yml`
- `cargo fmt --all --check`
- `git diff --check`
- HAProxy 2.9 configuration validation
- local HAProxy 2.9 protocol reproduction: an `Expect: 100-continue` PUT rejected before body consumption produced `PR-- <BADREQ>` on the next keep-alive request without buffering, while `option http-buffer-request` preserved both responses
- exact-head multi-node run https://github.com/rustfs/rustfs/actions/runs/32571041959 passed `test_bucket_policy_put_obj_s3_noenc`; JUnit recorded 1 test, 0 failures, and 0 errors

## Impact

Scheduled and default test selection are unchanged. Manual runs may select an exact pytest expression, and multi-node failure artifacts gain proxy-boundary evidence without request headers, bodies, or query strings. The CI proxy now receives each small request body before forwarding it, preventing an early backend rejection from leaving the frontend parser waiting for body bytes.

## Additional Notes

The first targeted run at https://github.com/rustfs/rustfs/actions/runs/32568823358 proved the blank S3 error never reached a RustFS backend: the expected 403 was immediately followed on the same client connection by HAProxy `PR-- <BADREQ>`. A minimal local HAProxy reproduction confirmed this was independent of RustFS.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
