### PR TITLE
test(scanner): repair post-fence fixtures

### DIFF
--- a/crates/scanner/src/scanner/tests.rs
+++ b/crates/scanner/src/scanner/tests.rs
@@ -69,6 +69,14 @@ async fn setup_scanner_cycle_store() -> (tempfile::TempDir, Arc<ECStore>) {
     .await
     .expect("scanner cycle test ECStore should initialize");
     init_bucket_metadata_sys_for_scanner_tests(store.clone()).await;
+    save_config(
+        store.clone(),
+        DATA_USAGE_OBJ_NAME_PATH.as_str(),
+        serde_json::to_vec(&complete_usage_with_bucket_count(Some(std::time::SystemTime::UNIX_EPOCH), 0))
+            .expect("scanner cycle usage baseline should encode"),
+    )
+    .await
+    .expect("scanner cycle usage baseline should persist");
 
     (temp_dir, store)
 }

--- a/crates/scanner/src/scanner_folder/tests.rs
+++ b/crates/scanner/src/scanner_folder/tests.rs
@@ -425,7 +425,9 @@ async fn malformed_size_reconciliation_replays_after_restart() {
     summary.record_size_reconciliation(entry.clone());
     summary.record_reconciliation_scope("b", "object");
     scanner.apply_size_reconciliation(&summary);
+    scanner.finish_size_reconciliation_batch();
     scanner.apply_size_reconciliation(&summary);
+    scanner.finish_size_reconciliation_batch();
 
     assert_eq!(scanner.new_cache.info.size_reconciliation.len(), 1);
     assert_eq!(scanner.update_cache.info.size_reconciliation.len(), 1);
@@ -440,6 +442,7 @@ async fn malformed_size_reconciliation_replays_after_restart() {
     let mut resolved = SizeSummary::default();
     resolved.record_reconciliation_scope("b", "object");
     scanner.apply_size_reconciliation(&resolved);
+    scanner.finish_size_reconciliation_batch();
     assert!(scanner.new_cache.info.size_reconciliation.is_empty());
     assert!(scanner.update_cache.info.size_reconciliation.is_empty());
 }
@@ -453,18 +456,20 @@ async fn malformed_size_reconciliation_clears_bounded_long_object_scope() {
     let entry = SizeReconciliationEntry {
         key: "long-object-key".to_string(),
         bucket: "b".to_string(),
-        object: bounded_object,
+        object: bounded_object.clone(),
         reason: "invalid_declared_size".to_string(),
         ..Default::default()
     };
     let mut summary = SizeSummary::default();
     summary.record_size_reconciliation(entry);
     scanner.apply_size_reconciliation(&summary);
+    scanner.finish_size_reconciliation_batch();
     assert_eq!(scanner.new_cache.info.size_reconciliation.len(), 1);
 
     let mut resolved = SizeSummary::default();
-    resolved.record_reconciliation_scope("b", &long_object);
+    resolved.record_reconciliation_scope("b", &bounded_object);
     scanner.apply_size_reconciliation(&resolved);
+    scanner.finish_size_reconciliation_batch();
     assert!(scanner.new_cache.info.size_reconciliation.is_empty());
 }
 

--- a/crates/scanner/src/scanner_io/tests.rs
+++ b/crates/scanner/src/scanner_io/tests.rs
@@ -151,8 +151,8 @@ async fn scanner_set_cache_admission_tracks_owner_snapshot_and_fails_closed() {
     let set = store.pools[0].disk_set[0].clone();
 
     assert!(
-        set.scanner_data_usage_publication_admission_guard().await.is_none(),
-        "a set must not publish before the owner has refreshed its movement snapshot"
+        set.scanner_data_usage_publication_admission_guard().await.is_some(),
+        "a set should refresh the idle owner snapshot before its first publication"
     );
     assert!(!store.scanner_data_usage_publication_blocked().await);
     assert!(


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1897.

## Summary

- Seed an authoritative usage baseline in scanner cycle fixtures.
- Finish reconciliation batches before asserting persisted state.
- Keep the set-level admission test aligned with automatic owner refresh without removing its fail-closed checks.

## Verification

- Fresh nextest runs on #6466 and #6471 exposed the same deterministic scanner fixture failures.
- `rustfmt --edition 2024 --check` on all three changed files.
- `git diff --check origin/main...HEAD`.

No local Cargo run was performed after the disk gate. Fresh CI currently reaches Quick Checks, then the feature lanes stop at the unrelated main dead-code issue fixed by #6466/#6476 before these tests can execute.