### PR TITLE
ci: align cache writer and reader keys

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -94,6 +94,9 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Swatinem/rust-cache hashes every RUST* variable. Keep this aligned with
+  # ci.yml or the writer and readers use disjoint cache keys.
+  RUST_BACKTRACE: 1
 
 jobs:
   # Readers: test-and-lint, test-ilm-integration-serial, build-rustfs-debug-binary,
@@ -101,7 +104,7 @@ jobs:
   warm-ci-dev:
     name: Warm ci-dev
     runs-on: sm-standard-4
-    timeout-minutes: 90
+    timeout-minutes: 120
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
@@ -191,7 +194,7 @@ jobs:
   warm-ci-feat-rio:
     name: Warm ci-feat-rio
     runs-on: sm-standard-4
-    timeout-minutes: 90
+    timeout-minutes: 120
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
@@ -219,7 +222,7 @@ jobs:
   warm-ci-feat-proto:
     name: Warm ci-feat-proto
     runs-on: sm-standard-4
-    timeout-minutes: 90
+    timeout-minutes: 120
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:

--- a/scripts/security/check_cache_save_if.sh
+++ b/scripts/security/check_cache_save_if.sh
@@ -64,3 +64,25 @@ if [ "$status" -ne 0 ]; then
 fi
 
 echo "OK: every ./.github/actions/setup call states cache-save-if explicitly"
+
+# rust-cache hashes every CARGO*, CC*, CFLAGS*, CXX*, CMAKE*, and RUST*
+# variable that is present when the setup action runs. The dedicated writer
+# and the CI readers therefore need identical workflow-level compiler env.
+compiler_env() {
+    awk '
+        /^env:[[:space:]]*$/ { in_env = 1; next }
+        in_env && /^[^[:space:]]/ { exit }
+        in_env && /^  (CARGO|CC|CFLAGS|CXX|CMAKE|RUST)[A-Z0-9_]*:/ { print }
+    ' "$1" | sort
+}
+
+ci_env="$(compiler_env .github/workflows/ci.yml)"
+warm_env="$(compiler_env .github/workflows/cache-warm.yml)"
+
+if [ "$ci_env" != "$warm_env" ]; then
+    echo "CI and cache-warm compiler environments differ; rust-cache keys will not match:" >&2
+    diff -u <(printf '%s\n' "$ci_env") <(printf '%s\n' "$warm_env") >&2 || true
+    exit 1
+fi
+
+echo "OK: cache-warm and CI compiler environments match"


### PR DESCRIPTION
## Related Issues

Part of rustfs/backlog#1897 and rustfs/backlog#1600.

## Summary of Changes

- Align the cache-writer workflow's compiler environment with the CI readers so Swatinem/rust-cache generates the same environment key.
- Keep the three cold-cache writer jobs bounded at 120 minutes so the first matching cache can finish and become reusable.
- Extend the cache guard to reject future workflow-level compiler environment drift.

## Verification

- `bash scripts/security/check_cache_save_if.sh`
- `shellcheck scripts/security/check_cache_save_if.sh`
- `actionlint .github/workflows/cache-warm.yml`
- `make script-tests`
- `cargo fmt --all --check`
- `git diff --check`
- Negative guard probe: removing `RUST_BACKTRACE` from the writer produced exit 1 and an exact environment diff.

## Impact

CI test lanes can restore the caches produced by `cache-warm` instead of rebuilding from an empty target directory until their 90-minute job timeout. Runtime behavior is unchanged.

## Additional Notes

Run https://github.com/rustfs/rustfs/actions/runs/32565878848 showed the CI reader using environment key `e1d29d70` with no cache found, while writer run https://github.com/rustfs/rustfs/actions/runs/32564075641 used `82aa0801`; the extra hashed variable was `RUST_BACKTRACE`. The same runs also show the cold ILM and protocol paths reaching the existing 90-minute limit, which is why the writer bootstrap budget is now 120 minutes.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
