### PR TITLE
test(e2e): require 404 absence oracles

### DIFF
--- a/crates/e2e_test/src/checksum_upload_test.rs
+++ b/crates/e2e_test/src/checksum_upload_test.rs
@@ -199,8 +199,18 @@ mod tests {
         );
 
         // And the object must not have been stored.
-        let head = client.head_object().bucket(bucket).key(key).send().await;
-        assert!(head.is_err(), "Object must not exist after a rejected mismatched-checksum PutObject");
+        let error = client
+            .head_object()
+            .bucket(bucket)
+            .key(key)
+            .send()
+            .await
+            .expect_err("Object must not exist after a rejected mismatched-checksum PutObject");
+        assert_eq!(
+            error.raw_response().map(|response| response.status().as_u16()),
+            Some(404),
+            "Rejected mismatched-checksum PutObject absence probe must return HTTP 404, got {error:?}"
+        );
         info!("PASSED: PutObject rejects mismatched SHA256 and stores nothing");
     }
 
@@ -552,8 +562,18 @@ mod tests {
                 msg.contains("BadDigest") || msg.to_lowercase().contains("digest") || msg.to_lowercase().contains("checksum"),
                 "{header}: expected a BadDigest/checksum error, got: {msg}"
             );
-            let head = client.head_object().bucket(bucket).key(&bad_key).send().await;
-            assert!(head.is_err(), "{header}: nothing must be stored after a rejected PutObject");
+            let error = client
+                .head_object()
+                .bucket(bucket)
+                .key(&bad_key)
+                .send()
+                .await
+                .expect_err("nothing must be stored after a rejected PutObject");
+            assert_eq!(
+                error.raw_response().map(|response| response.status().as_u16()),
+                Some(404),
+                "{header}: rejected PutObject absence probe must return HTTP 404, got {error:?}"
+            );
 
             info!("PASSED additional-checksum verify-on-write: {header}");
         }

--- a/crates/e2e_test/src/delete_regression_test.rs
+++ b/crates/e2e_test/src/delete_regression_test.rs
@@ -117,9 +117,18 @@ mod tests {
         );
 
         // Verify HEAD returns 404
-        let head = client.head_object().bucket(bucket).key("to-delete.txt").send().await;
-
-        assert!(head.is_err(), "RT-05 FAIL: HEAD on deleted object should return error, got success");
+        let error = client
+            .head_object()
+            .bucket(bucket)
+            .key("to-delete.txt")
+            .send()
+            .await
+            .expect_err("RT-05 FAIL: HEAD on deleted object should return 404, got success");
+        assert_eq!(
+            error.raw_response().map(|response| response.status().as_u16()),
+            Some(404),
+            "RT-05 FAIL: HEAD on deleted object must return HTTP 404, got {error:?}"
+        );
 
         info!("RT-05 PASS: delete correctly removes object from LIST and HEAD");
         Ok(())
@@ -414,9 +423,18 @@ mod tests {
 
         // All HEAD requests should return 404
         for key in &keys {
-            let head = client.head_object().bucket(bucket).key(*key).send().await;
-
-            assert!(head.is_err(), "RT-05f FAIL: HEAD on deleted key '{key}' should return error");
+            let error = client
+                .head_object()
+                .bucket(bucket)
+                .key(*key)
+                .send()
+                .await
+                .expect_err("RT-05f FAIL: HEAD on deleted key should return 404, got success");
+            assert_eq!(
+                error.raw_response().map(|response| response.status().as_u16()),
+                Some(404),
+                "RT-05f FAIL: HEAD on deleted key '{key}' must return HTTP 404, got {error:?}"
+            );
         }
 
         // LIST should be empty

--- a/crates/e2e_test/src/leading_slash_key_test.rs
+++ b/crates/e2e_test/src/leading_slash_key_test.rs
@@ -131,8 +131,18 @@ mod tests {
 
         // DELETE through the raw key removes the normalized object.
         client.delete_object().bucket(bucket).key("//keyname").send().await?;
-        let result = client.get_object().bucket(bucket).key("keyname").send().await;
-        assert!(result.is_err(), "object must be gone after DELETE with raw key");
+        let error = client
+            .get_object()
+            .bucket(bucket)
+            .key("keyname")
+            .send()
+            .await
+            .expect_err("object must be gone after DELETE with raw key");
+        assert_eq!(
+            error.raw_response().map(|response| response.status().as_u16()),
+            Some(404),
+            "GET after DELETE with raw key must return HTTP 404, got {error:?}"
+        );
 
         env.stop_server();
         info!("Test completed successfully");

--- a/crates/e2e_test/src/presigned_negative_test.rs
+++ b/crates/e2e_test/src/presigned_negative_test.rs
@@ -340,7 +340,18 @@ async fn tampered_presigned_put_returns_signature_does_not_match() -> Result<(),
     assert_error_code(&body, "SignatureDoesNotMatch");
 
     // The rejected write must not have created the object.
-    let head = env.create_s3_client().head_object().bucket(BUCKET).key(key).send().await;
-    assert!(head.is_err(), "tampered presigned PUT must not store the object");
+    let error = env
+        .create_s3_client()
+        .head_object()
+        .bucket(BUCKET)
+        .key(key)
+        .send()
+        .await
+        .expect_err("tampered presigned PUT must not store the object");
+    assert_eq!(
+        error.raw_response().map(|response| response.status().as_u16()),
+        Some(404),
+        "tampered presigned PUT absence probe must return HTTP 404, got {error:?}"
+    );
     Ok(())
 }

--- a/crates/e2e_test/src/special_chars_test.rs
+++ b/crates/e2e_test/src/special_chars_test.rs
@@ -404,8 +404,18 @@ mod tests {
         info!("✅ DELETE object succeeded");
 
         // Verify it's deleted
-        let result = client.get_object().bucket(bucket).key(key).send().await;
-        assert!(result.is_err(), "Object should not exist after DELETE");
+        let error = client
+            .get_object()
+            .bucket(bucket)
+            .key(key)
+            .send()
+            .await
+            .expect_err("Object should not exist after DELETE");
+        assert_eq!(
+            error.raw_response().map(|response| response.status().as_u16()),
+            Some(404),
+            "GET after DELETE must return HTTP 404, got {error:?}"
+        );
 
         // Cleanup
         env.stop_server();


### PR DESCRIPTION
## Summary

- require HTTP 404 when deletion tests prove an object is absent
- distinguish expected S3 missing-object responses from transport or server failures
- cover delete consistency, normalized keys, presigned rejection, and checksum rejection

Related: rustfs/backlog#1897

## Validation

- `rustfmt --edition 2024 --check` on the five changed files
- `python3 scripts/check_test_wiring.py`
- `./scripts/check_logging_guardrails.sh`
- `./scripts/check_architecture_migration_rules.sh`

Local Cargo was not run while another task owns the shared build budget; fresh PR CI is authoritative.