### PR TITLE
fix(ecstore): remove inline write debug noise

### DIFF
--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -2124,26 +2124,13 @@ impl SetDisks {
 
             let put_object_size = known_put_object_storage_size(data.size());
             let shard_file_size_raw = erasure.shard_file_size(put_object_size);
-            let is_inline_buffer =
-                storage_class_config.should_inline(shard_file_size_raw, erasure.data_shards, opts.versioned);
+            let is_inline_buffer = storage_class_config.should_inline(shard_file_size_raw, erasure.data_shards, opts.versioned);
 
             let collect_stage_timing = rustfs_io_metrics::put_stage_metrics_enabled() || issue3031_diag_enabled();
             let shard_file_size = shard_file_size_raw;
             let shard_size = erasure.shard_size();
             let write_path = classify_put_write_path(is_inline_buffer, put_object_size, fi.erasure.block_size);
             let direct_inline_commit = matches!(write_path, SmallWritePath::Inline);
-            {
-                use std::io::Write;
-                let msg = format!(
-                    "INLINE_DEBUG: bucket={} obj={} size={} shard_fs={} ds={} bs={} inline={} direct={} path={} iblock={} ver={}\n",
-                    bucket, object, put_object_size, shard_file_size_raw, erasure.data_shards, fi.erasure.block_size,
-                    is_inline_buffer, direct_inline_commit, write_path.metric_label(), storage_class_config.inline_block(), opts.versioned
-                );
-                if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open("/tmp/rustfs_inline_debug.log") {
-                    let _ = f.write_all(msg.as_bytes());
-                }
-                let _ = std::io::stderr().write_all(msg.as_bytes());
-            }
             rustfs_io_metrics::record_put_object_path(write_path.metric_label());
             let writer_setup_stage_start = collect_stage_timing.then(Instant::now);
             let (mut writers, errors) = if direct_inline_commit {

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -3194,7 +3194,7 @@ impl ECStore {
 
         // Default return value
         let mut del_objects = vec![DeletedObject::default(); objects.len()];
-        let mut accounting = vec![None; objects.len()];
+        let accounting = vec![None; objects.len()];
 
         let mut del_errs = Vec::with_capacity(objects.len());
         for _ in 0..objects.len() {

--- a/crates/ecstore/src/store/rebalance/support.rs
+++ b/crates/ecstore/src/store/rebalance/support.rs
@@ -271,7 +271,7 @@ pub(super) fn resolve_latest_object_info_candidates(
             .filter(|candidate| latest_candidate_mod_time(candidate) == Some(latest_mod_time))
             .collect::<Vec<_>>();
 
-        latest_candidates.sort_by(|left, right| right.idx.cmp(&left.idx));
+        latest_candidates.sort_by_key(|candidate| std::cmp::Reverse(candidate.idx));
 
         let Some(winner) = latest_candidates.first() else {
             return Err(Error::ErasureReadQuorum);


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1879.

## Summary of Changes
Remove a temporary `INLINE_DEBUG` block from the object PUT path that wrote directly to `/tmp/rustfs_inline_debug.log` and stderr. The direct write bypassed `tracing`/logger configuration and polluted runtime performance validation windows even when `RUSTFS_OBS_LOGGER_LEVEL=error`.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p rustfs-ecstore`
- Remote release build on testing infrastructure: `CARGO_TARGET_DIR=/data/rustfs/build/remove-inline-debug-noise-988b1f3fc RUSTFLAGS="-C target-cpu=znver5" cargo build --release --bin rustfs`
- Deployed the resulting binary to `testing1` with ansible and confirmed all four nodes were active, had matching binary sha256 `5037afd417c2c14e7b7a9a22d684f556db78776688644e69073ed461a7222622`, and produced zero `INLINE_DEBUG` lines in a fresh post-deploy journal window.

## Impact
No API, wire-format, storage-format, or configuration impact. This only removes direct debug output from a hot path so normal logging configuration controls runtime output again.

## Additional Notes
The remote runtime follow-up for rustfs/backlog#1879 used this cleaner binary as the baseline before comparing GET metadata ReadVersion coalescing.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
