### PR TITLE
fix(ecstore): resolve lint regressions

### DIFF
--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -3194,7 +3194,7 @@ impl ECStore {
 
         // Default return value
         let mut del_objects = vec![DeletedObject::default(); objects.len()];
-        let mut accounting = vec![None; objects.len()];
+        let accounting = vec![None; objects.len()];
 
         let mut del_errs = Vec::with_capacity(objects.len());
         for _ in 0..objects.len() {

--- a/crates/ecstore/src/store/rebalance/support.rs
+++ b/crates/ecstore/src/store/rebalance/support.rs
@@ -271,7 +271,7 @@ pub(super) fn resolve_latest_object_info_candidates(
             .filter(|candidate| latest_candidate_mod_time(candidate) == Some(latest_mod_time))
             .collect::<Vec<_>>();
 
-        latest_candidates.sort_by(|left, right| right.idx.cmp(&left.idx));
+        latest_candidates.sort_by_key(|right| std::cmp::Reverse(right.idx));
 
         let Some(winner) = latest_candidates.first() else {
             return Err(Error::ErasureReadQuorum);


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Remove an unused mutable binding from batch-delete accounting.
- Use `sort_by_key` with `Reverse` for the existing descending candidate order.

These two mechanical fixes restore the workspace Clippy gate without changing behavior.

## Verification

- `cargo fmt --all --check`
- `cargo clippy -p rustfs-ecstore --lib -- -D warnings`
- `git diff --check origin/main...HEAD`

## Impact

No runtime, API, storage-format, or compatibility impact.

## Additional Notes

The branch was refreshed onto the current `main` head before verification.
