### PR TITLE
fix(ecstore): run metadata decommission before buckets

### DIFF
--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -7958,20 +7958,20 @@ mod pools_tests {
         resolve_decommission_terminal_mark_result, resolve_decommission_update_after_result,
         resolve_start_decommission_pool_meta_reload_result, rollback_start_decommission_pool_meta,
         run_decommission_buckets_bounded, run_decommission_listing_with_retry, run_decommission_listing_with_retry_and_drain,
-        run_decommission_side_effect, should_cleanup_decommission_source_entry, should_continue_decommission_queue,
-        should_count_decommission_version_complete, should_preserve_decommission_canceled_state,
-        should_reject_decommission_cancel_as_terminal, should_retry_decommission_cancel_reload,
-        should_retry_decommission_listing, should_skip_canceled_decommission_routine, spawn_decommission_index_cancelers,
-        split_decommission_buckets, take_and_cancel_decommission_canceler, take_decommission_canceler,
-        track_decommission_current_object, track_decommission_current_object_stage, update_decommission_for_operation,
-        validate_start_decommission_request, wait_decommission_listing_retry, wait_decommission_worker_drain,
-        with_decommission_entry_context,
+        run_decommission_phases, run_decommission_side_effect, should_cleanup_decommission_source_entry,
+        should_continue_decommission_queue, should_count_decommission_version_complete,
+        should_preserve_decommission_canceled_state, should_reject_decommission_cancel_as_terminal,
+        should_retry_decommission_cancel_reload, should_retry_decommission_listing, should_skip_canceled_decommission_routine,
+        spawn_decommission_index_cancelers, split_decommission_buckets, take_and_cancel_decommission_canceler,
+        take_decommission_canceler, track_decommission_current_object, track_decommission_current_object_stage,
+        update_decommission_for_operation, validate_start_decommission_request, wait_decommission_listing_retry,
+        wait_decommission_worker_drain, with_decommission_entry_context,
     };
     use crate::bucket::lifecycle::{
         DurableIlmRecordCheckpoint,
         bucket_lifecycle_ops::{ManualTransitionQueueSnapshot, ManualTransitionRunOptions},
         manual_transition_job::{ManualTransitionJobRecord, manual_transition_job_record_object_name},
-        run_decommission_phases, validate_durable_ilm_record,
+        validate_durable_ilm_record,
     };
     use crate::data_movement;
     use crate::disk::endpoint::Endpoint;

--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -1838,6 +1838,7 @@ where
     let limit = limit.max(1);
 
     for _ in 0..limit {
+        decommission_cancel_signal_result(rx.is_cancelled())?;
         let Some(bucket) = pending.next() else {
             break;
         };
@@ -1862,6 +1863,7 @@ where
             continue;
         };
 
+        decommission_cancel_signal_result(rx.is_cancelled())?;
         active.push(start_bucket(bucket, rx.clone()));
     }
 
@@ -8555,6 +8557,42 @@ mod pools_tests {
             ]
         );
         assert_eq!(events.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_decommission_metadata_completion_cancel_prevents_regular_launch() {
+        let rx = CancellationToken::new();
+        let regular_started = Arc::new(AtomicUsize::new(0));
+        let result = run_decommission_phases(
+            rx.clone(),
+            vec![DecomBucketInfo {
+                name: "regular".to_string(),
+                ..Default::default()
+            }],
+            vec![DecomBucketInfo {
+                name: crate::disk::RUSTFS_META_BUCKET.to_string(),
+                prefix: crate::config::com::CONFIG_PREFIX.to_string(),
+            }],
+            2,
+            {
+                let regular_started = Arc::clone(&regular_started);
+                move |bucket, rx| {
+                    let regular_started = Arc::clone(&regular_started);
+                    Box::pin(async move {
+                        if bucket.name == crate::disk::RUSTFS_META_BUCKET {
+                            rx.cancel();
+                        } else {
+                            regular_started.fetch_add(1, Ordering::SeqCst);
+                        }
+                        Ok(())
+                    })
+                }
+            },
+        )
+        .await;
+
+        assert!(matches!(result, Err(Error::OperationCanceled)));
+        assert_eq!(regular_started.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -1876,6 +1876,36 @@ where
     Ok(())
 }
 
+async fn run_decommission_phases<F>(
+    rx: CancellationToken,
+    regular_buckets: Vec<DecomBucketInfo>,
+    meta_buckets: Vec<DecomBucketInfo>,
+    bucket_concurrency: usize,
+    mut start_bucket: F,
+) -> Result<()>
+where
+    F: FnMut(DecomBucketInfo, CancellationToken) -> BoxFuture<'static, Result<()>>,
+{
+    decommission_cancel_signal_result(rx.is_cancelled())?;
+
+    for bucket in meta_buckets {
+        decommission_cancel_signal_result(rx.is_cancelled())?;
+        start_bucket(bucket, rx.clone()).await?;
+    }
+
+    decommission_cancel_signal_result(rx.is_cancelled())?;
+
+    if bucket_concurrency <= 1 {
+        for bucket in regular_buckets {
+            decommission_cancel_signal_result(rx.is_cancelled())?;
+            start_bucket(bucket, rx.clone()).await?;
+        }
+        return Ok(());
+    }
+
+    run_decommission_buckets_bounded(rx, regular_buckets, bucket_concurrency, start_bucket).await
+}
+
 #[cfg(test)]
 async fn wait_decommission_worker_drain(workers: &Semaphore, limit: usize) -> Result<()> {
     let permits = u32::try_from(limit)
@@ -5462,25 +5492,6 @@ impl ECStore {
         Ok(())
     }
 
-    async fn decommission_buckets_concurrently(
-        self: &Arc<Self>,
-        rx: CancellationToken,
-        idx: usize,
-        pool: Arc<Sets>,
-        buckets: Vec<DecomBucketInfo>,
-        limit: usize,
-        entry_budget: Arc<Semaphore>,
-    ) -> Result<()> {
-        let store = Arc::clone(self);
-        run_decommission_buckets_bounded(rx, buckets, limit, move |bucket, rx| {
-            let store = Arc::clone(&store);
-            let pool = pool.clone();
-            let entry_budget = entry_budget.clone();
-            Box::pin(async move { store.decommission_pending_bucket(rx, idx, pool, bucket, entry_budget).await })
-        })
-        .await
-    }
-
     #[tracing::instrument(skip(self, rx))]
     async fn decommission_in_background(
         self: &Arc<Self>,
@@ -5495,31 +5506,15 @@ impl ECStore {
             pool_meta.pending_buckets(idx)
         };
         let bucket_concurrency = decommission_bucket_concurrency_limit();
-        if bucket_concurrency <= 1 {
-            for bucket in pending {
-                self.decommission_pending_bucket(rx.clone(), idx, pool.clone(), bucket, entry_budget.clone())
-                    .await?;
-            }
-            return Ok(());
-        }
-
         let (regular_buckets, meta_buckets) = split_decommission_buckets(pending);
-        self.decommission_buckets_concurrently(
-            rx.clone(),
-            idx,
-            pool.clone(),
-            regular_buckets,
-            bucket_concurrency,
-            entry_budget.clone(),
-        )
-        .await?;
-
-        for bucket in meta_buckets {
-            self.decommission_pending_bucket(rx.clone(), idx, pool.clone(), bucket, entry_budget.clone())
-                .await?;
-        }
-
-        Ok(())
+        let store = Arc::clone(self);
+        run_decommission_phases(rx, regular_buckets, meta_buckets, bucket_concurrency, move |bucket, rx| {
+            let store = Arc::clone(&store);
+            let pool = pool.clone();
+            let entry_budget = entry_budget.clone();
+            Box::pin(async move { store.decommission_pending_bucket(rx, idx, pool, bucket, entry_budget).await })
+        })
+        .await
     }
 
     #[tracing::instrument(skip(self))]
@@ -7971,6 +7966,7 @@ mod pools_tests {
         bucket_lifecycle_ops::{ManualTransitionQueueSnapshot, ManualTransitionRunOptions},
         manual_transition_job::{ManualTransitionJobRecord, manual_transition_job_record_object_name},
         validate_durable_ilm_record,
+        run_decommission_phases,
     };
     use crate::data_movement;
     use crate::disk::endpoint::Endpoint;
@@ -7983,7 +7979,7 @@ mod pools_tests {
     use rustfs_filemeta::{MetaCacheEntries, MetadataResolutionParams};
     use rustfs_rio::Index;
     use std::sync::{
-        Arc,
+        Arc, Mutex as StdMutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     };
     use std::time::Duration as StdDuration;
@@ -8446,6 +8442,66 @@ mod pools_tests {
             DECOMMISSION_META_PREFIXES
         );
         assert!(!reconcile_decommission_meta_buckets(&mut meta, 0));
+    }
+
+    #[tokio::test]
+    async fn test_decommission_metadata_phase_precedes_regular_failure() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let err = run_decommission_phases(
+            CancellationToken::new(),
+            vec![
+                DecomBucketInfo {
+                    name: "regular-fails".to_string(),
+                    ..Default::default()
+                },
+                DecomBucketInfo {
+                    name: "regular-not-started".to_string(),
+                    ..Default::default()
+                },
+            ],
+            vec![
+                DecomBucketInfo {
+                    name: crate::disk::RUSTFS_META_BUCKET.to_string(),
+                    prefix: crate::config::com::CONFIG_PREFIX.to_string(),
+                },
+                DecomBucketInfo {
+                    name: crate::disk::RUSTFS_META_BUCKET.to_string(),
+                    prefix: crate::disk::BUCKET_META_PREFIX.to_string(),
+                },
+            ],
+            1,
+            {
+                let events = Arc::clone(&events);
+                move |bucket, _rx| {
+                    let events = Arc::clone(&events);
+                    Box::pin(async move {
+                        let event = if bucket.name == crate::disk::RUSTFS_META_BUCKET {
+                            format!("meta:{}", bucket.prefix)
+                        } else {
+                            format!("regular:{}", bucket.name)
+                        };
+                        events.lock().expect("phase event lock should not be poisoned").push(event);
+                        if bucket.name == "regular-fails" {
+                            Err(Error::SlowDown)
+                        } else {
+                            Ok(())
+                        }
+                    })
+                }
+            },
+        )
+        .await
+        .expect_err("regular failure should remain fatal after metadata completes");
+
+        assert!(matches!(err, Error::SlowDown));
+        assert_eq!(
+            *events.lock().expect("phase event lock should not be poisoned"),
+            vec![
+                format!("meta:{}", crate::config::com::CONFIG_PREFIX),
+                format!("meta:{}", crate::disk::BUCKET_META_PREFIX),
+                "regular:regular-fails".to_string(),
+            ]
+        );
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -1838,7 +1838,9 @@ where
     let limit = limit.max(1);
 
     for _ in 0..limit {
-        decommission_cancel_signal_result(rx.is_cancelled())?;
+        if rx.is_cancelled() {
+            break;
+        }
         let Some(bucket) = pending.next() else {
             break;
         };
@@ -1863,11 +1865,13 @@ where
             continue;
         };
 
-        decommission_cancel_signal_result(rx.is_cancelled())?;
+        if rx.is_cancelled() {
+            continue;
+        }
         active.push(start_bucket(bucket, rx.clone()));
     }
 
-    if first_err.is_none() && rx.is_cancelled() && pending.len() > 0 {
+    if first_err.is_none() && rx.is_cancelled() {
         return decommission_cancel_signal_result(true);
     }
 

--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -7965,8 +7965,7 @@ mod pools_tests {
         DurableIlmRecordCheckpoint,
         bucket_lifecycle_ops::{ManualTransitionQueueSnapshot, ManualTransitionRunOptions},
         manual_transition_job::{ManualTransitionJobRecord, manual_transition_job_record_object_name},
-        validate_durable_ilm_record,
-        run_decommission_phases,
+        run_decommission_phases, validate_durable_ilm_record,
     };
     use crate::data_movement;
     use crate::disk::endpoint::Endpoint;
@@ -8502,6 +8501,129 @@ mod pools_tests {
                 "regular:regular-fails".to_string(),
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn test_decommission_metadata_barrier_holds_with_regular_concurrency() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        run_decommission_phases(
+            CancellationToken::new(),
+            vec![
+                DecomBucketInfo {
+                    name: "regular-a".to_string(),
+                    ..Default::default()
+                },
+                DecomBucketInfo {
+                    name: "regular-b".to_string(),
+                    ..Default::default()
+                },
+            ],
+            vec![
+                DecomBucketInfo {
+                    name: crate::disk::RUSTFS_META_BUCKET.to_string(),
+                    prefix: crate::config::com::CONFIG_PREFIX.to_string(),
+                },
+                DecomBucketInfo {
+                    name: crate::disk::RUSTFS_META_BUCKET.to_string(),
+                    prefix: crate::disk::BUCKET_META_PREFIX.to_string(),
+                },
+            ],
+            2,
+            {
+                let events = Arc::clone(&events);
+                move |bucket, _rx| {
+                    let events = Arc::clone(&events);
+                    Box::pin(async move {
+                        events
+                            .lock()
+                            .expect("phase event lock should not be poisoned")
+                            .push(bucket.name);
+                        Ok(())
+                    })
+                }
+            },
+        )
+        .await
+        .expect("metadata barrier should complete before regular workers");
+
+        let events = events.lock().expect("phase event lock should not be poisoned");
+        assert_eq!(
+            &events[..2],
+            &[
+                crate::disk::RUSTFS_META_BUCKET.to_string(),
+                crate::disk::RUSTFS_META_BUCKET.to_string()
+            ]
+        );
+        assert_eq!(events.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_decommission_phase_gate_honors_cancellation_before_metadata() {
+        let rx = CancellationToken::new();
+        rx.cancel();
+        let started = Arc::new(AtomicUsize::new(0));
+        let err = run_decommission_phases(
+            rx,
+            vec![DecomBucketInfo {
+                name: "regular".to_string(),
+                ..Default::default()
+            }],
+            vec![DecomBucketInfo {
+                name: crate::disk::RUSTFS_META_BUCKET.to_string(),
+                prefix: crate::config::com::CONFIG_PREFIX.to_string(),
+            }],
+            2,
+            {
+                let started = Arc::clone(&started);
+                move |_bucket, _rx| {
+                    let started = Arc::clone(&started);
+                    Box::pin(async move {
+                        started.fetch_add(1, Ordering::SeqCst);
+                        Ok(())
+                    })
+                }
+            },
+        )
+        .await
+        .expect_err("canceled phase gate should stop before metadata");
+
+        assert!(matches!(err, Error::OperationCanceled));
+        assert_eq!(started.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_decommission_metadata_failure_blocks_regular_phase() {
+        let regular_started = Arc::new(AtomicUsize::new(0));
+        let err = run_decommission_phases(
+            CancellationToken::new(),
+            vec![DecomBucketInfo {
+                name: "regular".to_string(),
+                ..Default::default()
+            }],
+            vec![DecomBucketInfo {
+                name: crate::disk::RUSTFS_META_BUCKET.to_string(),
+                prefix: crate::config::com::CONFIG_PREFIX.to_string(),
+            }],
+            2,
+            {
+                let regular_started = Arc::clone(&regular_started);
+                move |bucket, _rx| {
+                    let regular_started = Arc::clone(&regular_started);
+                    Box::pin(async move {
+                        if bucket.name != crate::disk::RUSTFS_META_BUCKET {
+                            regular_started.fetch_add(1, Ordering::SeqCst);
+                            return Ok(());
+                        }
+                        Err(Error::SlowDown)
+                    })
+                }
+            },
+        )
+        .await
+        .expect_err("metadata failure must remain fatal");
+
+        assert!(matches!(err, Error::SlowDown));
+        assert_eq!(regular_started.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#1941. Supersedes the conflicting duplicate implementation in #6410.

## Summary of Changes

Run decommission system-metadata buckets (`.rustfs.sys/config`, `.rustfs.sys/buckets`, and existing metadata prefixes) in a dedicated serial phase before regular buckets. Preserve the existing bounded regular scheduler, fail-fast error propagation, cancellation semantics, persisted queue format, and terminal-state handling. Cancellation now stops new launches while draining already-started bucket workers. Deterministic tests cover metadata ordering, metadata failure, concurrent regular scheduling, post-metadata cancellation, and bounded-worker cancellation.

## Verification

- `cargo fmt --all --check` (passed)
- `git diff --check` (passed)
- `cargo test -p rustfs-ecstore --lib test_decommission_metadata_ -- --nocapture` (4 passed; run against the rebased head with the unrelated upstream `drop(operation_guard)` typo temporarily removed for compilation)
- `cargo test -p rustfs-ecstore --lib test_run_decommission_buckets_bounded_ -- --nocapture` (3 passed; same upstream typo isolation)
- `cargo clippy -p rustfs-ecstore --lib -- -D warnings` (passed before rebase; latest main currently has an unrelated undefined `operation_guard` in `crates/ecstore/src/core/pools.rs:3631`)
- `make pre-pr` (guard checks passed; clippy stopped on unchanged baseline findings in `crates/scanner/src/scanner_io/io_cache.rs:257`, `crates/heal/src/heal/manager.rs:1407`, and `crates/scanner/src/scanner_io/publish_gate_tests.rs:163`)

## Impact

No on-disk schema, wire protocol, or public S3 behavior changes. Metadata decommission work is no longer skipped when a regular bucket fails; regular bucket concurrency remains bounded by the existing setting.

## Additional Notes

High-risk adversarial review verdicts: correctness — attacked metadata ordering, fatal/cancel paths, and queue replay; no break found. Simplicity — phase helper is the smallest local boundary and removes the obsolete wrapper; no break found. Security — no new trust boundary; no break found. Concurrency/durability — cancellation stops new launches and drains active workers; no break found. Compatibility — persisted queue and terminal semantics are unchanged; no break found. Performance — metadata remains serial by design and regular fan-out retains its bound; no break found. Test coverage — focused tests fail on phase inversion, fatal bypass, cancellation launch, and scheduler regressions; no break found.

The current upstream main contains an unrelated compile error (`drop(operation_guard)` with no binding) and pre-existing strict-Clippy failures; these are recorded above and are outside this one-file task diff.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
