### PR TITLE
fix(ci): restore main branch checks

### DIFF
--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -7363,7 +7363,7 @@ impl ECStore {
         let buckets = self.get_buckets_to_decommission().await?;
         let pool = self.pools[idx].clone();
         self.ensure_decommission_multipart_uploads_drained(idx, pool.as_ref(), &buckets)
-        .await
+            .await
     }
     #[cfg(test)]
     pub(crate) async fn check_after_decommission_for_test(self: &Arc<Self>, idx: usize) -> Result<()> {

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -183,6 +183,7 @@ subtle = { workspace = true, optional = true }
 socket2 = { workspace = true, optional = true, features = ["all"] }
 
 [dev-dependencies]
+http = { workspace = true }
 tempfile = { workspace = true }
 proptest = "1"
 rustfs-test-utils = { workspace = true }


### PR DESCRIPTION
## Related Issues

rustfs/backlog#1897

## Summary of Changes

- Declare `http` as a protocols dev dependency so the SFTP-only lib test target can compile its shared dummy storage.
- Apply the missing rustfmt indentation in the decommission drain path.

## Verification

- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `CARGO_INCREMENTAL=0 cargo clippy -p rustfs-protocols --all-targets --features sftp -- -D warnings`
- `cargo test -p rustfs-protocols --lib --features sftp` (238 passed)

## Impact

Build and test configuration only. Runtime behavior is unchanged.

## Additional Notes

These were the remaining main-branch failures after the broader lint compatibility fix merged.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
