### PR TITLE
fix(ci): restore workspace lint compatibility

### DIFF
--- a/crates/heal/src/heal/manager.rs
+++ b/crates/heal/src/heal/manager.rs
@@ -117,13 +117,13 @@ async fn pause_duplicate_admission_after_active_lock(request_id: &str) {
 type WorkloadSnapshotProviderRef = Arc<dyn WorkloadAdmissionSnapshotProvider + Send + Sync>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct MrfRepairNoticeTarget {
-    bucket: Arc<str>,
-    object: Arc<str>,
-    version_id: Option<[u8; 16]>,
-    kind: rustfs_common::mrf_channel::MrfKind,
-    scope: Option<rustfs_common::mrf_channel::MrfScope>,
-    lease: Option<rustfs_common::mrf_channel::MrfIngressLease>,
+pub(super) struct MrfRepairNoticeTarget {
+    pub(super) bucket: Arc<str>,
+    pub(super) object: Arc<str>,
+    pub(super) version_id: Option<[u8; 16]>,
+    pub(super) kind: rustfs_common::mrf_channel::MrfKind,
+    pub(super) scope: Option<rustfs_common::mrf_channel::MrfScope>,
+    pub(super) lease: Option<rustfs_common::mrf_channel::MrfIngressLease>,
 }
 
 #[derive(Debug, Clone)]
@@ -1400,33 +1400,27 @@ impl HealManager {
             HealType::ECDecode { .. } => rustfs_common::mrf_channel::MrfKind::DecodeFailure,
             _ => rustfs_common::mrf_channel::MrfKind::PartialWrite,
         };
-        self.submit_mrf_heal_request_with_receipt_and_identity(request, bucket, object, version_id, kind, None, None)
-            .await
+        self.submit_mrf_heal_request_with_receipt_and_identity(
+            request,
+            MrfRepairNoticeTarget {
+                bucket,
+                object,
+                version_id,
+                kind,
+                scope: None,
+                lease: None,
+            },
+        )
+        .await
     }
 
     pub(crate) async fn submit_mrf_heal_request_with_receipt_and_identity(
         &self,
         request: HealRequest,
-        bucket: Arc<str>,
-        object: Arc<str>,
-        version_id: Option<[u8; 16]>,
-        kind: rustfs_common::mrf_channel::MrfKind,
-        scope: Option<rustfs_common::mrf_channel::MrfScope>,
-        lease: Option<rustfs_common::mrf_channel::MrfIngressLease>,
+        mrf_notice_target: MrfRepairNoticeTarget,
     ) -> Result<HealAdmissionReceipt> {
-        self.submit_heal_request_with_receipt_alias_and_mrf_notice(
-            request,
-            true,
-            Some(MrfRepairNoticeTarget {
-                bucket,
-                object,
-                version_id,
-                kind,
-                scope,
-                lease,
-            }),
-        )
-        .await
+        self.submit_heal_request_with_receipt_alias_and_mrf_notice(request, true, Some(mrf_notice_target))
+            .await
     }
 
     async fn submit_heal_request_with_receipt_alias_and_mrf_notice(

--- a/crates/heal/src/heal/manager.rs
+++ b/crates/heal/src/heal/manager.rs
@@ -1414,7 +1414,7 @@ impl HealManager {
         .await
     }
 
-    pub(crate) async fn submit_mrf_heal_request_with_receipt_and_identity(
+    pub(super) async fn submit_mrf_heal_request_with_receipt_and_identity(
         &self,
         request: HealRequest,
         mrf_notice_target: MrfRepairNoticeTarget,

--- a/crates/heal/src/heal/mrf_queue.rs
+++ b/crates/heal/src/heal/mrf_queue.rs
@@ -33,7 +33,7 @@
 //! than waiting for the failed-object TTL to re-scan the path.
 
 use super::{DiskStore, HealDiskExt as _, local_disk_map_read};
-use crate::heal::manager::HealManager;
+use crate::heal::manager::{HealManager, MrfRepairNoticeTarget};
 use metrics::{counter, gauge};
 use rustfs_common::heal_channel::{HealAdmissionDropReason, HealAdmissionResult};
 use rustfs_common::mrf_channel::{MRF_MAX_ATTEMPTS, MrfIntent};
@@ -491,12 +491,14 @@ async fn submit_mrf_heal_request(manager: &HealManager, intent: &MrfIntent) -> c
     let receipt = manager
         .submit_mrf_heal_request_with_receipt_and_identity(
             build_heal_request(intent),
-            intent.bucket.clone(),
-            intent.object.clone(),
-            intent.version_id,
-            intent.kind,
-            intent.scope,
-            intent.lease,
+            MrfRepairNoticeTarget {
+                bucket: intent.bucket.clone(),
+                object: intent.object.clone(),
+                version_id: intent.version_id,
+                kind: intent.kind,
+                scope: intent.scope,
+                lease: intent.lease,
+            },
         )
         .await?;
     Ok(receipt.result)

--- a/crates/protocols/src/sftp/server.rs
+++ b/crates/protocols/src/sftp/server.rs
@@ -127,6 +127,7 @@ const SFTP_COMPRESSION: &[russh::compression::Name] = &[russh::compression::NONE
 fn build_preferred() -> russh::Preferred {
     russh::Preferred {
         kex: Cow::Borrowed(SFTP_KEX),
+        host_key_certificates: Cow::Borrowed(&[]),
         key: Cow::Borrowed(SFTP_HOST_KEY_ALGORITHMS),
         cipher: Cow::Borrowed(SFTP_CIPHERS),
         mac: Cow::Borrowed(SFTP_MACS),

--- a/crates/scanner/src/scanner_io/publish_gate_tests.rs
+++ b/crates/scanner/src/scanner_io/publish_gate_tests.rs
@@ -167,7 +167,7 @@ fn stale_quota_uses_complete_baseline_plus_positive_deltas() {
     let (observed, _) = observational_data_usage_info(&[current], &expected, &all_buckets, &[], TEST_PLAN_DIGEST, 8, 3)
         .expect("complete set data is a valid observational baseline");
     assert_eq!(observed.objects_total_size, 30);
-    assert_eq!(observed.usage_snapshot_set_states[0].complete, true);
+    assert!(observed.usage_snapshot_set_states[0].complete);
 }
 
 #[test]

--- a/rustfs/src/admin/handlers/cluster_snapshot.rs
+++ b/rustfs/src/admin/handlers/cluster_snapshot.rs
@@ -1358,7 +1358,7 @@ mod tests {
         assert_eq!(component.last_usage_save_result, "success");
         assert_eq!(component.last_success_unix_secs, Some(450));
 
-        let mut legacy_snapshot = snapshot.clone();
+        let mut legacy_snapshot = snapshot;
         legacy_snapshot.usage_freshness.last_durable_success_unix_secs = 0;
         let legacy_component = super::summarize_usage_freshness(&legacy_snapshot);
         assert_eq!(legacy_component.last_success_unix_secs, Some(456));

--- a/rustfs/src/connect/inventory.rs
+++ b/rustfs/src/connect/inventory.rs
@@ -659,6 +659,10 @@ mod tests {
 
     use super::*;
 
+    fn create_directory(path: &Path) -> io::Result<()> {
+        fs::create_dir(path)
+    }
+
     #[test]
     fn inventory_directory_creation_is_synced_before_state_can_be_committed() {
         let temp = tempfile::tempdir().expect("tempdir");
@@ -699,7 +703,7 @@ mod tests {
         fs::create_dir(&root).expect("state root");
         let directory = root.join("inventory");
         let state = directory.join("state.json");
-        let error = prepare_inventory_directory_with(&directory, fs::create_dir, |path| {
+        let error = prepare_inventory_directory_with(&directory, create_directory, |path| {
             if path == directory {
                 Err(io::Error::other("injected leaf sync failure"))
             } else {
@@ -710,7 +714,7 @@ mod tests {
         assert!(matches!(error, InventoryError::StateIo { path, .. } if path == directory));
         assert!(!state.exists());
 
-        let error = prepare_inventory_directory_with(&directory, fs::create_dir, |path| {
+        let error = prepare_inventory_directory_with(&directory, create_directory, |path| {
             if path == root {
                 Err(io::Error::other("injected parent sync failure"))
             } else {
@@ -722,7 +726,7 @@ mod tests {
         assert!(!state.exists());
 
         let mut synced = Vec::new();
-        prepare_inventory_directory_with(&directory, fs::create_dir, |path| {
+        prepare_inventory_directory_with(&directory, create_directory, |path| {
             synced.push(path.to_path_buf());
             Ok(())
         })
@@ -737,7 +741,7 @@ mod tests {
         let directory = root.join("inventory");
 
         assert!(matches!(
-            prepare_inventory_directory_with(&directory, fs::create_dir, |_| Ok(())),
+            prepare_inventory_directory_with(&directory, create_directory, |_| Ok(())),
             Err(InventoryError::StateIo { path, .. }) if path == root
         ));
         assert!(!directory.exists());

--- a/rustfs/src/connect/offline/redaction.rs
+++ b/rustfs/src/connect/offline/redaction.rs
@@ -173,7 +173,6 @@ pub enum RedactionError {
     NotRepresentable,
 }
 
-#[must_use]
 pub(super) fn redact(source: RedactionSource, document: &Map<String, Value>) -> Result<RedactionResult, RedactionError> {
     let encoded = serde_json::to_vec(document).map_err(|_| RedactionError::NotRepresentable)?;
     if encoded.len() > MAX_INPUT_BYTES {

--- a/rustfs/tests/connect_registration_bootstrap.rs
+++ b/rustfs/tests/connect_registration_bootstrap.rs
@@ -399,13 +399,14 @@ async fn response_loss_reuses_the_pending_request_and_existing_credential_is_ide
         .await
         .expect("retry registration");
     assert_eq!(registered.device_uid, DEVICE_UID);
-    let requests = flaky_server.seen.lock().expect("seen lock");
-    assert_eq!(requests.len(), 4);
-    for request in &requests[1..] {
-        assert_eq!(request["requestId"], requests[0]["requestId"]);
-        assert_eq!(request["certificateRequest"], requests[0]["certificateRequest"]);
+    {
+        let requests = flaky_server.seen.lock().expect("seen lock");
+        assert_eq!(requests.len(), 4);
+        for request in &requests[1..] {
+            assert_eq!(request["requestId"], requests[0]["requestId"]);
+            assert_eq!(request["certificateRequest"], requests[0]["certificateRequest"]);
+        }
     }
-    drop(requests);
 
     let idle = server(&state, vec![]).await;
     let idempotent = register_from_protected_input(&idle.endpoint, &root, &state, Some(&token))

--- a/rustfs/tests/connect_registration_bootstrap.rs
+++ b/rustfs/tests/connect_registration_bootstrap.rs
@@ -375,7 +375,7 @@ async fn production_command_never_echoes_a_remote_reason() {
 async fn response_loss_reuses_the_pending_request_and_existing_credential_is_idempotent() {
     let temp = secure_tempdir();
     let state = temp.path().join("state");
-    let server = server(
+    let flaky_server = server(
         &state,
         vec![
             Reply::DropConnection,
@@ -385,21 +385,21 @@ async fn response_loss_reuses_the_pending_request_and_existing_credential_is_ide
         ],
     )
     .await;
-    let (root, token) = prepare_inputs(&temp, &server.root_pem);
+    let (root, token) = prepare_inputs(&temp, &flaky_server.root_pem);
 
-    while server.seen.lock().expect("seen lock").len() < 3 {
-        let error = register_from_protected_input(&server.endpoint, &root, &state, Some(&token))
+    while flaky_server.seen.lock().expect("seen lock").len() < 3 {
+        let error = register_from_protected_input(&flaky_server.endpoint, &root, &state, Some(&token))
             .await
             .expect_err("lost response must leave a retryable failure");
         assert!(!error.to_string().contains(TOKEN_SECRET));
         assert!(state.join("credential/registration.pending.json").is_file());
     }
 
-    let registered = register_from_protected_input(&server.endpoint, &root, &state, Some(&token))
+    let registered = register_from_protected_input(&flaky_server.endpoint, &root, &state, Some(&token))
         .await
         .expect("retry registration");
     assert_eq!(registered.device_uid, DEVICE_UID);
-    let requests = server.seen.lock().expect("seen lock");
+    let requests = flaky_server.seen.lock().expect("seen lock");
     assert_eq!(requests.len(), 4);
     for request in &requests[1..] {
         assert_eq!(request["requestId"], requests[0]["requestId"]);

--- a/rustfs/tests/connect_registration_bootstrap.rs
+++ b/rustfs/tests/connect_registration_bootstrap.rs
@@ -158,6 +158,15 @@ impl Drop for TestServer {
     }
 }
 
+fn assert_reused_pending_requests(server: &TestServer) {
+    let requests = server.seen.lock().expect("seen lock");
+    assert_eq!(requests.len(), 4);
+    for request in &requests[1..] {
+        assert_eq!(request["requestId"], requests[0]["requestId"]);
+        assert_eq!(request["certificateRequest"], requests[0]["certificateRequest"]);
+    }
+}
+
 async fn server(state_directory: &std::path::Path, replies: Vec<Reply>) -> TestServer {
     let pki = Arc::new(TestPki::new());
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind test server");
@@ -399,14 +408,7 @@ async fn response_loss_reuses_the_pending_request_and_existing_credential_is_ide
         .await
         .expect("retry registration");
     assert_eq!(registered.device_uid, DEVICE_UID);
-    {
-        let requests = flaky_server.seen.lock().expect("seen lock");
-        assert_eq!(requests.len(), 4);
-        for request in &requests[1..] {
-            assert_eq!(request["requestId"], requests[0]["requestId"]);
-            assert_eq!(request["certificateRequest"], requests[0]["certificateRequest"]);
-        }
-    }
+    assert_reused_pending_requests(&flaky_server);
 
     let idle = server(&state, vec![]).await;
     let idempotent = register_from_protected_input(&idle.endpoint, &root, &state, Some(&token))


### PR DESCRIPTION
Fixes eight workspace lint and compile regressions exposed on main: groups the MRF repair-notice target fields, uses the idiomatic scanner boolean assertion, initializes russh 0.63 client-only host-key certificate preferences as empty for the SFTP server, removes a redundant cluster-snapshot clone, avoids shadowing the registration server test helper, scopes its request lock before later awaits, gives inventory tests a concrete directory-creation function, and removes a redundant must-use attribute. No product behavior change is intended. Verification: formatting and diff checks passed locally; CI is the full workspace gate.