### PR TITLE
fix(server): adapt quick-xml name handling

### DIFF
--- a/rustfs/src/admin/handlers/site_replication.rs
+++ b/rustfs/src/admin/handlers/site_replication.rs
@@ -8176,7 +8176,7 @@ fn is_zero_rule_lifecycle_tombstone(raw: &[u8]) -> bool {
         match reader.read_event() {
             Ok(quick_xml::events::Event::Start(element)) => {
                 if depth == 0 {
-                    if seen_root || closed_root || element.name().as_ref() != b"LifecycleConfiguration" {
+                    if seen_root || closed_root || element.name().as_ref() != "LifecycleConfiguration" {
                         break false;
                     }
                     seen_root = true;
@@ -8185,7 +8185,7 @@ fn is_zero_rule_lifecycle_tombstone(raw: &[u8]) -> bool {
             }
             Ok(quick_xml::events::Event::Empty(element)) => {
                 if depth == 0 {
-                    if seen_root || closed_root || element.name().as_ref() != b"LifecycleConfiguration" {
+                    if seen_root || closed_root || element.name().as_ref() != "LifecycleConfiguration" {
                         break false;
                     }
                     seen_root = true;
@@ -8208,7 +8208,9 @@ fn is_zero_rule_lifecycle_tombstone(raw: &[u8]) -> bool {
                 seen_declaration = true;
             }
             Ok(quick_xml::events::Event::DocType(_)) => break false,
-            Ok(quick_xml::events::Event::Text(text)) if depth == 0 && !text.iter().all(u8::is_ascii_whitespace) => {
+            Ok(quick_xml::events::Event::Text(text))
+                if depth == 0 && !text.as_ref().bytes().all(|byte| byte.is_ascii_whitespace()) =>
+            {
                 break false;
             }
             Ok(quick_xml::events::Event::Text(_)) => {}

--- a/rustfs/src/server/layer.rs
+++ b/rustfs/src/server/layer.rs
@@ -1653,13 +1653,8 @@ fn add_sts_response_metadata(xml: &str, request_id: &str) -> Option<Bytes> {
                     if !is_sts_success_response_tag(element.local_name().as_ref()) {
                         return None;
                     }
-                    root_prefix = element
-                        .name()
-                        .prefix()
-                        .map(|prefix| std::str::from_utf8(prefix.as_ref()).map(str::to_owned))
-                        .transpose()
-                        .ok()?;
-                } else if depth == 1 && element.local_name().as_ref() == STS_RESPONSE_METADATA_TAG.as_bytes() {
+                    root_prefix = element.name().prefix().map(|prefix| prefix.as_ref().to_owned());
+                } else if depth == 1 && element.local_name().as_ref() == STS_RESPONSE_METADATA_TAG {
                     return None;
                 }
                 depth += 1;
@@ -1668,7 +1663,7 @@ fn add_sts_response_metadata(xml: &str, request_id: &str) -> Option<Bytes> {
                 if depth == 0 {
                     return None;
                 }
-                if depth == 1 && element.local_name().as_ref() == STS_RESPONSE_METADATA_TAG.as_bytes() {
+                if depth == 1 && element.local_name().as_ref() == STS_RESPONSE_METADATA_TAG {
                     return None;
                 }
             }
@@ -1702,8 +1697,8 @@ fn add_sts_response_metadata(xml: &str, request_id: &str) -> Option<Bytes> {
     }
 }
 
-fn is_sts_success_response_tag(tag: &[u8]) -> bool {
-    STS_SUCCESS_RESPONSE_TAGS.iter().any(|candidate| candidate.as_bytes() == tag)
+fn is_sts_success_response_tag(tag: &str) -> bool {
+    STS_SUCCESS_RESPONSE_TAGS.contains(&tag)
 }
 
 fn wrap_sts_error_response(xml: &str, status: StatusCode, request_id: &str) -> String {


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Adapts two quick-xml parser call sites to the current name/text APIs. XML element names and prefixes are now handled as strings instead of byte slices in the STS metadata wrapper and site-replication lifecycle tombstone parser, preserving the existing validation logic while fixing current-main compile errors.

## Verification
- `rustfmt --edition 2024 --check rustfs/src/admin/handlers/site_replication.rs rustfs/src/server/layer.rs`
- `git diff --check origin/main...HEAD`
- Remote Linux build: `cargo build --profile profiling --bin rustfs`

## Impact
No user-facing behavior change is intended. This is a compile fix for quick-xml name/text type handling in existing XML validation and response metadata paths.

## Additional Notes
Local Cargo commands are currently blocked by a user-level Cargo configuration parse error, so the full RustFS binary build was verified on the Linux validation host instead.
