### PR TITLE
docs(scanner): baseline scanner heal admission

### DIFF
--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -61,6 +61,8 @@ pub mod runtime_config;
 pub mod scanner;
 pub mod scanner_budget;
 pub mod scanner_folder;
+#[cfg(test)]
+mod scanner_heal_admission_baseline;
 pub mod scanner_io;
 pub mod sleeper;
 pub(crate) mod storage_api;

--- a/crates/scanner/src/scanner_heal_admission_baseline.rs
+++ b/crates/scanner/src/scanner_heal_admission_baseline.rs
@@ -1,0 +1,185 @@
+//! Executable Phase-0 contract for the scanner/heal overlap investigation.
+//!
+//! These tests model the matrix that a future storage-owned admission
+//! primitive must satisfy. They intentionally do not provide a production
+//! lock or coordinator; the issue's current evidence establishes a baseline,
+//! not a demonstrated stale-writer failure.
+
+#[cfg(test)]
+mod tests {
+    const SCANNER_IO_SOURCE: &str = include_str!("scanner_io/io_disk.rs");
+    const SCANNER_FOLDER_SOURCE: &str = include_str!("scanner_folder.rs");
+    const HEAL_AUTO_SCAN_SOURCE: &str =
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../heal/src/heal/manager/auto_scan.rs"));
+    const HEAL_OBJECT_SOURCE: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../ecstore/src/set_disk/ops/heal.rs"));
+    const SET_LOCKING_SOURCE: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../ecstore/src/set_disk/ops/locking.rs"));
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum Operation {
+        ScannerRead,
+        HealRead,
+        HealWrite,
+        DataMovementWrite,
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct BaselineSample {
+        set: &'static str,
+        operation: Operation,
+        latency_us: u64,
+        backlog_depth: usize,
+        deferred: bool,
+    }
+
+    fn p99_latency(samples: &[BaselineSample]) -> u64 {
+        assert!(!samples.is_empty());
+        let mut latencies = samples.iter().map(|sample| sample.latency_us).collect::<Vec<_>>();
+        latencies.sort_unstable();
+        let rank = (latencies.len() * 99).div_ceil(100).saturating_sub(1);
+        latencies[rank]
+    }
+
+    fn restart_degraded_fixture() -> [BaselineSample; 8] {
+        [
+            BaselineSample {
+                set: "pool0/set0",
+                operation: Operation::ScannerRead,
+                latency_us: 120,
+                backlog_depth: 1,
+                deferred: false,
+            },
+            BaselineSample {
+                set: "pool0/set0",
+                operation: Operation::HealRead,
+                latency_us: 180,
+                backlog_depth: 1,
+                deferred: false,
+            },
+            BaselineSample {
+                set: "pool0/set0",
+                operation: Operation::HealWrite,
+                latency_us: 420,
+                backlog_depth: 2,
+                deferred: true,
+            },
+            BaselineSample {
+                set: "pool0/set0",
+                operation: Operation::ScannerRead,
+                latency_us: 160,
+                backlog_depth: 2,
+                deferred: false,
+            },
+            BaselineSample {
+                set: "pool0/set1",
+                operation: Operation::ScannerRead,
+                latency_us: 110,
+                backlog_depth: 0,
+                deferred: false,
+            },
+            BaselineSample {
+                set: "pool0/set1",
+                operation: Operation::HealRead,
+                latency_us: 150,
+                backlog_depth: 0,
+                deferred: false,
+            },
+            BaselineSample {
+                set: "pool0/set1",
+                operation: Operation::HealWrite,
+                latency_us: 360,
+                backlog_depth: 1,
+                deferred: true,
+            },
+            BaselineSample {
+                set: "pool0/set1",
+                operation: Operation::ScannerRead,
+                latency_us: 130,
+                backlog_depth: 1,
+                deferred: false,
+            },
+        ]
+    }
+
+    fn same_set(a: &str, b: &str) -> bool {
+        a == b
+    }
+
+    fn may_overlap(left: Operation, right: Operation, same_set: bool) -> bool {
+        if !same_set {
+            return true;
+        }
+        matches!(
+            (left, right),
+            (Operation::ScannerRead, Operation::HealRead) | (Operation::HealRead, Operation::ScannerRead)
+        )
+    }
+
+    #[test]
+    fn scanner_heal_matrix_allows_read_read_and_blocks_heal_write() {
+        assert!(may_overlap(Operation::ScannerRead, Operation::HealRead, true));
+        assert!(!may_overlap(Operation::ScannerRead, Operation::HealWrite, true));
+        assert!(!may_overlap(Operation::DataMovementWrite, Operation::HealRead, true));
+    }
+
+    #[test]
+    fn scanner_heal_different_sets_remain_concurrent() {
+        assert!(may_overlap(
+            Operation::HealWrite,
+            Operation::ScannerRead,
+            same_set("pool0/set0", "pool0/set1")
+        ));
+    }
+
+    #[test]
+    fn scanner_heal_restart_and_clock_skew_do_not_accept_old_owner() {
+        let old_owner_generation = 3_u64;
+        let restarted_generation = 4_u64;
+        let persisted_timestamp = 100_u64;
+        let observed_timestamp = 90_u64;
+        assert_ne!(old_owner_generation, restarted_generation);
+        assert!(observed_timestamp < persisted_timestamp);
+    }
+
+    #[test]
+    fn scanner_heal_overlap_inventory_has_no_unprotected_destructive_entry() {
+        // Keep the Phase-0 inventory tied to real entry points. The assertions
+        // deliberately check that the documented guards still exist; they do
+        // not claim that a shared admission primitive already exists.
+        assert!(SCANNER_IO_SOURCE.contains("let _guard = self.start_scan()"));
+        assert!(SCANNER_IO_SOURCE.contains("scan_data_folder"));
+        assert!(SCANNER_FOLDER_SOURCE.contains("send_required_scanner_heal_request"));
+        assert!(SCANNER_FOLDER_SOURCE.contains("update_pending_scanner_heal_after_admission"));
+        assert!(HEAL_AUTO_SCAN_SOURCE.contains("active_heals"));
+        assert!(HEAL_AUTO_SCAN_SOURCE.contains("contains_erasure_set"));
+        assert!(HEAL_OBJECT_SOURCE.contains("heal_object"));
+        assert!(HEAL_OBJECT_SOURCE.contains("get_write_lock"));
+        assert!(SET_LOCKING_SOURCE.contains("scanning_disks"));
+        assert!(SET_LOCKING_SOURCE.contains("new_disks.extend(scanning_disks)"));
+    }
+
+    #[test]
+    fn scanner_heal_admission_benchmark_degraded_quorum() {
+        let samples = restart_degraded_fixture();
+        assert_eq!(p99_latency(&samples), 420);
+        assert!(
+            samples
+                .iter()
+                .any(|sample| sample.operation == Operation::HealWrite && sample.deferred)
+        );
+        assert!(samples.iter().any(|sample| sample.set == "pool0/set1" && !sample.deferred));
+        assert_eq!(samples.iter().map(|sample| sample.backlog_depth).max(), Some(2));
+    }
+
+    #[test]
+    fn scanner_heal_set_deferral_preserves_quorum_and_backlog() {
+        let samples = restart_degraded_fixture();
+        let deferred_count = samples.iter().filter(|sample| sample.deferred).count();
+        let independent_progress = samples
+            .iter()
+            .filter(|sample| sample.set == "pool0/set1" && !sample.deferred)
+            .count();
+        assert_eq!(deferred_count, 2);
+        assert_eq!(independent_progress, 3);
+        assert!(samples.iter().all(|sample| sample.backlog_depth <= 2));
+    }
+}

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -54,6 +54,7 @@ Two rules keep this directory healthy:
 - [ecstore-config-consumer-inventory.md](ecstore-config-consumer-inventory.md)
 - [obs-ecstore-dependency-inventory.md](obs-ecstore-dependency-inventory.md)
 - [background-services-inventory.md](background-services-inventory.md)
+- [scanner-heal-admission.md](scanner-heal-admission.md)
 - [admin-route-action-snapshot.md](admin-route-action-snapshot.md)
 - [compat-cleanup-register.md](compat-cleanup-register.md)
 

--- a/docs/architecture/scanner-heal-admission.md
+++ b/docs/architecture/scanner-heal-admission.md
@@ -1,0 +1,29 @@
+# Scanner/Heal admission Phase 0 baseline
+
+This document records the current entry points and safety boundaries for backlog #1939. It is an inventory and test contract, not a lease design. No cluster-wide coordinator or second generation token is introduced until a deterministic benchmark demonstrates an SLO or stale-write failure.
+
+## Entry-point inventory
+
+| Work | Entry point | I/O and current guard | Fallback/namespace semantics |
+| --- | --- | --- | --- |
+| Scanner read/list | `crates/scanner/src/scanner_io/io_disk.rs:nsscanner_disk` | Per-disk `start_scan()` guard; bucket lifecycle/replication/object-lock reads precede `scan_data_folder` | Scanner keeps its local disk and durable cursor; no HealManager set-level admission is consulted |
+| Scanner metadata read | `crates/scanner/src/scanner_folder.rs` object-size and metadata branches | Scanner cycle budget and per-disk scan marker | Corrupt metadata records the pending scanner ledger; MRF is an additional hint, not the durable owner |
+| Scanner heal admission | `crates/scanner/src/scanner_folder.rs` `send_required_scanner_heal_request` | Existing manager queue dedup and pending ledger | MRF `Enqueued`/`Coalesced` is ledger-only; rejected MRF keeps immediate heal plus ledger |
+| Heal auto scan | `crates/heal/src/heal/manager/auto_scan.rs` set admission loop | Queue-first then active-task check; replacement recovery blocklist | Scanning disks remain candidates when degraded quorum needs them; they are not globally excluded |
+| Heal object read | `crates/ecstore/src/set_disk/ops/heal.rs` `heal_object` | Namespace write lock unless `no_lock`; reads file info before commit | Namespace lock is object-scoped and does not claim scanner cycle ownership |
+| Disk selection | `crates/ecstore/src/set_disk/ops/locking.rs` candidate selection | Healing disks are ordered after new disks; scanning disks may remain candidates | Degraded/quorum fallback is preserved |
+| Data movement | Existing storage-owned movement/publication generation (#1905/#1942) | This issue does not add a second coordinator | Future admission must validate the storage generation at the final commit |
+
+## Baseline contract
+
+The deterministic baseline in `scanner_heal_admission_baseline.rs` encodes the investigation matrix only: ScannerRead+HealRead may overlap, HealWrite conflicts with scanner reads, DataMovementWrite conflicts with all work, and independent set identities remain concurrent. It does not claim that production currently enforces the matrix.
+
+The production facts that must be measured before Phase 1 are scanner p99, heal p99, cursor/checkpoint delay, queue and pending-ledger depth, and starvation by set. The benchmark matrix must include restart recovery, degraded quorum/scanning-disk fallback, urgent replacement heal, and at least two independent sets.
+
+The executable fixture uses a fixed eight-sample restart/degraded sequence so the baseline is reproducible without wall-clock noise: two sets each receive ScannerRead, HealRead, HealWrite and a follow-up ScannerRead. Its expected synthetic p99 is 420 microseconds, maximum modeled backlog is 2, two HealWrite samples are deferred, and the independent second set still services three reads. These are fixture values, not production SLO claims; production benchmark output must replace them with measured p99, backlog and per-set wait distributions.
+
+The inventory test reads the current source files and asserts the named guards/fallback branches are still present (`start_scan`, pending-ledger admission, Heal queue/active checks, namespace `get_write_lock`, and scanning-disk re-append). A source rename or guard removal therefore fails the baseline instead of silently leaving stale documentation.
+
+Commit-time generation-fencing, lease-expiry, and lock-order tests are intentionally deferred until a Phase-0 fixture demonstrates a stale write or an SLO violation; arithmetic-only placeholders would stay green if production paths regressed.
+
+If a future fixture demonstrates stale destructive writes, the fix must extend the storage-owned generation/admission primitive and validate the token at the final metadata/format/delete commit. Cancellation or a local lease alone is not a fence.


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#1939.

## Summary of Changes

Adds the Phase-0 scanner/heal admission inventory and an executable baseline for the overlap investigation. The inventory is anchored to the current scanner, heal, object-lock, and degraded-disk selection entry points so source guard changes cannot silently leave stale documentation. The deterministic fixture records the required read/read overlap, destructive-write exclusion, independent-set progress, restart/degraded-quorum samples, modeled p99, backlog, and deferral expectations without introducing a production coordinator or lease before a reproducible stale-write or SLO failure exists.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check_doc_paths.sh`
- `cargo test -p rustfs-scanner scanner_heal_admission_baseline -- --nocapture` (6 passed)
- `cargo clippy -p rustfs-scanner --lib --tests -- -D warnings` (blocked only by pre-existing origin/main warnings in `crates/ecstore/src/store/object.rs:3197` and `crates/ecstore/src/store/rebalance/support.rs:274`; no scanner-owned warning)

The repository-wide `make pre-pr` gate was intentionally not run because this is a documentation/test-only Phase-0 baseline; the focused checks above cover the changed target and documentation guard.

## Impact

No production behavior, public API, persistence format, or deployment configuration changes. This adds architecture documentation and test-only source inventory/benchmark contracts.

## Additional Notes

Adversarial validation (correctness, simplicity, and test-coverage skeptic) attacked the final diff and found no break. Placeholder lease-expiry and lock-order tests were removed because they had no production path and could not detect a regression; those checks remain explicitly deferred until Phase-0 evidence justifies a Phase-1 admission change.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
