### PR TITLE
fix(ecstore): migrate tier free versions during decommission

### DIFF
--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use crate::bucket::replication::replication_state_from_filemeta;
+#[cfg(test)]
+use crate::bucket::utils::is_meta_bucketname;
 use crate::bucket::versioning_sys::BucketVersioningSys;
 use crate::bucket::{
     lifecycle::{
@@ -967,6 +969,7 @@ fn with_decommission_entry_context<E: Display>(stage: &str, bucket: &str, object
     Error::other(format!("decommission entry {stage} failed for bucket {bucket} object {object}: {err}"))
 }
 
+#[cfg(test)]
 fn load_decommission_entry_versions(entry: &MetaCacheEntry, bucket: &str, stage: &str) -> Result<FileInfoVersions> {
     entry
         .file_info_versions(bucket)
@@ -1935,6 +1938,53 @@ async fn run_decommission_cleanup_mutation_hook(bucket: &str, object: &str, atte
         .clone();
     if let Some(hook) = hook {
         hook(bucket, object, attempt).await;
+    }
+}
+
+const DECOMMISSION_FREE_VERSION_MIGRATED_REASON: &str = "tier_free_version_migrated";
+const DECOMMISSION_FREE_VERSION_CONSUMED_REASON: &str = "tier_free_version_already_consumed";
+const DECOMMISSION_FREE_VERSION_RETAINED_REASON: &str = "tier_free_version_migration_failed";
+const DECOMMISSION_FREE_VERSION_SWEEP_REASON: &str = "tier_free_version_unresolved_after_decommission";
+const DECOMMISSION_FREE_VERSION_DISPOSITION_REASON: &str = "tier_free_version_disposition_recorded";
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct DecommissionFreeVersionDisposition {
+    migrated: usize,
+    consumed: usize,
+    retained: usize,
+}
+
+impl DecommissionFreeVersionDisposition {
+    fn record_migrated(&mut self) {
+        self.migrated += 1;
+    }
+
+    fn record_consumed(&mut self) {
+        self.consumed += 1;
+    }
+
+    fn record_retained(&mut self) {
+        self.retained += 1;
+    }
+
+    fn total(self) -> usize {
+        self.migrated.saturating_add(self.consumed).saturating_add(self.retained)
+    }
+}
+
+enum DecommissionFreeVersionAttempt {
+    Migrated,
+    Consumed,
+    CapacityFailure(Error),
+    Retry(Error),
+}
+
+fn classify_decommission_free_version_attempt(result: Result<()>) -> DecommissionFreeVersionAttempt {
+    match result {
+        Ok(()) => DecommissionFreeVersionAttempt::Migrated,
+        Err(err) if is_decommission_copy_cleanup_safe_error(&err) => DecommissionFreeVersionAttempt::Consumed,
+        Err(err) if is_decommission_target_capacity_error(&err) => DecommissionFreeVersionAttempt::CapacityFailure(err),
+        Err(err) => DecommissionFreeVersionAttempt::Retry(err),
     }
 }
 
@@ -3414,8 +3464,12 @@ fn determine_decommission_final_state(items_failed: usize, was_cancelled: bool) 
     }
 }
 
-fn decommission_remaining_version_count(total_versions: usize, expired: usize) -> usize {
-    total_versions.saturating_sub(expired)
+fn decommission_remaining_version_count(versions: &[rustfs_filemeta::FileInfo], expired: usize) -> usize {
+    versions
+        .iter()
+        .filter(|version| !version.tier_free_version())
+        .count()
+        .saturating_sub(expired)
 }
 
 fn should_skip_decommission_delete_marker(
@@ -3478,6 +3532,7 @@ fn decommission_remote_tiered_opts(
         user_defined: version.metadata.clone(),
         src_pool_idx,
         data_movement: true,
+        incl_free_versions: version.tier_free_version(),
         include_part_checksums: true,
         http_preconditions: Some(data_movement::data_movement_target_precondition()),
         expected_bucket_incarnation_id,
@@ -4848,6 +4903,7 @@ impl ECStore {
 
         let mut decommissioned: usize = 0;
         let mut expired: usize = 0;
+        let mut free_version_disposition = DecommissionFreeVersionDisposition::default();
         let mut cleanup_preflight_allowed_missing = Vec::new();
         let mut entry_blocked = false;
 
@@ -4856,6 +4912,115 @@ impl ECStore {
                 rx.cancel();
             }
             decommission_cancel_signal_result(rx.is_cancelled())?;
+
+            if version.tier_free_version() {
+                let version_id = version.version_id.map(|v| v.to_string());
+                let mut migration_error = None;
+                let mut migrated = false;
+                let mut consumed = false;
+                let mut capacity_failure = false;
+                for _ in 0..3 {
+                    match classify_decommission_free_version_attempt(
+                        run_decommission_side_effect(&rx, &operation_gate, || async {
+                            self.decommission_tiered_object(
+                                bucket.as_str(),
+                                &version.name,
+                                version,
+                                &decommission_remote_tiered_opts(
+                                    version,
+                                    version_id.clone(),
+                                    idx,
+                                    expected_bucket_incarnation_id,
+                                ),
+                            )
+                            .await
+                        })
+                        .await,
+                    ) {
+                        DecommissionFreeVersionAttempt::Migrated => {
+                            migrated = true;
+                            migration_error = None;
+                            break;
+                        }
+                        DecommissionFreeVersionAttempt::Consumed => {
+                            consumed = true;
+                            migration_error = None;
+                            break;
+                        }
+                        DecommissionFreeVersionAttempt::CapacityFailure(err) => {
+                            capacity_failure = true;
+                            migration_error = Some(err);
+                            break;
+                        }
+                        DecommissionFreeVersionAttempt::Retry(err) => migration_error = Some(err),
+                    }
+                }
+
+                if counted_versions.insert((version.version_id, version.deleted)) {
+                    let mut pool_meta = self.pool_meta.write().await;
+                    ensure_decommission_generation(&pool_meta, idx, generation)?;
+                    if let Err(err) = count_decommission_item(&mut pool_meta, idx, 0, !migrated && !consumed) {
+                        return Err(with_decommission_entry_context(
+                            "count_decommission_item",
+                            bucket.as_str(),
+                            entry.name.as_str(),
+                            err,
+                        ));
+                    }
+                }
+
+                if migrated || consumed {
+                    decommissioned += 1;
+                    cleanup_preflight_allowed_missing.push(data_movement::source_cleanup_version_identity(version));
+                }
+                if migrated {
+                    free_version_disposition.record_migrated();
+                } else if consumed {
+                    free_version_disposition.record_consumed();
+                } else {
+                    free_version_disposition.record_retained();
+                }
+
+                debug!(
+                    event = EVENT_DECOMMISSION_ENTRY,
+                    component = LOG_COMPONENT_ECSTORE,
+                    subsystem = LOG_SUBSYSTEM_POOLS,
+                    pool_index = idx,
+                    bucket = %bucket,
+                    object = %version.name,
+                    version_id = ?version_id,
+                    result = ?migration_error,
+                    reason = if migrated {
+                        DECOMMISSION_FREE_VERSION_MIGRATED_REASON
+                    } else if consumed {
+                        DECOMMISSION_FREE_VERSION_CONSUMED_REASON
+                    } else {
+                        DECOMMISSION_FREE_VERSION_RETAINED_REASON
+                    },
+                    state = if migrated {
+                        "free_version_migrated"
+                    } else if consumed {
+                        "free_version_consumed"
+                    } else {
+                        "free_version_retained"
+                    },
+                    "Decommission free-version disposition recorded"
+                );
+
+                if capacity_failure {
+                    return Err(with_decommission_entry_context(
+                        "decommission_tier_free_version",
+                        bucket.as_str(),
+                        version.name.as_str(),
+                        migration_error.expect("capacity failure must retain its error"),
+                    ));
+                }
+
+                if !migrated && !consumed {
+                    break;
+                }
+                continue;
+            }
 
             if run_decommission_side_effect(&rx, &operation_gate, || async {
                 should_skip_lifecycle_for_data_movement(
@@ -4877,7 +5042,7 @@ impl ECStore {
                 continue;
             }
 
-            let remaining_versions = decommission_remaining_version_count(fivs.versions.len(), expired);
+            let remaining_versions = decommission_remaining_version_count(&fivs.versions, expired);
             if should_skip_decommission_delete_marker(version, remaining_versions, replication_config.is_some()) {
                 //
                 decommissioned += 1;
@@ -5343,6 +5508,24 @@ impl ECStore {
             }
         }
 
+        if free_version_disposition.total() > 0 {
+            debug!(
+                event = EVENT_DECOMMISSION_ENTRY,
+                component = LOG_COMPONENT_ECSTORE,
+                subsystem = LOG_SUBSYSTEM_POOLS,
+                pool_index = idx,
+                bucket = %bucket,
+                object = %entry.name,
+                free_versions_migrated = free_version_disposition.migrated,
+                free_versions_consumed = free_version_disposition.consumed,
+                free_versions_retained = free_version_disposition.retained,
+                free_versions_total = free_version_disposition.total(),
+                reason = DECOMMISSION_FREE_VERSION_DISPOSITION_REASON,
+                state = "free_version_disposition",
+                "Decommission free-version disposition summary"
+            );
+        }
+
         if should_cleanup_decommission_source_entry(decommissioned, fivs.versions.len(), expired) && durable_ilm_record.is_none()
         {
             if bucket_incarnation_fence.as_ref().is_some_and(|guard| guard.is_lock_lost()) {
@@ -5591,6 +5774,36 @@ impl ECStore {
             None,
             expected_bucket_incarnation_id,
             source_changed_exhaustions,
+        )
+        .await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn decommission_entry_for_test_with_bucket_incarnation(
+        self: &Arc<Self>,
+        idx: usize,
+        entry: MetaCacheEntry,
+        bucket: String,
+        set: Arc<SetDisks>,
+    ) -> Result<()> {
+        let expected_bucket_incarnation_id = if is_meta_bucketname(&bucket) {
+            None
+        } else {
+            Some(self.bucket_incarnation_id_from_disk(&bucket).await?)
+        };
+        let generation = self.active_decommission_generation(idx).await?;
+        self.decommission_entry(
+            CancellationToken::new(),
+            idx,
+            generation,
+            entry,
+            bucket,
+            set,
+            None,
+            None,
+            None,
+            expected_bucket_incarnation_id,
+            Arc::new(AtomicUsize::new(0)),
         )
         .await
     }
@@ -6263,30 +6476,6 @@ impl ECStore {
         warn!("decommission: decommission_pool bucket_done {}", &bucket.name);
 
         Ok(())
-    }
-
-    async fn decommission_buckets_concurrently(
-        self: &Arc<Self>,
-        rx: CancellationToken,
-        idx: usize,
-        pool: Arc<Sets>,
-        buckets: Vec<DecomBucketInfo>,
-        entry_budget: Arc<Semaphore>,
-        source_changed_exhaustions: Arc<AtomicUsize>,
-    ) -> Result<()> {
-        let store = Arc::clone(self);
-        run_decommission_buckets_bounded(rx, buckets, decommission_bucket_concurrency_limit(), move |bucket, rx| {
-            let store = Arc::clone(&store);
-            let pool = pool.clone();
-            let entry_budget = entry_budget.clone();
-            let source_changed_exhaustions = Arc::clone(&source_changed_exhaustions);
-            Box::pin(async move {
-                store
-                    .decommission_pending_bucket(rx, idx, pool, bucket, entry_budget, source_changed_exhaustions)
-                    .await
-            })
-        })
-        .await
     }
 
     #[tracing::instrument(skip(self, rx))]
@@ -7539,11 +7728,14 @@ impl ECStore {
                             return;
                         }
 
-                        let fivs = match load_decommission_entry_versions(
+                        let fivs = match load_decommission_entry_exact_versions(
+                            &source_set,
                             &entry,
                             &bucket_name,
                             "check_after_decommission.file_info_versions",
-                        ) {
+                        )
+                        .await
+                        {
                             Ok(fivs) => fivs,
                             Err(err) => {
                                 let mut first_err = entry_error.lock().await;
@@ -7556,7 +7748,23 @@ impl ECStore {
                         };
 
                         let mut remaining = 0;
-                        for version in &fivs.versions {
+                        for version in fivs.versions.iter().chain(fivs.free_versions.iter()) {
+                            if version.tier_free_version() {
+                                remaining += 1;
+                                debug!(
+                                    event = EVENT_DECOMMISSION_ENTRY,
+                                    component = LOG_COMPONENT_ECSTORE,
+                                    subsystem = LOG_SUBSYSTEM_POOLS,
+                                    pool_index = idx,
+                                    bucket = %bucket_name,
+                                    object = %entry.name,
+                                    version_id = ?version.version_id,
+                                    reason = DECOMMISSION_FREE_VERSION_SWEEP_REASON,
+                                    state = "free_version_retained",
+                                    "Decommission final sweep retained a free version"
+                                );
+                                continue;
+                            }
                             if version.deleted {
                                 continue;
                             }
@@ -7897,13 +8105,6 @@ mod tests {
     }
 
     #[test]
-    fn decommission_remaining_version_count_excludes_only_expired_versions() {
-        assert_eq!(decommission_remaining_version_count(1, 0), 1);
-        assert_eq!(decommission_remaining_version_count(2, 1), 1);
-        assert_eq!(decommission_remaining_version_count(1, 1), 0);
-    }
-
-    #[test]
     fn lifecycle_action_removes_data_movement_version_rejects_delete_marker_action() {
         assert!(!lifecycle_action_removes_data_movement_version(IlmAction::DeleteAction));
     }
@@ -7957,6 +8158,21 @@ mod tests {
             "object".to_string(),
             "version".to_string()
         )));
+    }
+
+    #[test]
+    fn decommission_free_version_attempt_treats_missing_source_as_consumed() {
+        let attempt =
+            classify_decommission_free_version_attempt(Err(Error::ObjectNotFound("bucket".to_string(), "object".to_string())));
+
+        assert!(matches!(attempt, DecommissionFreeVersionAttempt::Consumed));
+    }
+
+    #[test]
+    fn decommission_free_version_attempt_preserves_capacity_failure() {
+        let attempt = classify_decommission_free_version_attempt(Err(Error::DiskFull));
+
+        assert!(matches!(attempt, DecommissionFreeVersionAttempt::CapacityFailure(Error::DiskFull)));
     }
 
     #[test]
@@ -8134,6 +8350,12 @@ mod tests {
         assert!(opts.include_part_checksums);
         assert!(opts.http_preconditions.is_some());
         assert_eq!(opts.expected_bucket_incarnation_id, Some(incarnation));
+        assert!(!opts.incl_free_versions);
+
+        let mut free_version = version;
+        free_version.set_tier_free_version();
+        let free_opts = decommission_remote_tiered_opts(&free_version, Some("free-version-id".to_string()), 9, Some(incarnation));
+        assert!(free_opts.incl_free_versions);
     }
 
     #[test]

--- a/crates/ecstore/src/data_movement/mod.rs
+++ b/crates/ecstore/src/data_movement/mod.rs
@@ -1951,6 +1951,19 @@ mod tests {
     }
 
     #[test]
+    fn test_decommission_cleanup_preflight_accepts_migrated_free_version_consumed_from_source() {
+        let migrated = cleanup_test_file_info("object.txt", Uuid::from_u128(1), "migrated");
+        let mut free_version = cleanup_test_file_info("object.txt", Uuid::from_u128(2), "tier-cleanup");
+        free_version.deleted = true;
+        free_version.set_tier_free_version();
+        let expected = cleanup_test_versions(vec![migrated.clone(), free_version.clone()]);
+        let current = cleanup_test_versions(vec![migrated]);
+        let allowed_missing = vec![source_cleanup_version_identity(&free_version)];
+
+        assert!(source_cleanup_versions_match_with_allowed_missing(&expected, &current, &allowed_missing));
+    }
+
+    #[test]
     fn test_decommission_cleanup_preflight_rejects_unexpected_missing_version() {
         let migrated = cleanup_test_file_info("object.txt", Uuid::from_u128(1), "migrated");
         let protected = cleanup_test_file_info("object.txt", Uuid::from_u128(2), "protected");

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -228,6 +228,69 @@ pub(super) fn restore_commit_operation_id_from_metadata(metadata: &HashMap<Strin
     restore_operation_id_from_metadata(metadata)
 }
 
+async fn inspect_decommission_tier_free_version_target(
+    disk: &DiskStore,
+    bucket: &str,
+    object: &str,
+    source: &FileInfo,
+) -> Result<bool> {
+    let raw = match disk.read_xl(bucket, object, false).await {
+        Ok(raw) => raw,
+        Err(DiskError::FileNotFound | DiskError::FileVersionNotFound | DiskError::VolumeNotFound) => return Ok(false),
+        Err(err) => return Err(err.into()),
+    };
+    let meta = FileMeta::load(&raw.buf)?;
+    let source_version_id = source.version_id.filter(|version_id| !version_id.is_nil());
+    let mut matching_count = 0;
+    let mut all_matching_versions_equivalent = true;
+    for existing in meta
+        .versions
+        .iter()
+        .filter(|version| version.header.version_id.filter(|version_id| !version_id.is_nil()) == source_version_id)
+    {
+        matching_count += 1;
+        let existing = existing.into_fileinfo(bucket, object, true)?;
+        existing.validate_for_metadata_read()?;
+        if !existing.tier_free_version() || !crate::store::tiered_data_movement_source_matches(source, &existing)? {
+            all_matching_versions_equivalent = false;
+        }
+    }
+    if matching_count == 0 {
+        return Ok(false);
+    }
+    if matching_count == 1 && all_matching_versions_equivalent {
+        return Ok(true);
+    }
+
+    Err(StorageError::DataMovementOverwriteErr(
+        bucket.to_owned(),
+        object.to_owned(),
+        source_version_id.map(|version_id| version_id.to_string()).unwrap_or_default(),
+    ))
+}
+
+fn ensure_decommission_tier_free_version_commit_fence(bucket: &str, object: &str, opts: &ObjectOptions) -> Result<()> {
+    if opts
+        .namespace_lock_fence
+        .as_ref()
+        .is_some_and(NamespaceLockFence::is_lock_lost)
+        || opts
+            .bucket_lifecycle_lock_fence
+            .as_ref()
+            .is_some_and(NamespaceLockFence::is_lock_lost)
+    {
+        return Err(StorageError::NamespaceLockQuorumUnavailable {
+            mode: "decommission_tier_free_version_commit",
+            bucket: bucket.to_string(),
+            object: object.to_string(),
+            required: 1,
+            achieved: 0,
+        });
+    }
+
+    Ok(())
+}
+
 impl SetDisks {
     pub(super) async fn require_current_restore_operation_id(
         &self,
@@ -4686,6 +4749,94 @@ fn resolve_delete_version_state(opts: &ObjectOptions, goi: &ObjectInfo, version_
 }
 
 impl SetDisks {
+    /// Publish an internal tier free-version record without changing its
+    /// delete-marker shape or remote-tier identity. The caller holds the
+    /// source and target object locks; a write quorum is required before the
+    /// source cleanup may remove the original record.
+    #[tracing::instrument(skip(self, fi, opts))]
+    pub(crate) async fn decommission_tier_free_version(
+        &self,
+        bucket: &str,
+        object: &str,
+        fi: &FileInfo,
+        opts: &ObjectOptions,
+    ) -> Result<()> {
+        if !fi.deleted || !fi.tier_free_version() {
+            return Err(Error::other("decommission tier free-version write requires a free version record"));
+        }
+        ensure_decommission_tier_free_version_commit_fence(bucket, object, opts)?;
+
+        let write_quorum = self.default_write_quorum();
+        if self
+            .count_decommission_tier_free_version_equivalents(bucket, object, fi)
+            .await?
+            >= write_quorum
+        {
+            ensure_decommission_tier_free_version_commit_fence(bucket, object, opts)?;
+            return Ok(());
+        }
+        ensure_decommission_tier_free_version_commit_fence(bucket, object, opts)?;
+
+        let disks = self.disks.read().await.clone();
+        let futures = disks.into_iter().map(|disk| {
+            let file_info = fi.clone();
+            async move {
+                if let Some(disk) = disk {
+                    disk.write_metadata("", bucket, object, file_info).await
+                } else {
+                    Err(DiskError::DiskNotFound)
+                }
+            }
+        });
+
+        let mut errs = Vec::new();
+        for result in join_all(futures).await {
+            match result {
+                Ok(_) => errs.push(None),
+                Err(err) => errs.push(Some(err)),
+            }
+        }
+
+        ensure_decommission_tier_free_version_commit_fence(bucket, object, opts)?;
+
+        resolve_tiered_decommission_write_quorum_result(&errs, write_quorum, bucket, object)
+    }
+
+    async fn count_decommission_tier_free_version_equivalents(&self, bucket: &str, object: &str, fi: &FileInfo) -> Result<usize> {
+        // The caller holds the source and target object locks. Inspect every
+        // target disk before an idempotent return or metadata fan-out so a
+        // sub-quorum conflict cannot be hidden by a successful quorum.
+        let disks = self.disks.read().await.clone();
+        let preflight = disks.iter().map(|disk| async {
+            match disk {
+                Some(disk) => inspect_decommission_tier_free_version_target(disk, bucket, object, fi).await,
+                None => Ok(false),
+            }
+        });
+        let mut equivalent = 0;
+        for result in join_all(preflight).await {
+            if result? {
+                equivalent += 1;
+            }
+        }
+        Ok(equivalent)
+    }
+
+    pub(crate) async fn has_decommission_tier_free_version_write_quorum(
+        &self,
+        bucket: &str,
+        object: &str,
+        fi: &FileInfo,
+        opts: &ObjectOptions,
+    ) -> Result<bool> {
+        ensure_decommission_tier_free_version_commit_fence(bucket, object, opts)?;
+        let equivalent = self
+            .count_decommission_tier_free_version_equivalents(bucket, object, fi)
+            .await?;
+        ensure_decommission_tier_free_version_commit_fence(bucket, object, opts)?;
+        Ok(equivalent >= self.default_write_quorum())
+    }
+
     #[tracing::instrument(skip(self, fi, opts))]
     pub(crate) async fn decommission_tiered_object(
         &self,
@@ -9914,6 +10065,147 @@ mod tests {
         assert_eq!(updated.erasure.parity_blocks, 4);
         assert_eq!(layout.write_quorum, 12);
         assert_ne!(updated.erasure.distribution, original.erasure.distribution);
+    }
+
+    #[tokio::test]
+    async fn decommission_tier_free_version_preserves_remote_identity() {
+        let set_disks = make_local_bucket_test_set_disks().await;
+        let bucket = "free-version-decommission";
+        let object = "object.txt";
+        set_disks
+            .make_bucket(bucket, &MakeBucketOptions::default())
+            .await
+            .expect("target bucket should exist before free-version migration");
+        let version_id = Uuid::new_v4();
+        let mut free_version = FileInfo {
+            name: object.to_string(),
+            volume: bucket.to_string(),
+            version_id: Some(version_id),
+            mod_time: Some(time::OffsetDateTime::now_utc()),
+            deleted: true,
+            transition_tier: "WARM-TIER".to_string(),
+            transitioned_objname: "remote/object".to_string(),
+            ..Default::default()
+        };
+        free_version.set_tier_free_version();
+        // Decoded free versions always carry the on-disk free-version
+        // suffix alongside the in-memory tier marker; mirror that here so
+        // the record satisfies delete-marker metadata validation.
+        rustfs_utils::http::metadata_compat::insert_str(
+            &mut free_version.metadata,
+            rustfs_utils::http::metadata_compat::SUFFIX_FREE_VERSION,
+            String::new(),
+        );
+
+        set_disks
+            .decommission_tier_free_version(bucket, object, &free_version, &ObjectOptions::default())
+            .await
+            .expect("free-version metadata should reach the target quorum");
+        set_disks
+            .decommission_tier_free_version(bucket, object, &free_version, &ObjectOptions::default())
+            .await
+            .expect("replaying the same free-version metadata should be idempotent");
+
+        let versions = set_disks
+            .load_file_info_versions_exact(bucket, object)
+            .await
+            .expect("migrated free-version metadata should decode")
+            .expect("migrated free-version metadata should exist");
+        let migrated = versions
+            .versions
+            .iter()
+            .find(|version| version.version_id == Some(version_id))
+            .expect("free version should be present on the target");
+
+        assert_eq!(
+            versions
+                .versions
+                .iter()
+                .filter(|version| version.version_id == Some(version_id))
+                .count(),
+            1
+        );
+        assert!(migrated.tier_free_version());
+        assert_eq!(migrated.transition_tier, "WARM-TIER");
+        assert_eq!(migrated.transitioned_objname, "remote/object");
+    }
+
+    #[tokio::test]
+    async fn decommission_tier_free_version_resume_requires_write_quorum() {
+        let set_disks = make_local_bucket_test_set_disks_with_drive_count(4).await;
+        let bucket = "free-version-decommission-resume";
+        let object = "object.txt";
+        set_disks
+            .make_bucket(bucket, &MakeBucketOptions::default())
+            .await
+            .expect("target bucket should exist before free-version migration");
+        let mut free_version = FileInfo {
+            name: object.to_string(),
+            volume: bucket.to_string(),
+            version_id: Some(Uuid::new_v4()),
+            mod_time: Some(time::OffsetDateTime::now_utc()),
+            deleted: true,
+            transition_tier: "WARM-TIER".to_string(),
+            transitioned_objname: "remote/object".to_string(),
+            ..Default::default()
+        };
+        free_version.set_tier_free_version();
+        // Decoded free versions always carry the on-disk free-version
+        // suffix alongside the in-memory tier marker; mirror that here so
+        // the record satisfies delete-marker metadata validation.
+        rustfs_utils::http::metadata_compat::insert_str(
+            &mut free_version.metadata,
+            rustfs_utils::http::metadata_compat::SUFFIX_FREE_VERSION,
+            String::new(),
+        );
+        let opts = ObjectOptions::default();
+
+        let disks = set_disks.get_disks_internal().await;
+        for disk in disks.iter().take(2).flatten() {
+            disk.write_metadata("", bucket, object, free_version.clone())
+                .await
+                .expect("partial first attempt should leave equivalent metadata");
+        }
+        assert!(
+            !set_disks
+                .has_decommission_tier_free_version_write_quorum(bucket, object, &free_version, &opts)
+                .await
+                .expect("partial target metadata should remain valid"),
+            "write-quorum-minus-one must not be accepted as an idempotent migration"
+        );
+
+        disks[2]
+            .as_ref()
+            .expect("third target disk should be online")
+            .write_metadata("", bucket, object, free_version.clone())
+            .await
+            .expect("third equivalent target write should complete quorum");
+        assert!(
+            set_disks
+                .has_decommission_tier_free_version_write_quorum(bucket, object, &free_version, &opts)
+                .await
+                .expect("write-quorum target metadata should remain valid")
+        );
+    }
+
+    #[test]
+    fn decommission_tier_free_version_commit_rejects_lost_fence() {
+        let opts = ObjectOptions {
+            namespace_lock_fence: Some(NamespaceLockFence::lost_for_test()),
+            ..Default::default()
+        };
+
+        let err = ensure_decommission_tier_free_version_commit_fence("bucket", "object", &opts)
+            .expect_err("lost target lock must fail the free-version commit");
+        assert!(matches!(
+            err,
+            Error::NamespaceLockQuorumUnavailable {
+                mode: "decommission_tier_free_version_commit",
+                required: 1,
+                achieved: 0,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -582,6 +582,8 @@ mod tests {
         wait_for_local_decommission_resume_delay,
     };
     #[cfg(feature = "test-util")]
+    use crate::disk::DiskAPI;
+    #[cfg(feature = "test-util")]
     use crate::{
         bucket::lifecycle::{
             DurableIlmRecordCheckpoint, ILM_META_PREFIX, ValidatedDurableIlmRecord,
@@ -1528,6 +1530,77 @@ mod tests {
             matches!(err, StorageError::ObjectNotFound(_, _) | StorageError::VersionNotFound(_, _, _)),
             "unexpected decommission source result: {err:?}"
         );
+    }
+
+    #[cfg(feature = "test-util")]
+    async fn seed_transitioned_free_version(
+        ctx: &Arc<crate::runtime::instance::InstanceContext>,
+        store: &Arc<crate::store::ECStore>,
+        bucket: &str,
+        object: &str,
+    ) -> (uuid::Uuid, uuid::Uuid) {
+        let tier_name = format!("DECOMFREE{}", uuid::Uuid::new_v4().simple());
+        register_mock_tier(&ctx.tier_config_mgr(), &tier_name).await;
+
+        let mut reader = PutObjReader::from_vec(b"transitioned source bytes".to_vec());
+        let source = store.pools[0]
+            .put_object(
+                bucket,
+                object,
+                &mut reader,
+                &ObjectOptions {
+                    versioned: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("write transitioned decommission source");
+        let source_version = source.version_id.expect("transitioned source must be versioned");
+        store.pools[0]
+            .transition_object(
+                bucket,
+                object,
+                &ObjectOptions {
+                    versioned: true,
+                    version_id: Some(source_version.to_string()),
+                    transition: TransitionOptions {
+                        status: TRANSITION_PENDING.to_string(),
+                        tier: tier_name,
+                        etag: source.etag.clone().expect("transitioned source must have an ETag"),
+                        ..Default::default()
+                    },
+                    mod_time: source.mod_time,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("transition source before decommission");
+        store.pools[0]
+            .delete_object(
+                bucket,
+                object,
+                ObjectOptions {
+                    versioned: true,
+                    version_id: Some(source_version.to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("delete transitioned source version");
+
+        let versions = store.pools[0]
+            .get_disks_by_key(object)
+            .load_file_info_versions_exact(bucket, object)
+            .await
+            .expect("source versions should decode after transition delete")
+            .expect("source free version should remain after transition delete");
+        let free_version = versions
+            .versions
+            .iter()
+            .find(|version| version.tier_free_version())
+            .and_then(|version| version.version_id)
+            .expect("transition delete should create a free version");
+        (source_version, free_version)
     }
 
     async fn write_decommission_test_multipart_source(
@@ -4768,6 +4841,383 @@ mod tests {
             .await
             .expect_err("source cleanup must remove the decommissioned source versions");
 
+        shutdown.cancel();
+    }
+
+    #[cfg(feature = "test-util")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial_test::serial(storage_class_env)]
+    async fn decommission_entry_skips_cleanup_only_marker_when_free_version_is_present() {
+        let temp_dir = tempfile::tempdir().expect("create free-version decommission store dir");
+        let (ctx, store, shutdown) =
+            without_storage_class_env(build_isolated_test_store(temp_dir.path(), "decommission-free-marker", &[4, 4])).await;
+        crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
+        let bucket = format!("decom-free-marker-{}", uuid::Uuid::new_v4());
+        let object = "free-marker-object";
+        store
+            .make_bucket(&bucket, &MakeBucketOptions::default())
+            .await
+            .expect("create free-version decommission bucket");
+        let (_, free_version) = seed_transitioned_free_version(&ctx, &store, &bucket, object).await;
+        let source_free = store.pools[0]
+            .get_disks_by_key(object)
+            .load_file_info_versions_exact(&bucket, object)
+            .await
+            .expect("source free-version metadata should decode")
+            .and_then(|versions| {
+                versions
+                    .versions
+                    .into_iter()
+                    .find(|version| version.version_id == Some(free_version) && version.tier_free_version())
+            })
+            .expect("source free-version identity should be present before decommission");
+        let mut target_reader = PutObjReader::from_vec(b"target ordinary bytes".to_vec());
+        let target_w = store.pools[1]
+            .put_object(
+                &bucket,
+                object,
+                &mut target_reader,
+                &ObjectOptions {
+                    versioned: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("write unrelated target version");
+        let target_w_version = target_w.version_id.expect("target version should have an id");
+        let marker = store.pools[0]
+            .delete_object(
+                &bucket,
+                object,
+                ObjectOptions {
+                    versioned: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("write cleanup-only delete marker");
+        assert!(marker.delete_marker);
+
+        mark_test_pool_decommissioning(&store, 0).await;
+        let source_set = store.pools[0].get_disks_by_key(object);
+        store
+            .decommission_entry_for_test_with_bucket_incarnation(
+                0,
+                MetaCacheEntry {
+                    name: object.to_string(),
+                    ..Default::default()
+                },
+                bucket.clone(),
+                source_set.clone(),
+            )
+            .await
+            .expect("real decommission entry should migrate the free version");
+
+        let target_versions = store.pools[1]
+            .get_disks_by_key(object)
+            .load_file_info_versions_exact(&bucket, object)
+            .await
+            .expect("target versions should decode")
+            .expect("target free version should be present");
+        assert!(
+            target_versions
+                .versions
+                .iter()
+                .any(|version| { version.version_id == Some(free_version) && version.tier_free_version() })
+        );
+        let migrated_free = target_versions
+            .versions
+            .iter()
+            .find(|version| version.version_id == Some(free_version) && version.tier_free_version())
+            .expect("migrated free-version identity should remain readable from target disks");
+        assert!(
+            crate::store::tiered_data_movement_source_matches(&source_free, migrated_free)
+                .expect("migrated free-version identity should decode")
+        );
+        let retained_w = target_versions
+            .versions
+            .iter()
+            .find(|version| version.version_id == Some(target_w_version))
+            .expect("unrelated target version should remain");
+        assert!(!retained_w.deleted && !retained_w.tier_free_version());
+        assert_eq!(retained_w.size, target_w.size);
+        assert_eq!(retained_w.get_etag(), target_w.etag);
+        assert!(
+            target_versions
+                .versions
+                .iter()
+                .all(|version| { version.tier_free_version() || !version.deleted })
+        );
+        assert!(
+            source_set
+                .load_file_info_versions_exact(&bucket, object)
+                .await
+                .expect("source versions should be readable after cleanup")
+                .is_none(),
+            "successful free-version migration should permit source cleanup"
+        );
+        let (heal_versions, _, _) = store
+            .heal_walk_versions_page(1, 0, &bucket, "", None, 2, 16, true)
+            .await
+            .expect("heal walk should decode the migrated free version");
+        let free_version_string = free_version.to_string();
+        let healed_free = heal_versions
+            .iter()
+            .find(|version| version.version_id.as_deref() == Some(free_version_string.as_str()))
+            .expect("heal walk should surface the migrated free version");
+        let healed_info = healed_free
+            .lifecycle_object_info
+            .as_ref()
+            .expect("heal walk should retain lifecycle identity for the migrated free version");
+        assert!(healed_info.transitioned_object.free_version);
+        assert_eq!(healed_info.transitioned_object.tier, source_free.transition_tier);
+        assert_eq!(healed_info.transitioned_object.name, source_free.transitioned_objname);
+        shutdown.cancel();
+    }
+
+    #[cfg(feature = "test-util")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial_test::serial(storage_class_env)]
+    async fn decommission_entry_allows_free_version_consumed_before_source_lock() {
+        let temp_dir = tempfile::tempdir().expect("create consumed free-version store dir");
+        let (ctx, store, shutdown) =
+            without_storage_class_env(build_isolated_test_store(temp_dir.path(), "decommission-free-consumed", &[4, 4])).await;
+        crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
+        let bucket = format!("decom-free-consumed-{}", uuid::Uuid::new_v4());
+        let object = "free-consumed-object";
+        store
+            .make_bucket(&bucket, &MakeBucketOptions::default())
+            .await
+            .expect("create consumed free-version bucket");
+        let (_, free_version) = seed_transitioned_free_version(&ctx, &store, &bucket, object).await;
+
+        mark_test_pool_decommissioning(&store, 0).await;
+        let source_set = store.pools[0].get_disks_by_key(object);
+        let barrier = crate::store::object::DecommissionFreeVersionSourceRaceBarrier::install(&bucket, object);
+        let decommission = tokio::spawn({
+            let store = store.clone();
+            let bucket = bucket.clone();
+            let source_set = source_set.clone();
+            async move {
+                store
+                    .decommission_entry_for_test_with_bucket_incarnation(
+                        0,
+                        MetaCacheEntry {
+                            name: object.to_string(),
+                            ..Default::default()
+                        },
+                        bucket,
+                        source_set,
+                    )
+                    .await
+            }
+        });
+
+        barrier.wait_until_paused().await;
+        store.pools[0]
+            .delete_object(
+                &bucket,
+                object,
+                ObjectOptions {
+                    versioned: true,
+                    version_id: Some(free_version.to_string()),
+                    incl_free_versions: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("lifecycle should consume the source free version before decommission locks it");
+        assert!(
+            source_set
+                .load_file_info_versions_exact(&bucket, object)
+                .await
+                .expect("consumed source metadata should remain readable")
+                .is_none(),
+            "the lifecycle delete should remove the source free version"
+        );
+
+        barrier.release();
+        decommission
+            .await
+            .expect("decommission task should join")
+            .expect("a concurrently consumed free version should not fail source cleanup");
+        assert!(
+            store.pools[1]
+                .get_disks_by_key(object)
+                .load_file_info_versions_exact(&bucket, object)
+                .await
+                .expect("target metadata should remain readable")
+                .is_none(),
+            "an already consumed free version should not be recreated on the target"
+        );
+        shutdown.cancel();
+    }
+
+    #[cfg(feature = "test-util")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial_test::serial(storage_class_env)]
+    async fn decommission_entry_rejects_subquorum_free_version_conflict_and_retains_source() {
+        let temp_dir = tempfile::tempdir().expect("create sub-quorum free-version store dir");
+        let (ctx, store, shutdown) =
+            without_storage_class_env(build_isolated_test_store(temp_dir.path(), "decommission-free-conflict", &[4, 4])).await;
+        crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
+        let bucket = format!("decom-free-conflict-{}", uuid::Uuid::new_v4());
+        let object = "free-conflict-object";
+        store
+            .make_bucket(&bucket, &MakeBucketOptions::default())
+            .await
+            .expect("create sub-quorum conflict bucket");
+        let (_, free_version) = seed_transitioned_free_version(&ctx, &store, &bucket, object).await;
+        let source_free = store.pools[0]
+            .get_disks_by_key(object)
+            .load_file_info_versions_exact(&bucket, object)
+            .await
+            .expect("source free version should decode before crash replay setup")
+            .and_then(|versions| {
+                versions
+                    .versions
+                    .into_iter()
+                    .find(|version| version.version_id == Some(free_version))
+            })
+            .expect("source free version should be available for crash replay setup");
+
+        let mut target_reader = PutObjReader::from_vec(b"target ordinary bytes".to_vec());
+        let target = store.pools[1]
+            .put_object(
+                &bucket,
+                object,
+                &mut target_reader,
+                &ObjectOptions {
+                    versioned: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("seed ordinary target version");
+        let target_version = target.version_id.expect("target version must have an ID");
+        let target_disks = store.pools[1].get_disks_by_key(object).disks.read().await.clone();
+        for disk in target_disks.iter().skip(1) {
+            disk.as_ref()
+                .expect("target crash replay quorum disk should be online")
+                .write_metadata("", &bucket, object, source_free.clone())
+                .await
+                .expect("seed an equivalent free version on the target quorum");
+        }
+        let conflict_path = temp_dir
+            .path()
+            .join(format!("pool1/set0/disk0/{bucket}/{object}/{STORAGE_FORMAT_FILE}"));
+        let encoded = tokio::fs::read(&conflict_path)
+            .await
+            .expect("target metadata should be readable");
+        let mut metadata = FileMeta::load(&encoded).expect("target metadata should decode");
+        let target_index = metadata
+            .versions
+            .iter()
+            .position(|version| version.header.version_id == Some(target_version))
+            .expect("target version should be present on the conflict disk");
+        let mut target_meta = metadata.versions[target_index]
+            .parse_version_meta()
+            .expect("target version metadata should decode");
+        target_meta
+            .object
+            .as_mut()
+            .expect("target conflict must remain an ordinary object")
+            .version_id = Some(free_version);
+        metadata.versions[target_index] = target_meta.try_into().expect("conflict metadata should encode");
+        let expected_conflict_meta = metadata.versions[target_index].meta.clone();
+        let expected_conflict = metadata.versions[target_index]
+            .into_fileinfo(&bucket, object, true)
+            .expect("conflict metadata should decode as an ordinary object");
+        let duplicate_free: rustfs_filemeta::FileMetaShallowVersion = rustfs_filemeta::FileMetaVersion::from(source_free.clone())
+            .try_into()
+            .expect("duplicate free metadata should encode");
+        metadata.versions.insert(target_index, duplicate_free);
+        tokio::fs::write(&conflict_path, metadata.marshal_msg().expect("conflict metadata should encode"))
+            .await
+            .expect("write sub-quorum conflict metadata");
+
+        mark_test_pool_decommissioning(&store, 0).await;
+        let source_set = store.pools[0].get_disks_by_key(object);
+        store
+            .decommission_entry_for_test_with_bucket_incarnation(
+                0,
+                MetaCacheEntry {
+                    name: object.to_string(),
+                    ..Default::default()
+                },
+                bucket.clone(),
+                source_set.clone(),
+            )
+            .await
+            .expect("conflicted decommission entry should retain the source and retry later");
+
+        let source_versions = source_set
+            .load_file_info_versions_exact(&bucket, object)
+            .await
+            .expect("retained source versions should decode")
+            .expect("source free version should be retained after conflict");
+        assert!(
+            source_versions
+                .versions
+                .iter()
+                .any(|version| { version.version_id == Some(free_version) && version.tier_free_version() })
+        );
+        let post_encoded = tokio::fs::read(&conflict_path)
+            .await
+            .expect("conflict metadata should remain readable");
+        let post_metadata = FileMeta::load(&post_encoded).expect("post-conflict metadata should decode");
+        let same_id = post_metadata
+            .versions
+            .iter()
+            .filter(|version| version.header.version_id == Some(free_version))
+            .collect::<Vec<_>>();
+        assert_eq!(same_id.len(), 2, "conflict metadata should retain both same-ID records");
+        assert_eq!(same_id.iter().filter(|version| version.header.free_version()).count(), 1);
+        assert_eq!(same_id.iter().filter(|version| !version.header.free_version()).count(), 1);
+        let post_conflict = same_id
+            .into_iter()
+            .find(|version| !version.header.free_version())
+            .expect("ordinary conflict version must remain addressable by the source ID");
+        let post_conflict_info = post_conflict
+            .into_fileinfo(&bucket, object, true)
+            .expect("post-conflict ordinary metadata should decode");
+        assert!(!post_conflict_info.deleted && !post_conflict_info.tier_free_version());
+        assert_eq!(post_conflict.meta, expected_conflict_meta);
+        assert_eq!(post_conflict_info.size, expected_conflict.size);
+        assert_eq!(post_conflict_info.data_dir, expected_conflict.data_dir);
+        assert_eq!(post_conflict_info.metadata, expected_conflict.metadata);
+        assert_eq!(post_conflict_info.get_etag(), expected_conflict.get_etag());
+
+        for disk_index in 0..4 {
+            let target_path = temp_dir
+                .path()
+                .join(format!("pool1/set0/disk{disk_index}/{bucket}/{object}/{STORAGE_FORMAT_FILE}"));
+            let target_encoded = tokio::fs::read(&target_path)
+                .await
+                .expect("target metadata should remain readable");
+            let target_meta = FileMeta::load(&target_encoded).expect("target metadata should decode");
+            let same_id = target_meta
+                .versions
+                .iter()
+                .filter(|version| version.header.version_id == Some(free_version))
+                .collect::<Vec<_>>();
+            if disk_index == 0 {
+                assert_eq!(same_id.len(), 2);
+                assert!(same_id[0].header.free_version());
+                assert!(!same_id[1].header.free_version());
+            } else {
+                assert_eq!(same_id.len(), 1);
+                assert!(same_id[0].header.free_version());
+            }
+        }
+        let sweep_err = store
+            .check_after_decommission_for_test(0)
+            .await
+            .expect_err("final sweep must report the retained free version");
+        assert!(
+            sweep_err.to_string().contains("version(s) were found"),
+            "unexpected final sweep error: {sweep_err}"
+        );
         shutdown.cancel();
     }
 

--- a/crates/ecstore/src/store/mod.rs
+++ b/crates/ecstore/src/store/mod.rs
@@ -151,7 +151,7 @@ pub(crate) mod init_format;
 pub(crate) mod list_objects;
 mod multipart;
 mod object;
-pub(crate) use object::{ObjectLockDiagGuard, SourceCleanupMutationFence};
+pub(crate) use object::{ObjectLockDiagGuard, SourceCleanupMutationFence, tiered_data_movement_source_matches};
 pub use object::{
     PrepareSelectObjectSnapshotError, PreparedGetObjectReader, SelectObjectSnapshot, SelectObjectSnapshotReadError,
     SnapshotConsistencyError,

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -490,6 +490,82 @@ fn decommission_mutation_fence_for_test(
         .map(|hook| hook.fence.clone())
 }
 
+#[cfg(test)]
+struct DecommissionFreeVersionSourceRaceState {
+    bucket: String,
+    object: String,
+    arrived: tokio::sync::Notify,
+    release: tokio::sync::Notify,
+}
+
+#[cfg(test)]
+pub(crate) struct DecommissionFreeVersionSourceRaceBarrier {
+    state: Arc<DecommissionFreeVersionSourceRaceState>,
+}
+
+#[cfg(test)]
+static DECOMMISSION_FREE_VERSION_SOURCE_RACE_BARRIER: std::sync::OnceLock<
+    std::sync::Mutex<Option<Arc<DecommissionFreeVersionSourceRaceState>>>,
+> = std::sync::OnceLock::new();
+
+#[cfg(test)]
+impl DecommissionFreeVersionSourceRaceBarrier {
+    pub(crate) fn install(bucket: &str, object: &str) -> Self {
+        let state = Arc::new(DecommissionFreeVersionSourceRaceState {
+            bucket: bucket.to_string(),
+            object: object.to_string(),
+            arrived: tokio::sync::Notify::new(),
+            release: tokio::sync::Notify::new(),
+        });
+        let mut slot = DECOMMISSION_FREE_VERSION_SOURCE_RACE_BARRIER
+            .get_or_init(|| std::sync::Mutex::new(None))
+            .lock()
+            .expect("decommission free-version source race barrier should not poison");
+        assert!(slot.is_none(), "decommission free-version source race barrier must be unique");
+        *slot = Some(Arc::clone(&state));
+        Self { state }
+    }
+
+    pub(crate) async fn wait_until_paused(&self) {
+        tokio::time::timeout(Duration::from_secs(30), self.state.arrived.notified())
+            .await
+            .expect("decommission should pause before acquiring the free-version source lock");
+    }
+
+    pub(crate) fn release(&self) {
+        self.state.release.notify_one();
+    }
+}
+
+#[cfg(test)]
+impl Drop for DecommissionFreeVersionSourceRaceBarrier {
+    fn drop(&mut self) {
+        self.state.release.notify_one();
+        let mut slot = DECOMMISSION_FREE_VERSION_SOURCE_RACE_BARRIER
+            .get_or_init(|| std::sync::Mutex::new(None))
+            .lock()
+            .expect("decommission free-version source race barrier should not poison");
+        if slot.as_ref().is_some_and(|state| Arc::ptr_eq(state, &self.state)) {
+            *slot = None;
+        }
+    }
+}
+
+#[cfg(test)]
+async fn pause_decommission_free_version_before_source_lock(bucket: &str, object: &str) {
+    let state = DECOMMISSION_FREE_VERSION_SOURCE_RACE_BARRIER
+        .get_or_init(|| std::sync::Mutex::new(None))
+        .lock()
+        .expect("decommission free-version source race barrier should not poison")
+        .as_ref()
+        .filter(|state| state.bucket == bucket && state.object == object)
+        .cloned();
+    if let Some(state) = state {
+        state.arrived.notify_one();
+        state.release.notified().await;
+    }
+}
+
 pub(crate) struct SourceCleanupMutationFence {
     guard: ObjectLockDiagGuard,
     source_lock_covered: bool,
@@ -1495,13 +1571,15 @@ fn is_equivalent_data_movement_tiered_object(source: &rustfs_filemeta::FileInfo,
         && source_actual_size == target_actual_size
 }
 
-fn tiered_data_movement_source_matches(
+pub(crate) fn tiered_data_movement_source_matches(
     expected: &rustfs_filemeta::FileInfo,
     current: &rustfs_filemeta::FileInfo,
 ) -> Result<bool> {
     let expected_backend = crate::services::tier::tier::tier_destination_id_from_metadata(&expected.metadata)?;
     let current_backend = crate::services::tier::tier::tier_destination_id_from_metadata(&current.metadata)?;
     Ok(expected.version_id == current.version_id
+        && expected.deleted == current.deleted
+        && expected.tier_free_version() == current.tier_free_version()
         && expected.data_dir == current.data_dir
         && expected.mod_time == current.mod_time
         && expected.size == current.size
@@ -1513,6 +1591,14 @@ fn tiered_data_movement_source_matches(
         && expected.transition_version == current.transition_version
         && expected.transition_version_state == current.transition_version_state
         && expected_backend == current_backend)
+}
+
+fn decommission_free_version_overwrite_error(bucket: &str, object: &str, version_id: Option<Uuid>) -> Error {
+    StorageError::DataMovementOverwriteErr(
+        bucket.to_owned(),
+        object.to_owned(),
+        version_id.map(|id| id.to_string()).unwrap_or_default(),
+    )
 }
 
 fn should_check_data_movement_resume_target(src_pool_idx: usize, target_pool_idx: usize) -> bool {
@@ -2222,6 +2308,23 @@ impl ECStore {
         )
     }
 
+    async fn has_equivalent_data_movement_tier_free_version(
+        &self,
+        bucket: &str,
+        object: &str,
+        source: &rustfs_filemeta::FileInfo,
+        opts: &ObjectOptions,
+        target_pool_idx: usize,
+    ) -> Result<bool> {
+        let pool = self
+            .pools
+            .get(target_pool_idx)
+            .ok_or_else(|| Error::other(format!("invalid tiered data movement target pool {target_pool_idx}")))?;
+        pool.get_disks_by_key(object)
+            .has_decommission_tier_free_version_write_quorum(bucket, object, source, opts)
+            .await
+    }
+
     fn resolve_decommission_target_pool_idx_result(result: Result<usize>, bucket: &str, object: &str) -> Result<usize> {
         result.map_err(|err| Error::other(format!("failed to select decommission target pool for {bucket}/{object}: {err}")))
     }
@@ -2241,6 +2344,10 @@ impl ECStore {
         check_put_object_args(bucket, object)?;
 
         let mut opts = opts.clone();
+        let is_free_version = fi.tier_free_version();
+        if is_free_version {
+            opts.incl_free_versions = true;
+        }
         let bucket_incarnation_fence = if is_meta_bucketname(bucket) {
             None
         } else {
@@ -2278,6 +2385,10 @@ impl ECStore {
                 &object,
             )?
         };
+        #[cfg(test)]
+        if is_free_version {
+            pause_decommission_free_version_before_source_lock(bucket, logical_object).await;
+        }
         let _object_guards = self
             .acquire_data_movement_object_write_locks(bucket, &object, opts.src_pool_idx, idx, &mut opts)
             .await?;
@@ -2295,7 +2406,7 @@ impl ECStore {
                 versions
                     .versions
                     .iter()
-                    .find(|current| current.version_id == fi.version_id && !current.tier_free_version())
+                    .find(|current| current.version_id == fi.version_id && current.tier_free_version() == is_free_version)
             })
             .ok_or_else(|| to_object_err(StorageError::FileNotFound, vec![bucket, object.as_str()]))?;
         if !tiered_data_movement_source_matches(fi, current_source)? {
@@ -2310,24 +2421,34 @@ impl ECStore {
                 .get_available_pool_idx_excluding(bucket, &object, fi.size, opts.src_pool_idx)
                 .await;
             let target_pool_idx = resolve_data_movement_resume_target_pool(idx, resume_target_pool_idx, opts.src_pool_idx);
-            if self
-                .has_equivalent_data_movement_tiered_object(bucket, &object, &fi, &opts, target_pool_idx)
-                .await?
-            {
+            if is_free_version && target_pool_idx == opts.src_pool_idx {
+                return Err(Error::DiskFull);
+            }
+            let equivalent = if is_free_version {
+                self.has_equivalent_data_movement_tier_free_version(bucket, &object, &fi, &opts, target_pool_idx)
+                    .await?
+            } else {
+                self.has_equivalent_data_movement_tiered_object(bucket, &object, &fi, &opts, target_pool_idx)
+                    .await?
+            };
+            if equivalent {
                 return Ok(());
             }
 
-            return Err(StorageError::DataMovementOverwriteErr(
-                bucket.to_owned(),
-                object.to_owned(),
-                opts.version_id.clone().unwrap_or_default(),
-            ));
+            return Err(decommission_free_version_overwrite_error(bucket, &object, fi.version_id));
         }
 
-        let result = self.pools[idx]
-            .get_disks_by_key(&object)
-            .decommission_tiered_object(bucket, &object, &fi, &opts)
-            .await;
+        let result = if is_free_version {
+            self.pools[idx]
+                .get_disks_by_key(&object)
+                .decommission_tier_free_version(bucket, &object, &fi, &opts)
+                .await
+        } else {
+            self.pools[idx]
+                .get_disks_by_key(&object)
+                .decommission_tiered_object(bucket, &object, &fi, &opts)
+                .await
+        };
         if matches!(result, Err(Error::PreconditionFailed)) {
             if self
                 .has_equivalent_data_movement_tiered_object(bucket, &object, &fi, &opts, idx)

--- a/crates/filemeta/src/filemeta.rs
+++ b/crates/filemeta/src/filemeta.rs
@@ -90,6 +90,21 @@ fn legacy_data_key_for_version(version_id: Option<Uuid>) -> Option<String> {
 pub const TRANSITION_COMPLETE: &str = "complete";
 pub const TRANSITION_PENDING: &str = "pending";
 
+/// xl.meta key marking a tier free-version record.
+///
+/// A free version is a delete-marker-shaped cleanup hint appended by
+/// [`MetaObject::delete_version`] when a version whose remote transition
+/// completed is removed from xl.meta; it carries the remote tier identity for
+/// an idempotent remote delete and is never a user-visible version
+/// (`num_versions` excludes it). While the record exists it is consumed by the
+/// lifecycle free-version recovery scan and the usage scanner, which re-enqueue
+/// the pending remote delete, and by heal metadata walks. On S3 and lifecycle
+/// delete paths the same obligation is also carried by a committed tier-journal
+/// entry; deletes without such an entry (for example a removed version whose
+/// transition state decodes as unknown) rely on this record alone until the
+/// worker removes it after a successful remote delete. Decommission preserves
+/// the record and its remote identity on the target pool before source cleanup
+/// — see docs/architecture/decommission-compatibility.md.
 pub const FREE_VERSION: &str = "free-version";
 
 pub const TRANSITION_STATUS: &str = "transition-status";
@@ -447,6 +462,10 @@ impl FileMeta {
         };
 
         if let Some(fidx) = existing_idx {
+            let existing = self.versions[fidx].parse_version_meta()?;
+            if existing.free_version() != version.free_version() {
+                return Err(Error::other("cannot replace a free version with a non-free version"));
+            }
             return self.set_idx(fidx, version);
         }
 
@@ -1361,6 +1380,39 @@ mod test {
         assert_eq!(fm.versions[0].header.version_type, VersionType::Object);
         assert_eq!(fm.versions[1].header.version_type, VersionType::Delete);
         assert!(fm.versions[0].header.sorts_before(&fm.versions[1].header));
+    }
+
+    #[test]
+    fn add_version_filemata_rejects_free_and_ordinary_same_id_replacement() {
+        let version_id = Uuid::new_v4();
+        let mut free_meta_sys = HashMap::new();
+        insert_bytes(&mut free_meta_sys, rustfs_utils::http::SUFFIX_FREE_VERSION, Vec::new());
+        let free_version = FileMetaVersion {
+            version_type: VersionType::Delete,
+            delete_marker: Some(MetaDeleteMarker {
+                version_id: Some(version_id),
+                mod_time: Some(OffsetDateTime::now_utc()),
+                meta_sys: free_meta_sys,
+            }),
+            ..Default::default()
+        };
+        let ordinary_version = valid_object_version(version_id, vec![10, 20]);
+
+        for (existing, replacement) in [
+            (free_version.clone(), ordinary_version.clone()),
+            (ordinary_version, free_version),
+        ] {
+            let mut fm = FileMeta::new();
+            fm.add_version_filemata(existing).expect("seed same-id version");
+            let before = fm.marshal_msg().expect("serialize original metadata");
+
+            let err = fm
+                .add_version_filemata(replacement)
+                .expect_err("free and ordinary versions with the same ID must not replace each other");
+
+            assert!(err.to_string().contains("cannot replace a free version"));
+            assert_eq!(fm.marshal_msg().expect("serialize rejected metadata"), before);
+        }
     }
 
     /// `add_version_filemata` positions an inserted version with

--- a/crates/filemeta/src/filemeta/version.rs
+++ b/crates/filemeta/src/filemeta/version.rs
@@ -2725,6 +2725,15 @@ impl MetaObject {
         self.meta_sys.retain(|k, _| !k.starts_with("X-Amz-Restore"));
     }
 
+    /// Builds the free-version cleanup record appended when a transitioned
+    /// version is removed from xl.meta. The record keeps the remote tier
+    /// identity so the lifecycle worker can issue the idempotent remote delete
+    /// and only then remove the record; until then the recovery scan and the
+    /// usage scanner keep re-enqueueing it. S3 and lifecycle deletes also
+    /// persist a committed tier-journal entry for the same remote delete. The
+    /// decommission path copies this record unchanged before source cleanup,
+    /// including when the transition state is unknown — see
+    /// docs/architecture/decommission-compatibility.md.
     pub fn init_free_version(&self, fi: &FileInfo) -> Result<(FileMetaVersion, bool)> {
         if fi.skip_tier_free_version() {
             return Ok((FileMetaVersion::default(), false));

--- a/docs/architecture/decommission-compatibility.md
+++ b/docs/architecture/decommission-compatibility.md
@@ -153,6 +153,99 @@ No migration step is required for these decisions because this note documents th
 current RustFS behavior. Changing either decision later requires an operator
 compatibility note and updated characterization tests.
 
+## Tier Free Versions During Decommission
+
+A tier free version is an internal xl.meta record (`rustfs_filemeta::FREE_VERSION`,
+flagged `XL_FLAG_FREE_VERSION`) shaped like a delete marker. It is created by
+`MetaObject::init_free_version` when a version whose remote transition completed is
+deleted locally: the visible version is removed and the record keeps the remote-tier
+identity (tier, object name, version id, state, destination id) needed for an
+idempotent remote delete. Free versions are not user-visible versions; `num_versions`
+and all listing/GET paths exclude them.
+
+### Lifecycle And Consumers
+
+Creation: any local delete that removes a version whose transition status is
+`complete` appends the record via `MetaObject::delete_version` →
+`init_free_version` (skipped only when `skip_tier_free_version` is set, as on
+data-movement copies). The same deletes also persist a durable tier-journal
+entry on every user-facing path: S3 single deletes (`execute_delete_object` →
+`delete_object_with_tier_delete_journal`), S3 batch deletes, lifecycle expiry,
+and lifecycle delete-all all prepare and commit a journal entry around the
+delete. A journal entry is omitted when the removed version's transition state
+decodes as `TransitionVersionState::Unknown`, or on internal journal-less
+delete paths that never touch transitioned user objects.
+
+Consumption while the record exists: the background recovery loop started by
+`init_background_expiry` (spawned by `spawn_tier_free_version_recovery_once`,
+enabled by default) scans disks for pending records and re-enqueues them; the
+usage scanner does the same; the lifecycle worker then deletes the remote tier
+object idempotently and only afterwards removes the local record. Heal walks
+include free-version records in metadata healing. Transition planning,
+replication, restore, GET, listings, and usage aggregation never depend on
+them.
+
+### Decommission Handling
+
+The exact decommission inventory loader (`load_file_info_versions_exact` via
+`get_all_file_info_versions`) keeps free-version records inline in `versions`.
+The migration loop handles them before lifecycle expiry and delete-marker
+shortcuts. It selects a target pool using the free-version-aware lookup, then
+writes the original free record to every target disk with the normal metadata
+write quorum. The free-version marker, local version id, transition identity,
+transition state, and destination id are preserved at the FileInfo/metadata
+boundary.
+
+The source record is physically removed only after the target write quorum has
+committed and the source cleanup preflight still matches the exact inventory.
+If the lifecycle worker has already completed the remote delete and removed the
+source record before decommission acquires the source lock, decommission records
+that identity as already consumed and treats the missing source record as safe.
+If target capacity, metadata validation, lock fencing, or quorum fails, the
+source record remains and the entry records `state = "free_version_retained"`
+with reason `tier_free_version_migration_failed`; the worker retries the
+operation on a later pass. A target record with the same version id is accepted
+only when its free-version identity matches; a conflicting ordinary version or
+different free record is an overwrite error. This makes retries idempotent and
+prevents a free record from replacing a user-visible version.
+
+### Reference-Audit Result
+
+After migration, user-facing GET/list/transition/replication/restore paths still
+exclude the record. Recovery, usage scanning, lifecycle tier cleanup, and heal
+continue to see it when they request free versions, so an unresolved remote
+delete remains actionable on the target pool. The committed tier journal remains
+an independent retry source where one exists; it is not used as a reason to drop
+the xl.meta record. In particular, `Unknown` transition state records are
+migrated unchanged rather than discarded: the lifecycle worker retains them if
+remote identity validation cannot make a delete request.
+
+Each migrated record emits `state = "free_version_migrated"` with reason
+`tier_free_version_migrated`. A record consumed before migration emits
+`state = "free_version_consumed"` with reason
+`tier_free_version_already_consumed`. Each failed record emits the retained state
+and failure reason above. The entry also emits a disposition summary with
+migrated, consumed, retained, and total counts. The final decommission sweep uses
+the exact loader, counts free records still present, and emits one retained
+record/reason for each unresolved free version before failing the sweep. This
+makes successful migration, completed cleanup, and retained cleanup obligations
+visible instead of silently omitting free records.
+
+No new S3-visible version or admin response field is needed: free versions remain
+internal and are never counted as user-visible versions. The structured
+`decommission_entry` events are the operational status surface for the
+free-version disposition; the existing decommission item/failed counters still
+report the enclosing object migration result.
+
+Regression guard:
+
+- `decommission_tier_free_version_preserves_remote_identity`
+- `decommission_tier_free_version_resume_requires_write_quorum`
+- `decommission_tier_free_version_commit_rejects_lost_fence`
+- `test_decommission_cleanup_preflight_accepts_migrated_free_version_consumed_from_source`
+- `decommission_entry_skips_cleanup_only_marker_when_free_version_is_present`
+- `decommission_entry_rejects_subquorum_free_version_conflict_and_retains_source`
+
 ## Regression Guard
 
 The queued multi-pool contract is guarded by:

--- a/rustfs/src/storage/storage_api.rs
+++ b/rustfs/src/storage/storage_api.rs
@@ -522,9 +522,9 @@ pub(crate) mod ecstore_rpc {
         KMS_SIGNAL_SUBSYSTEM, LocalPeerS3Client, PEER_RESTDRY_RUN, PEER_RESTSIGNAL, PEER_RESTSUB_SYS, PeerRestClient,
         PeerS3Client, SERVICE_SIGNAL_REFRESH_CONFIG, SERVICE_SIGNAL_RELOAD_DYNAMIC, TONIC_RPC_PREFIX,
         check_and_record_signed_rpc_nonce, decode_heal_bucket_rpc_options, normalize_tonic_rpc_audience,
-        sign_ns_scanner_capability, sign_ns_scanner_capability_with_tier_registry_generation, sign_put_file_capability,
-        sign_tonic_rpc_response_proof, tonic_boot_epoch_challenge, tonic_boot_epoch_response_headers,
-        tonic_rpc_auth_failure_reason, verify_put_file_auth_trailer, verify_rpc_signature, verify_tonic_canonical_body_digest,
+        sign_ns_scanner_capability_with_tier_registry_generation, sign_put_file_capability, sign_tonic_rpc_response_proof,
+        tonic_boot_epoch_challenge, tonic_boot_epoch_response_headers, tonic_rpc_auth_failure_reason,
+        verify_put_file_auth_trailer, verify_rpc_signature, verify_tonic_canonical_body_digest,
         verify_tonic_mutation_body_digest, verify_tonic_rpc_signature_with_bootstrap,
     };
     #[cfg(test)]
@@ -1409,11 +1409,6 @@ where
 }
 
 pub(crate) trait StoragePeerS3ClientExt {
-    async fn heal_bucket(
-        &self,
-        bucket: &str,
-        opts: &rustfs_common::heal_channel::HealOpts,
-    ) -> DiskResult<rustfs_madmin::heal_commands::HealResultItem>;
     async fn heal_bucket_with_fence(
         &self,
         bucket: &str,
@@ -1431,14 +1426,6 @@ pub(crate) trait StoragePeerS3ClientExt {
 }
 
 impl StoragePeerS3ClientExt for LocalPeerS3Client {
-    async fn heal_bucket(
-        &self,
-        bucket: &str,
-        opts: &rustfs_common::heal_channel::HealOpts,
-    ) -> DiskResult<rustfs_madmin::heal_commands::HealResultItem> {
-        ecstore_rpc::PeerS3Client::heal_bucket(self, bucket, opts).await
-    }
-
     async fn heal_bucket_with_fence(
         &self,
         bucket: &str,


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#1923 and relates to rustfs/backlog#1901.

## Summary of Changes

- migrate tier free versions as exact decommission inventory entries instead of leaving them on the source pool
- preserve remote-delete identity and validate every target disk before writes and idempotent replay
- retain source state on conflicts, capacity failures, invalid metadata, lost fences, and failed write quorum
- keep cleanup-only delete-marker decisions independent from free-version records
- preserve current durable ILM, SourceChanged retry, metadata-first, MPU drain, and queue semantics
- cover migration, replay, conflicts, cleanup, final sweep, restart, and lifecycle-consumed races

## Verification

- `rustfmt --edition 2024 --check` on all changed Rust files
- `git diff --check`
- layer dependency, architecture migration, unsafe allowance, logging, doc path, and no-planning-doc guards
- two independent exact-head adversarial reviews: PASS on `6064ea9fc4cff874460ccccfe676a714821b513d`
- no local Cargo build was started because disk headroom is constrained; fresh CI is the execution gate

## Impact

Tier free versions now retain their remote-delete obligation through decommission and cannot overwrite a conflicting target version. Source cleanup remains fail-closed until target state and the exact source inventory are valid. No public S3 API or persisted wire-format version changes are introduced.