### PR TITLE
ci: pin s3tests Python tools

### DIFF
--- a/.github/workflows/e2e-s3tests.yml
+++ b/.github/workflows/e2e-s3tests.yml
@@ -178,8 +178,13 @@ jobs:
 
       - name: Install Python tools
         run: |
-          python3 -m pip install --user --upgrade pip awscurl tox
+          python3 -m pip install --user --upgrade pip "awscurl==0.44" "tox==4.60.0"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Verify Python tools
+        run: |
+          test "$(python3 -c 'import importlib.metadata as m; print(m.version("awscurl"))')" = "0.44"
+          test "$(python3 -c 'import importlib.metadata as m; print(m.version("tox"))')" = "4.60.0"
 
       - name: Enable buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3


### PR DESCRIPTION
## Related Issues

Relates to rustfs/backlog#1897.

## Summary of Changes

- pin the e2e-s3tests runner to awscurl 0.44 and tox 4.60.0 instead of resolving latest packages on every run
- verify the installed package metadata before building the test environment

## Verification

- `actionlint .github/workflows/e2e-s3tests.yml`
- `git diff --check`
- confirmed the pinned versions were used by successful run https://github.com/rustfs/rustfs/actions/runs/32571041959
- exact implemented-suite run https://github.com/rustfs/rustfs/actions/runs/32593399442 installed and verified awscurl 0.44 and tox 4.60.0, collected 838 upstream cases, and passed all 537 selected exact cases with zero regressions, unclassified failures, missing results, or timeouts

## Impact

CI-only. Scheduled and manual s3-tests runs no longer change behavior when PyPI publishes a new awscurl or tox release.

## Additional Notes

N/A
