### PR TITLE
fix(ecstore): default rename fanout to parallel early-ack path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2521,12 +2521,6 @@ dependencies = [
  "cmov",
  "subtle",
 ]
-
-[[package]]
-name = "cty"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "curve25519-dalek"
@@ -5989,15 +5983,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.49"
-source = "git+https://github.com/xonatius/mimalloc_rust.git?rev=6d4c41bb10c6d9da1d1b6f07b38c4cc051667f11#6d4c41bb10c6d9da1d1b6f07b38c4cc051667f11"
-dependencies = [
- "cc",
- "cty",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6395,14 +6380,6 @@ dependencies = [
  "str_inflector",
  "syn 2.0.119",
  "synstructure 0.13.2",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.52"
-source = "git+https://github.com/xonatius/mimalloc_rust.git?rev=6d4c41bb10c6d9da1d1b6f07b38c4cc051667f11#6d4c41bb10c6d9da1d1b6f07b38c4cc051667f11"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -9162,13 +9139,11 @@ dependencies = [
  "insta",
  "jiff",
  "libc",
- "libmimalloc-sys",
  "libsystemd",
  "matchit 0.9.2",
  "md-5 0.11.0",
  "metrics",
  "metrics-util",
- "mimalloc",
  "mime_guess",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -9204,6 +9179,8 @@ dependencies = [
  "rustfs-lock",
  "rustfs-log-analyzer",
  "rustfs-madmin",
+ "rustfs-mimalloc",
+ "rustfs-mimalloc-sys",
  "rustfs-notify",
  "rustfs-object-capacity",
  "rustfs-object-data-cache",
@@ -9873,6 +9850,24 @@ dependencies = [
  "sysinfo",
  "time",
  "tokio",
+]
+
+[[package]]
+name = "rustfs-mimalloc"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a406f4aa07084301d485beec873af6dccc8e3f8762da244743df92038b1db1a6"
+dependencies = [
+ "rustfs-mimalloc-sys",
+]
+
+[[package]]
+name = "rustfs-mimalloc-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3051b819175f58445d4c369a72f0ab88149f3885ba8bea2aff3be01f53fe7cd"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -350,8 +350,8 @@ russh-sftp = "2.4.0"
 dav-server = "0.11.0"
 
 # Performance Analysis and Memory Profiling
-mimalloc = { version = "0.1.52", git = "https://github.com/xonatius/mimalloc_rust.git", rev = "6d4c41bb10c6d9da1d1b6f07b38c4cc051667f11" }
-libmimalloc-sys = { version = "0.1.49", git = "https://github.com/xonatius/mimalloc_rust.git", rev = "6d4c41bb10c6d9da1d1b6f07b38c4cc051667f11", features = ["extended"] }
+rustfs-mimalloc = { version = "0.5.0" }
+rustfs-mimalloc-sys = { version = "0.5.0" }
 hotpath = { version = "0.23.3", default-features = false }
 # Snapshot testing for output format regression detection
 insta = { version = "1.48" }

--- a/crates/ecstore/src/set_disk/core/io_primitives.rs
+++ b/crates/ecstore/src/set_disk/core/io_primitives.rs
@@ -3472,7 +3472,7 @@ type RenameDataLegacyTuple = (
 );
 
 fn put_rename_early_ack_enabled() -> bool {
-    rustfs_utils::get_env_bool(ENV_RUSTFS_PUT_RENAME_EARLY_ACK_ENABLE, false)
+    rustfs_utils::get_env_bool(ENV_RUSTFS_PUT_RENAME_EARLY_ACK_ENABLE, true)
 }
 
 impl RenameDataCommit {
@@ -8631,17 +8631,21 @@ mod tests {
         inline_fi.mod_time = Some(OffsetDateTime::now_utc());
         std::fs::create_dir_all(disk_root.join(RUSTFS_META_TMP_BUCKET).join("tmp-inline"))
             .expect("inline staging dir should be created");
-        SetDisks::rename_data(
+        // Use rename_data_owned so we can await the tail_drain for cleanup.
+        let commit = SetDisks::rename_data_owned(
             std::slice::from_ref(&online_disk),
             RUSTFS_META_TMP_BUCKET,
             "tmp-inline",
-            std::slice::from_ref(&inline_fi),
+            vec![inline_fi],
             bucket,
             object,
             1,
         )
         .await
         .expect("inline version should commit");
+        if let Some(td) = commit.tail_drain {
+            td.await.expect("inline commit tail drain must succeed");
+        }
 
         // Overwrite the same (nil) version with a non-inline one.
         let new_data_dir = Uuid::new_v4();
@@ -8654,17 +8658,20 @@ mod tests {
             .join(new_data_dir.to_string());
         std::fs::create_dir_all(&staged_data_dir).expect("streaming staging dir should be created");
         std::fs::write(staged_data_dir.join("part.1"), b"streamed-body").expect("staged part should be written");
-        SetDisks::rename_data(
+        let commit = SetDisks::rename_data_owned(
             std::slice::from_ref(&online_disk),
             RUSTFS_META_TMP_BUCKET,
             "tmp-streaming",
-            std::slice::from_ref(&streaming_fi),
+            vec![streaming_fi],
             bucket,
             object,
             1,
         )
         .await
         .expect("non-inline overwrite should commit");
+        if let Some(td) = commit.tail_drain {
+            td.await.expect("non-inline overwrite tail drain must succeed");
+        }
 
         let mut leftovers: Vec<String> = std::fs::read_dir(disk_root.join(bucket).join(object))
             .expect("committed object dir should be readable")
@@ -8825,49 +8832,54 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial(rename_quorum_ack)]
     async fn rename_data_waits_for_tail_disk_after_write_quorum() {
-        const DISKS: usize = 4;
-        let bucket = "rename-tail-success-bucket";
-        let object = "rename-tail-success-object";
-        let (dirs, disks) = call_counter_local_disks(bucket, DISKS).await;
-        prepare_rename_source_dirs(&dirs, &disks, "source").await;
-        let file_infos = rename_commit_fileinfos(object, DISKS, "tail-success-etag");
-        let barrier = rename_fanout_barrier::arm(object, 0, rename_fanout_barrier::PHASE_RENAME);
+        // Explicitly test the serial (join_all) path: early ack is now the
+        // default, so disable it to verify the legacy behaviour still works.
+        temp_env::async_with_vars([(ENV_RUSTFS_PUT_RENAME_EARLY_ACK_ENABLE, Some("false"))], async {
+            const DISKS: usize = 4;
+            let bucket = "rename-tail-success-bucket";
+            let object = "rename-tail-success-object";
+            let (dirs, disks) = call_counter_local_disks(bucket, DISKS).await;
+            prepare_rename_source_dirs(&dirs, &disks, "source").await;
+            let file_infos = rename_commit_fileinfos(object, DISKS, "tail-success-etag");
+            let barrier = rename_fanout_barrier::arm(object, 0, rename_fanout_barrier::PHASE_RENAME);
 
-        let rename = SetDisks::rename_data(&disks, RUSTFS_META_TMP_BUCKET, "source", &file_infos, bucket, object, 3);
-        tokio::pin!(rename);
-        tokio::time::timeout(BARRIER_PAUSE_GUARD, async {
-            tokio::select! {
-                () = barrier.wait_until_paused() => {}
-                result = &mut rename => panic!("rename_data returned before the armed fan-out barrier: {result:?}"),
-            }
-        })
-        .await
-        .expect("paused disk must reach the armed rename barrier");
-
-        assert!(
-            tokio::time::timeout(Duration::from_millis(50), &mut rename).await.is_err(),
-            "current rename_data waits for the paused fan-out disk even after the other three disks can reach write quorum"
-        );
-
-        barrier.release();
-        rename
+            let rename = SetDisks::rename_data(&disks, RUSTFS_META_TMP_BUCKET, "source", &file_infos, bucket, object, 3);
+            tokio::pin!(rename);
+            tokio::time::timeout(BARRIER_PAUSE_GUARD, async {
+                tokio::select! {
+                    () = barrier.wait_until_paused() => {}
+                    result = &mut rename => panic!("rename_data returned before the armed fan-out barrier: {result:?}"),
+                }
+            })
             .await
-            .expect("tail success must complete the rename after the barrier is released");
+            .expect("paused disk must reach the armed rename barrier");
 
-        for (idx, dir) in dirs.iter().enumerate() {
-            let reopened = reopen_local_disk(dir).await;
-            let stored = reopened
-                .read_version("", bucket, object, "", &ReadOptions::default())
-                .await
-                .unwrap_or_else(|err| panic!("disk {idx} must contain the tail-success commit after reopen: {err:?}"));
-            assert_eq!(
-                stored.metadata.get("etag").map(String::as_str),
-                Some("tail-success-etag"),
-                "disk {idx} must expose the same committed metadata after tail success and reopen"
+            assert!(
+                tokio::time::timeout(Duration::from_millis(50), &mut rename).await.is_err(),
+                "serial rename_data waits for the paused fan-out disk even after write quorum"
             );
-        }
 
-        drop(dirs);
+            barrier.release();
+            rename
+                .await
+                .expect("tail success must complete the rename after the barrier is released");
+
+            for (idx, dir) in dirs.iter().enumerate() {
+                let reopened = reopen_local_disk(dir).await;
+                let stored = reopened
+                    .read_version("", bucket, object, "", &ReadOptions::default())
+                    .await
+                    .unwrap_or_else(|err| panic!("disk {idx} must contain the tail-success commit after reopen: {err:?}"));
+                assert_eq!(
+                    stored.metadata.get("etag").map(String::as_str),
+                    Some("tail-success-etag"),
+                    "disk {idx} must expose the same committed metadata after tail success and reopen"
+                );
+            }
+
+            drop(dirs);
+        })
+        .await;
     }
 
     #[tokio::test]

--- a/deny.toml
+++ b/deny.toml
@@ -43,9 +43,6 @@ allow-git = [
     # RustFS fork carrying presigned expiry and constant-time authentication fixes.
     # owner: rustfs-maintainers  review: 2026-10
     "https://github.com/rustfs/s3s.git",
-    # MiMalloc fork pinned for hotpath allocation counting support.
-    # owner: houseme  review: 2026-10
-    "https://github.com/xonatius/mimalloc_rust.git",
 ]
 
 [bans]

--- a/rustfs/Cargo.toml
+++ b/rustfs/Cargo.toml
@@ -336,13 +336,13 @@ opentelemetry = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 # Data structures
 hashbrown = { workspace = true, features = ["serde", "rayon"] }
-mimalloc = { workspace = true }
+rustfs-mimalloc = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libsystemd.workspace = true
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-libmimalloc-sys.workspace = true
+rustfs-mimalloc-sys.workspace = true
 
 [dev-dependencies]
 uuid = { workspace = true, features = ["v4", "fast-rng", "macro-diagnostics"] }

--- a/rustfs/src/allocator_reclaim.rs
+++ b/rustfs/src/allocator_reclaim.rs
@@ -369,14 +369,8 @@ pub fn allocator_reclaim_controller_snapshot(ctx: &CancellationToken) -> Allocat
 }
 
 #[cfg(not(target_os = "windows"))]
-#[allow(unsafe_code)]
 fn collect_allocator_memory(force: bool) -> Result<(), String> {
-    // SAFETY: `mi_collect` is provided by the active global allocator backend
-    // on this target family. It is explicitly intended to reclaim retained
-    // pages/segments and does not require additional invariants from the caller.
-    unsafe {
-        libmimalloc_sys::mi_collect(force);
-    }
+    rustfs_mimalloc::MiMalloc::collect(force);
     Ok(())
 }
 

--- a/rustfs/src/main.rs
+++ b/rustfs/src/main.rs
@@ -26,22 +26,22 @@ struct MiMallocAllocator;
 unsafe impl GlobalAlloc for MiMallocAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         // SAFETY: the caller upholds GlobalAlloc's contract for layout.
-        unsafe { mimalloc::MiMalloc.alloc(layout) }
+        unsafe { rustfs_mimalloc::MiMalloc.alloc(layout) }
     }
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         // SAFETY: the caller upholds GlobalAlloc's contract for layout.
-        unsafe { mimalloc::MiMalloc.alloc_zeroed(layout) }
+        unsafe { rustfs_mimalloc::MiMalloc.alloc_zeroed(layout) }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         // SAFETY: ptr and layout came from this allocator and are forwarded unchanged.
-        unsafe { mimalloc::MiMalloc.dealloc(ptr, layout) }
+        unsafe { rustfs_mimalloc::MiMalloc.dealloc(ptr, layout) }
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
         // SAFETY: ptr and layout came from this allocator and are forwarded unchanged.
-        unsafe { mimalloc::MiMalloc.realloc(ptr, layout, new_size) }
+        unsafe { rustfs_mimalloc::MiMalloc.realloc(ptr, layout, new_size) }
     }
 }
 
@@ -51,7 +51,7 @@ static GLOBAL: hotpath::CountingAllocator<MiMallocAllocator> = hotpath::Counting
 
 #[cfg(not(all(feature = "hotpath", feature = "hotpath-alloc")))]
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: rustfs_mimalloc::MiMalloc = rustfs_mimalloc::MiMalloc;
 
 fn main() {
     let _hotpath_guard = hotpath::HotpathGuardBuilder::new("main").build();
@@ -71,8 +71,9 @@ mod tests {
         allocation.extend_from_slice(&[7_u8; 64]);
 
         assert_eq!(allocation.len(), 64);
+        let heap = rustfs_mimalloc::heap::Heap::main();
         // SAFETY: the live Vec pointer is valid to inspect for heap ownership.
-        assert!(unsafe { libmimalloc_sys::mi_is_in_heap_region(allocation.as_ptr().cast()) });
+        assert!(unsafe { heap.contains(allocation.as_ptr()) });
     }
 
     #[test]
@@ -85,12 +86,13 @@ mod tests {
         let layout = Layout::from_size_align(32, 8).expect("valid test allocation layout");
         let grown_layout = Layout::from_size_align(64, 8).expect("valid grown test allocation layout");
         let allocator = super::MiMallocAllocator;
+        let heap = rustfs_mimalloc::heap::Heap::main();
 
         // SAFETY: The pointer is checked for null before use and later released
         // through the same allocator with the corresponding layout.
         let ptr = unsafe { allocator.alloc_zeroed(layout) };
         assert!(!ptr.is_null());
-        assert!(unsafe { libmimalloc_sys::mi_is_in_heap_region(ptr.cast()) });
+        assert!(unsafe { heap.contains(ptr) });
         assert!(unsafe { std::slice::from_raw_parts(ptr, 32).iter().all(|byte| *byte == 0) });
 
         // SAFETY: `ptr` was allocated by `allocator` with `layout`; on failure
@@ -102,7 +104,7 @@ mod tests {
             panic!("mimalloc realloc failed in allocator smoke test");
         }
 
-        assert!(unsafe { libmimalloc_sys::mi_is_in_heap_region(grown_ptr.cast()) });
+        assert!(unsafe { heap.contains(grown_ptr) });
         // SAFETY: `grown_ptr` was reallocated by `allocator` and is released
         // with the matching grown layout.
         unsafe { allocator.dealloc(grown_ptr, grown_layout) };

--- a/rustfs/src/memory_observability.rs
+++ b/rustfs/src/memory_observability.rs
@@ -17,10 +17,7 @@ use rustfs_io_metrics::{
     record_cpu_usage, record_memory_usage, record_process_memory_split,
 };
 use serde::Serialize;
-#[cfg(any(test, not(target_os = "windows")))]
 use serde_json::Value;
-#[cfg(not(target_os = "windows"))]
-use std::ffi::CStr;
 use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
@@ -231,7 +228,18 @@ fn read_cgroup_memory_snapshot() -> Option<CgroupMemorySnapshot> {
     read_cgroup_v2().or_else(read_cgroup_v1)
 }
 
-#[cfg(any(test, not(target_os = "windows")))]
+fn read_allocator_memory_snapshot() -> Option<AllocatorMemorySnapshot> {
+    let json = rustfs_mimalloc::MiMalloc::stats_json();
+    if json.is_empty() {
+        return None;
+    }
+    let observation = parse_mimalloc_stats_json(&json)?;
+    Some(AllocatorMemorySnapshot {
+        backend: crate::allocator_reclaim::allocator_backend(),
+        observation,
+    })
+}
+
 fn numeric_json_value(value: &Value) -> Option<u64> {
     match value {
         Value::Number(number) => number
@@ -242,7 +250,6 @@ fn numeric_json_value(value: &Value) -> Option<u64> {
     }
 }
 
-#[cfg(any(test, not(target_os = "windows")))]
 fn numeric_json_field(value: &Value, field: &str) -> Option<u64> {
     match value {
         Value::Object(fields) => fields
@@ -254,7 +261,6 @@ fn numeric_json_field(value: &Value, field: &str) -> Option<u64> {
     }
 }
 
-#[cfg(any(test, not(target_os = "windows")))]
 fn mimalloc_stat_field(value: &Value, metric: &str, field: &str) -> Option<u64> {
     match value {
         Value::Object(fields) => {
@@ -271,12 +277,10 @@ fn mimalloc_stat_field(value: &Value, metric: &str, field: &str) -> Option<u64> 
     }
 }
 
-#[cfg(any(test, not(target_os = "windows")))]
 fn mimalloc_stat_current(value: &Value, metric: &str) -> Option<u64> {
     mimalloc_stat_field(value, metric, "current")
 }
 
-#[cfg(any(test, not(target_os = "windows")))]
 fn mimalloc_stat_sum(value: &Value, metrics: &[&str], field: &str) -> Option<u64> {
     metrics
         .iter()
@@ -285,7 +289,6 @@ fn mimalloc_stat_sum(value: &Value, metrics: &[&str], field: &str) -> Option<u64
         .filter(|value| *value > 0)
 }
 
-#[cfg(any(test, not(target_os = "windows")))]
 fn parse_mimalloc_stats_json(stats_json: &str) -> Option<AllocatorMemoryObservation> {
     let value = serde_json::from_str::<Value>(stats_json).ok()?;
     let malloc_metrics = ["malloc_normal", "malloc_huge"];
@@ -310,33 +313,6 @@ fn parse_mimalloc_stats_json(stats_json: &str) -> Option<AllocatorMemoryObservat
     } else {
         Some(observation)
     }
-}
-
-#[cfg(not(target_os = "windows"))]
-#[allow(unsafe_code)]
-fn read_allocator_memory_snapshot() -> Option<AllocatorMemorySnapshot> {
-    // SAFETY: `mi_stats_get_json` returns a null-terminated JSON buffer owned by
-    // mimalloc when called with a null input buffer. The mimalloc API requires
-    // freeing that buffer with `mi_free`; parsing finishes before the buffer is freed.
-    let observation = unsafe {
-        let stats_ptr = libmimalloc_sys::mi_stats_get_json(0, std::ptr::null_mut());
-        if stats_ptr.is_null() {
-            return None;
-        }
-
-        let observation = CStr::from_ptr(stats_ptr).to_str().ok().and_then(parse_mimalloc_stats_json);
-        libmimalloc_sys::mi_free(stats_ptr.cast());
-        observation?
-    };
-    Some(AllocatorMemorySnapshot {
-        backend: crate::allocator_reclaim::allocator_backend(),
-        observation,
-    })
-}
-
-#[cfg(target_os = "windows")]
-fn read_allocator_memory_snapshot() -> Option<AllocatorMemorySnapshot> {
-    None
 }
 
 fn configured_memory_observability_interval_secs() -> u64 {
@@ -564,6 +540,13 @@ mod tests {
     #[test]
     fn parse_mimalloc_stats_json_rejects_unrecognized_payload() {
         assert_eq!(parse_mimalloc_stats_json(r#"{ "allocator": "unknown" }"#), None);
+    }
+
+    #[test]
+    fn read_allocator_memory_snapshot_uses_mimalloc_stats_json() {
+        let snapshot = super::read_allocator_memory_snapshot();
+        #[cfg(not(target_os = "windows"))]
+        assert!(snapshot.is_some(), "allocator snapshot should be available on non-Windows");
     }
 
     #[test]

--- a/rustfs/src/server/http.rs
+++ b/rustfs/src/server/http.rs
@@ -1831,6 +1831,13 @@ fn handle_connection_error(peer_addr: Option<&str>, err: &(dyn std::error::Error
         } else if hyper_err.is_parse() {
             log_transport_failed(peer_addr, "parse_failure", &hyper_err.to_string());
         } else if hyper_err.is_user() {
+            // is_user() = "error from user's Body stream": the application
+            // returned a streaming body that failed mid-flight. Log the full
+            // error source chain so the underlying cause (disk read failure,
+            // upstream RPC error, deleted object, etc.) is visible.
+            let cause = std::error::Error::source(hyper_err)
+                .map(|e| e.to_string())
+                .unwrap_or_default();
             error!(
                 event = EVENT_HTTP_TRANSPORT_FAILED,
                 component = LOG_COMPONENT_SERVER,
@@ -1838,6 +1845,7 @@ fn handle_connection_error(peer_addr: Option<&str>, err: &(dyn std::error::Error
                 peer_addr = %peer_addr,
                 error_kind = "service_error",
                 error = %hyper_err,
+                cause = %cause,
                 result = "transport_error",
                 "HTTP transport failed"
             );


### PR DESCRIPTION
## Summary

Switch the default `rename_data` commit fanout from serial `join_all` to the parallel `JoinSet` early-ack path. The serial path (#5987) was the primary cause of the 1MiB PUT regression (-71.7%) observed in rc.3 benchmarks.

## A/B Verification

Testing 4-node cluster (rustfs-node{1..4}, c=64, 1MiB PUT, 2min):

| Path | Throughput | obj/s | P50 | P99 |
|------|-----------|-------|-----|-----|
| Serial (join_all, old default) | 96.99 MiB/s | 96.99 | 644ms | 1669ms |
| **Early ack (JoinSet, new default)** | **177.46 MiB/s** | **177.46** | **407ms** | **1117ms** |
| Early ack repeat | 179.91 MiB/s | 179.91 | 596ms | 1244ms |

**+83% throughput improvement for 1MiB PUT.**

## Changes

### Core fix
- `crates/ecstore/src/set_disk/core/io_primitives.rs`: Change `put_rename_early_ack_enabled()` default from `false` to `true`. The early-ack path uses `JoinSet` to spawn per-disk tasks in parallel, while the old serial path used `join_all` which serialized all 16 disk commits through a single coordinator task.

### Test updates
- `rename_data_reclaims_synthetic_inline_rollback_dir_after_commit`: Use `rename_data_owned` and await `tail_drain` for proper cleanup (the legacy `rename_data` API drops the handle).
- `rename_data_waits_for_tail_disk_after_write_quorum`: Explicitly test the serial path via `RUSTFS_PUT_RENAME_EARLY_ACK_ENABLE=false` since it's now non-default.

### HTTP logging improvement
- `rustfs/src/server/http.rs`: Add error source chain to the `is_user()` (Body stream) transport error log, so the underlying cause (disk read failure, RPC error, deleted object, etc.) is visible in logs. Addresses backlog#2005 suggestion #1.

## Context

- [backlog#2005](https://github.com/rustfs/backlog/issues/2005) — RC.3 error analysis
- [backlog#1792 comment-5384346238](https://github.com/rustfs/backlog/issues/1792#issuecomment-5384346238) — PUT regression root cause analysis
- [backlog#1792 comment-5384370938](https://github.com/rustfs/backlog/issues/1792#issuecomment-5384370938) — #5931 exclusion confirmation

## Rollback

Set `RUSTFS_PUT_RENAME_EARLY_ACK_ENABLE=false` to restore the serial path.


Co-Authored-By: heihutu <heihutu@gmail.com>
