### PR TITLE
fix(ecstore): remove stale operation guard drop

### DIFF
--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -3592,8 +3592,6 @@ impl ECStore {
             }
             return Err(err);
         }
-        drop(operation_guard);
-
         if let Some(canceler) = terminal_canceler.as_ref() {
             self.release_decommission_canceler_slot(idx, canceler).await;
         }


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Remove a stale `drop(operation_guard)` left in `decommission_cancel_with_owner`. The binding no longer exists, so lib-test builds fail with `E0425` before running any test.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- Exact-head `io_uring Integration (real)` passed; this compiles the `rustfs-ecstore` lib-test target that exposed the stale reference
- Confirmed the same compiler error before this fix in independent PR CI runs 32632173958 and 32632424407

The broader matrix remains delegated to CI because the shared development host is disk constrained.

## Impact

Restores `rustfs-ecstore` lib-test compilation. Runtime behavior is unchanged because the removed statement referenced no live guard; `_movement_guard` retains the intended lifecycle.

## Additional Notes

Two independent reviews confirmed the real movement guard still covers state persistence, canceler release, and epoch advance before being released ahead of remote reload.
