### PR TITLE
ci(mint): pin manual image default

### DIFF
--- a/.github/workflows/mint.yml
+++ b/.github/workflows/mint.yml
@@ -45,13 +45,6 @@
 # docker-capable self-hosted `dind-sm-standard-2` label was the alternative but
 # has fewer cores and reintroduces fleet-state risk for no reliability gain.
 
-# DISABLED. This workflow is switched off in the repository's Actions settings
-# (state: disabled_manually) and does not run on any trigger, including its cron
-# and workflow_dispatch. That state lives in GitHub's UI and is invisible when
-# reading this file, which has already misled at least one audit — hence this
-# banner. Re-enabling is a UI action; anyone doing so should first check that the
-# workflow still matches the current CI layout. See rustfs/backlog#1603.
-#
 name: mint
 
 on:
@@ -70,9 +63,9 @@ on:
           - core
           - full
       mint-image:
-        description: "Mint image reference"
+        description: "Mint image reference (empty = pinned default)"
         required: false
-        default: "minio/mint:edge"
+        default: ""
   schedule:
     # Weekly, after the Sunday s3-tests full sweep (starts 02:00 UTC, up to
     # 3h) has finished, so the two never contend for the same runner pool.


### PR DESCRIPTION
## Related Issues

rustfs/backlog#1897

## Summary of Changes

- make an empty manual Mint image input select the existing digest-pinned default
- remove the stale disabled-workflow banner after restoring the workflow in GitHub Actions

## Verification

- `actionlint .github/workflows/mint.yml`
- `cargo fmt --all --check`
- `git diff --check`
- exact-head manual run: https://github.com/rustfs/rustfs/actions/runs/32573410869
- pinned image `minio/mint:edge@sha256:08a05e68893c68be2a83b6f79556853ed6aa3c6c9e64c823a00853e4e55d2200`
- AWS CLI core report: 18 passed, 0 failed, 0 errors

## Impact

Scheduled behavior is unchanged. Manual runs now use the same reproducible Mint image as scheduled runs unless an operator explicitly supplies another image reference.

## Additional Notes

The initial restored main smoke is https://github.com/rustfs/rustfs/actions/runs/32571267019. The exact-head run above verified that an empty manual input selects the pinned fallback and produces a non-empty report; this PR does not broaden the current AWS CLI core suite.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
