### PR TITLE
perf(runtime): enable fsync thread isolation by default

### DIFF
--- a/crates/config/src/constants/runtime.rs
+++ b/crates/config/src/constants/runtime.rs
@@ -60,9 +60,9 @@ pub const DEFAULT_RNG_SEED: Option<u64> = None; // None means random
 /// Dedicated blocking thread pool for fsync/fdatasync operations.
 /// When > 1, fsync operations are isolated from the main blocking pool to
 /// prevent device-bound fsync from starving read operations (pread/stat/open).
-/// Default 0 means auto (no isolation, use main runtime).
+/// Default 64 isolates fsync from the main blocking pool to prevent device-bound fsync from starving read I/O.
 pub const ENV_FSYNC_BLOCKING_THREADS: &str = "RUSTFS_RUNTIME_FSYNC_BLOCKING_THREADS";
-pub const DEFAULT_FSYNC_BLOCKING_THREADS: usize = 0;
+pub const DEFAULT_FSYNC_BLOCKING_THREADS: usize = 64;
 
 // Dial9 Tokio Telemetry Default values
 pub const DEFAULT_RUNTIME_DIAL9_ENABLED: bool = false; // Disabled by default


### PR DESCRIPTION
Change `DEFAULT_FSYNC_BLOCKING_THREADS` from `0` to `64` to isolate fsync/fdatasync operations into a dedicated blocking thread pool, preventing device-bound fsync from starving read I/O (pread/stat/open) on the main blocking pool.

## A/B Validation

4-node EC cluster (testing, 10.0.0.5/8/9/11:9000), binary `0e79106c2`:

| Workload | Metric | Baseline | Fsync Isolation | Δ |
|---|---|---|---|---|
| PUT 256KiB c16 | p99 | 226ms | 135ms | **−40%** |
| PUT 256KiB c16 | p50 | 60ms | 19ms | **−68%** |
| PUT 256KiB c16 | throughput | 635 obj/s | 685 obj/s | **+7.9%** |
| GET 256KiB c16 | p99 | 3.97ms | 3.63ms | **−9%** |
| GET 256KiB c16 | throughput | 7,459 obj/s | 7,595 obj/s | **+1.8%** |
| GET 4KiB c64 | all | neutral | neutral | 0% |

## Mechanism

When `RUSTFS_RUNTIME_FSYNC_BLOCKING_THREADS > 1`, a dedicated tokio runtime (with `worker_threads=min(cpu, 8)` and 512 KiB stack) is created for fsync/fdatasync operations. The main blocking pool then handles only read I/O (pread/stat/open) without contention from device-bound fsync syscalls.

The env var `RUSTFS_RUNTIME_FSYNC_BLOCKING_THREADS` remains available for operators to tune or disable (set to 0) if needed.

Co-Authored-By: heihutu <heihutu@gmail.com>