### PR TITLE
fix(app): restore stable Rust 1.98 builds

### DIFF
--- a/crates/log-analyzer/src/rules/seed/ops.rs
+++ b/crates/log-analyzer/src/rules/seed/ops.rs
@@ -21,7 +21,7 @@ use crate::model::LogLevel;
 pub(super) fn rules() -> Vec<Rule> {
     vec![
         Rule {
-            anchors: strings(["decommission_object err"]),
+            anchors: strings(["Decommission object migration failed"]),
             min_count: 3,
             ..base(
                 "decom-object-failed",
@@ -29,6 +29,7 @@ pub(super) fn rules() -> Vec<Rule> {
                 "ops",
                 "下线迁移部分对象失败",
                 any([
+                    contains("Decommission object migration failed"),
                     contains("decommission_object err"),
                     contains("get_object_reader err"),
                     contains("decommission_entry failed"),

--- a/crates/log-analyzer/src/rules/seed/tests.rs
+++ b/crates/log-analyzer/src/rules/seed/tests.rs
@@ -265,7 +265,7 @@ fn every_rule_has_a_positive_sample() {
             msg("failed to start decommission: insufficient target pool capacity: required 100 bytes available 50 bytes"),
         ),
         // ops
-        ("decom-object-failed", msg("decommission_pool: decommission_object err timeout")),
+        ("decom-object-failed", msg("Decommission object migration failed")),
         ("rebalance-worker-error", msg("Rebalance worker 3 error: disk gone")),
         (
             "datamove-same-pool",

--- a/crates/scanner/src/scanner_folder.rs
+++ b/crates/scanner/src/scanner_folder.rs
@@ -49,7 +49,9 @@ use rustfs_filemeta::{
     MetaCacheHealCandidateKind,
 };
 use rustfs_utils::path::{SLASH_SEPARATOR, path_join_buf};
-use s3s::dto::{BucketLifecycleConfiguration, ObjectLockConfiguration, VersioningConfiguration};
+use s3s::dto::{BucketLifecycleConfiguration, LifecycleRuleFilter, ObjectLockConfiguration, VersioningConfiguration};
+#[cfg(test)]
+use s3s::dto::{ExpirationStatus, LifecycleRule};
 use time::OffsetDateTime;
 use tokio::select;
 use tokio::sync::mpsc;

--- a/crates/scanner/src/scanner_folder/item_actions.rs
+++ b/crates/scanner/src/scanner_folder/item_actions.rs
@@ -251,7 +251,7 @@ fn resolve_sizes(object_infos: &[ObjectInfo]) -> Vec<SizeResolution> {
 }
 
 fn lifecycle_rule_has_size_filter(lifecycle: &BucketLifecycleConfiguration, rule_id: &str) -> bool {
-    let filter_has_size = |filter: &s3s::dto::LifecycleRuleFilter| {
+    let filter_has_size = |filter: &LifecycleRuleFilter| {
         filter.object_size_greater_than.is_some()
             || filter.object_size_less_than.is_some()
             || filter
@@ -1637,13 +1637,13 @@ mod tests {
     #[test]
     fn malformed_size_blocks_size_dependent_transition_but_allows_time_only_expiry() {
         let size_filtered = BucketLifecycleConfiguration {
-            rules: vec![s3s::dto::LifecycleRule {
-                status: s3s::dto::ExpirationStatus::from_static(s3s::dto::ExpirationStatus::ENABLED),
+            rules: vec![LifecycleRule {
+                status: ExpirationStatus::from_static(ExpirationStatus::ENABLED),
                 expiration: None,
                 abort_incomplete_multipart_upload: None,
                 del_marker_expiration: None,
                 id: Some("size".to_string()),
-                filter: Some(s3s::dto::LifecycleRuleFilter {
+                filter: Some(LifecycleRuleFilter {
                     object_size_greater_than: Some(1),
                     ..Default::default()
                 }),
@@ -1676,8 +1676,8 @@ mod tests {
         let mixed_filters = BucketLifecycleConfiguration {
             rules: vec![
                 size_filtered.rules[0].clone(),
-                s3s::dto::LifecycleRule {
-                    status: s3s::dto::ExpirationStatus::from_static(s3s::dto::ExpirationStatus::ENABLED),
+                LifecycleRule {
+                    status: ExpirationStatus::from_static(ExpirationStatus::ENABLED),
                     expiration: None,
                     abort_incomplete_multipart_upload: None,
                     del_marker_expiration: None,
@@ -1733,13 +1733,13 @@ mod tests {
         ));
         assert!(lifecycle_rule_has_size_filter(
             &BucketLifecycleConfiguration {
-                rules: vec![s3s::dto::LifecycleRule {
-                    status: s3s::dto::ExpirationStatus::from_static(s3s::dto::ExpirationStatus::ENABLED),
+                rules: vec![LifecycleRule {
+                    status: ExpirationStatus::from_static(ExpirationStatus::ENABLED),
                     expiration: None,
                     abort_incomplete_multipart_upload: None,
                     del_marker_expiration: None,
                     id: None,
-                    filter: Some(s3s::dto::LifecycleRuleFilter {
+                    filter: Some(LifecycleRuleFilter {
                         object_size_greater_than: Some(1),
                         ..Default::default()
                     }),

--- a/rustfs/src/app/multipart_usecase.rs
+++ b/rustfs/src/app/multipart_usecase.rs
@@ -524,7 +524,7 @@ impl DefaultMultipartUsecase {
                 .await
                 .map_err(ApiError::from)?,
         );
-        let object_lock_config_state = load_bucket_object_lock_config_state(&bucket).await?;
+        let object_lock_config_state = Box::pin(load_bucket_object_lock_config_state(&bucket)).await?;
         let previous_current_sizes = match store.get_object_info(&bucket, &key, &current_opts).await {
             Ok(existing_obj_info) => {
                 validate_existing_object_lock_for_write(&object_lock_config_state, &existing_obj_info, &current_opts)?;

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -65,8 +65,10 @@ use super::storage_api::object_usecase::contract::http::HTTPPreconditions;
 use super::storage_api::object_usecase::contract::namespace::NamespaceLocking;
 use super::storage_api::object_usecase::contract::object::{ObjectIO as _, ObjectOperations as _};
 use super::storage_api::object_usecase::contract::range::HTTPRangeSpec;
+#[cfg(test)]
+use super::storage_api::object_usecase::data_usage::apply_bucket_usage_memory_overlay;
 use super::storage_api::object_usecase::data_usage::{
-    apply_bucket_usage_memory_overlay, quota_object_size, record_bucket_delete_marker_memory, record_bucket_object_delete_memory,
+    quota_object_size, record_bucket_delete_marker_memory, record_bucket_object_delete_memory,
     record_bucket_object_version_write_memory, record_bucket_object_write_memory,
     record_bucket_object_write_unknown_previous_memory,
 };


### PR DESCRIPTION
## Summary

- Keep scanner-only DTOs and the usage overlay import behind test builds.
- Heap-bound the Object Lock metadata lookup without changing its fail-closed order or error propagation.
- Keep CompleteMultipartUpload within the default Tokio worker stack on Rust 1.98.
- Follow the current structured decommission migration log while retaining historical matcher compatibility.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p rustfs-log-analyzer` (87 passed)
- `scripts/check_log_analyzer_rules.sh`
- `make pre-pr`: pre-commit gates and all-target Clippy passed; workspace test linking hit local disk capacity and is being rerun with equivalent reduced debug artifacts
- Two independent exact-head adversarial reviews
- CI exercises the real serial ILM regression on Rust 1.98

Stacked on #6486; rebase to main after the base PR lands.
