### PR TITLE
ci: install protocol socket oracle

### DIFF
--- a/.github/workflows/e2e-replication-nightly.yml
+++ b/.github/workflows/e2e-replication-nightly.yml
@@ -196,8 +196,11 @@ jobs:
           cache-save-if: 'false'
           install-build-packaging-tools: 'false'
 
-      - name: Verify protocol socket oracle
-        run: ss -tn state CLOSE-WAIT >/dev/null
+      - name: Install and verify protocol socket oracle
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq iproute2
+          ss -tn state CLOSE-WAIT >/dev/null
 
       # The suite owns fixed protocol ports and serializes its internal cases.
       - name: Verify protocol e2e membership


### PR DESCRIPTION
## Related Issues

rustfs/backlog#1897, rustfs/backlog#1149

## Summary of Changes

- Install `iproute2` before the protocol nightly suite so its Linux `ss` socket oracle is available on a fresh self-hosted runner.
- Keep the preflight command fail-closed, preventing the SFTP CLOSE_WAIT assertions from silently becoming unavailable.

## Verification

- `actionlint .github/workflows/e2e-replication-nightly.yml`
- `git diff --check`
- Failure reproduced in https://github.com/rustfs/rustfs/actions/runs/32588618024: the protocol job exited 127 because `ss` was missing, while the cluster and replication jobs passed.
- Exact branch workflow https://github.com/rustfs/rustfs/actions/runs/32595592915 completed successfully: protocol membership matched 18 tests, all 18 passed, and the seven-test aggregate protocol suite reported zero failures. Replication and cluster-fault jobs also passed.

## Impact

No product behavior changes. The protocol nightly lane now provisions its required socket-inspection tool before running tests.

## Additional Notes

N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
