### PR TITLE
fix(ecstore): restore compile gates

### DIFF
--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -9035,10 +9035,8 @@ impl ECStore {
     ) -> Result<Vec<DecommissionUnresolvedEntry>> {
         self.ensure_decommission_generation_current(idx, generation).await?;
         let operation_gate = self.ctx.data_movement_operation_gate();
-        self.run_guarded_decommission_side_effect(rx, &operation_gate, || {
-            self.check_after_decommission_unfenced(idx, generation)
-        })
-        .await
+        self.run_guarded_decommission_side_effect(rx, &operation_gate, || self.check_after_decommission_unfenced(idx, generation))
+            .await
     }
 
     async fn check_after_decommission_unfenced(
@@ -11115,10 +11113,9 @@ mod pools_tests {
         load_decommission_entry_versions, local_decommission_queue_prefix, mark_decommission_bucket_done,
         merge_decommission_durable_ilm_receipts, merge_pool_meta_updates_for_save, merge_pool_status_refresh,
         missing_decommission_worker_prefix, observe_decommission_terminal_reload_result, pool_meta_has_active_decommission,
-        publish_pool_meta_updates, reconcile_decommission_meta_buckets,
-        reconcile_decommission_unresolved_entries_for_completion, record_decommission_unresolved_entry,
-        require_decommission_store,
-        reserve_decommission_start_cancelers, resolve_decommission_bucket_state, resolve_decommission_check_after_list_result,
+        publish_pool_meta_updates, reconcile_decommission_meta_buckets, reconcile_decommission_unresolved_entries_for_completion,
+        record_decommission_unresolved_entry, require_decommission_store, reserve_decommission_start_cancelers,
+        resolve_decommission_bucket_state, resolve_decommission_check_after_list_result,
         resolve_decommission_entry_cleanup_delete_result, resolve_decommission_entry_exact_versions,
         resolve_decommission_entry_reload_result, resolve_decommission_listing_worker_result,
         resolve_decommission_optional_bucket_config_result, resolve_decommission_pool_meta_reload_result,

--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -56,6 +56,7 @@ use crate::storage_api_contracts::{
     bucket::{BucketOperations, BucketOptions, MakeBucketOptions},
     heal::HealOperations as _,
     list::ListOperations as _,
+    namespace::NamespaceLocking as _,
     object::{EcstoreObjectIO, HTTPPreconditions, ObjectIO as _, ObjectOperations as _},
 };
 use crate::{core::sets::Sets, store::ECStore};

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -35,7 +35,10 @@ use crate::disk::{
     error::{DiskError, Error, FileAccessDeniedWithContext, Result},
     error_conv::{to_access_error, to_file_error, to_unformatted_disk_error, to_volume_error},
     format::FormatV3,
-    fs::{O_APPEND, O_CREATE, O_RDONLY, O_TRUNC, O_WRONLY, access, cached_access, invalidate_bucket_cache, lstat, lstat_std, remove, remove_all_std, remove_std, rename},
+    fs::{
+        O_APPEND, O_CREATE, O_RDONLY, O_TRUNC, O_WRONLY, access, cached_access, invalidate_bucket_cache, lstat, lstat_std,
+        remove, remove_all_std, remove_std, rename,
+    },
     is_quota_mutation_fence_path, os,
     os::{check_path_length, is_dir_not_empty_error, is_empty_dir, is_root_disk, rename_all, rename_all_ignore_missing_source},
     quota_mutation_fence_path,

--- a/crates/ecstore/src/services/rebalance/mod.rs
+++ b/crates/ecstore/src/services/rebalance/mod.rs
@@ -76,7 +76,7 @@ pub async fn test_store_with_persisted_rebalance_meta(
         rebalance_meta: tokio::sync::RwLock::new(Some(meta)),
         decommission_cancelers: tokio::sync::RwLock::new(vec![None]),
         start_gate: tokio::sync::Mutex::new(()),
-        pool_meta_save_gate: tokio::sync::Mutex::new(()),
+        pool_meta_save_gate: tokio::sync::Mutex::default(),
         ctx,
         bucket_fence_registry: std::sync::Arc::default(),
     });
@@ -168,7 +168,7 @@ async fn test_two_pool_stores_with_contexts(
             rebalance_meta: tokio::sync::RwLock::new(rebalance_meta.clone()),
             decommission_cancelers: tokio::sync::RwLock::new(vec![None, None]),
             start_gate: tokio::sync::Mutex::new(()),
-            pool_meta_save_gate: tokio::sync::Mutex::new(()),
+            pool_meta_save_gate: tokio::sync::Mutex::default(),
             ctx: store_ctx,
             bucket_fence_registry: std::sync::Arc::default(),
         })


### PR DESCRIPTION
Restore the pool metadata namespace-lock trait import and update two test-only ECStore constructors for PoolMetaWriteState. Stacked on #6498. Related to rustfs/backlog#1897.