### PR TITLE
fix(scanner): clarify follower status

### DIFF
--- a/crates/scanner/src/scanner.rs
+++ b/crates/scanner/src/scanner.rs
@@ -54,7 +54,7 @@ use rustfs_config::{
 };
 use rustfs_config::{ENV_SCANNER_CYCLE, ENV_SCANNER_SPEED, ENV_SCANNER_START_DELAY_SECS};
 use rustfs_data_usage::observed_data_usage_is_newer;
-use rustfs_lock::NamespaceLockGuard;
+use rustfs_lock::{NamespaceLockGuard, error::LockError};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use tokio::sync::{Notify, mpsc};
@@ -184,6 +184,8 @@ fn notify_scanner_cycle_state_persist_test_hook(leader_epoch: u64) {
 #[derive(Clone, Copy, Debug, Serialize)]
 #[non_exhaustive]
 pub struct ScannerCycleScheduleStatus {
+    execution_role: &'static str,
+    effective_interval_available: bool,
     effective_interval_seconds: u64,
     clean_idle_backoff_enabled: bool,
     clean_idle_backoff_multiplier: u64,
@@ -194,6 +196,8 @@ pub struct ScannerCycleScheduleStatus {
 impl Default for ScannerCycleScheduleStatus {
     fn default() -> Self {
         Self {
+            execution_role: "unknown",
+            effective_interval_available: false,
             effective_interval_seconds: 0,
             clean_idle_backoff_enabled: false,
             clean_idle_backoff_multiplier: 1,
@@ -230,6 +234,8 @@ fn record_scanner_cycle_schedule(
         .write()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     *schedule = ScannerCycleScheduleStatus {
+        execution_role: "leader",
+        effective_interval_available: true,
         effective_interval_seconds,
         clean_idle_backoff_enabled,
         clean_idle_backoff_multiplier: clean_idle_backoff_multiplier.max(1),
@@ -238,8 +244,30 @@ fn record_scanner_cycle_schedule(
     };
 }
 
+fn record_scanner_cycle_schedule_role(execution_role: &'static str) {
+    let mut schedule = SCANNER_CYCLE_SCHEDULE
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *schedule = ScannerCycleScheduleStatus {
+        execution_role,
+        ..ScannerCycleScheduleStatus::default()
+    };
+}
+
 fn reset_scanner_cycle_schedule() {
-    record_scanner_cycle_schedule(Duration::ZERO, false, 1, false, 0);
+    record_scanner_cycle_schedule_role("unknown");
+}
+
+enum ScannerLeaderLockFailure<'a> {
+    Contended,
+    Failed(&'a LockError),
+}
+
+fn classify_scanner_leader_lock_failure(error: &LockError) -> ScannerLeaderLockFailure<'_> {
+    match error {
+        LockError::Timeout { .. } => ScannerLeaderLockFailure::Contended,
+        error => ScannerLeaderLockFailure::Failed(error),
+    }
 }
 
 /// Returns the base cycle interval.
@@ -2041,6 +2069,7 @@ async fn run_data_scanner_with_maintenance_state(
     let mut guard = match storeapi.new_ns_lock(RUSTFS_META_BUCKET, "leader.lock").await {
         Ok(ns_lock) => match ns_lock.get_write_lock_quiet(get_lock_acquire_timeout()).await {
             Ok(guard) => {
+                record_scanner_cycle_schedule_role("leader");
                 record_scanner_leader_lock_state("acquired");
                 global_metrics().record_scanner_leader_liveness("acquired", true, "").await;
                 debug!(
@@ -2055,20 +2084,38 @@ async fn run_data_scanner_with_maintenance_state(
                 guard
             }
             Err(e) => {
-                record_scanner_leader_lock_state("contended");
-                global_metrics()
-                    .record_scanner_leader_liveness("contended", false, e.to_string())
-                    .await;
-                debug!(
-                    target: "rustfs::scanner",
-                    event = EVENT_SCANNER_LOCK_STATE,
-                    component = LOG_COMPONENT_SCANNER,
-                    subsystem = LOG_SUBSYSTEM_RUNTIME,
-                    lock_name = "leader.lock",
-                    state = "contended",
-                    error = ?e,
-                    "Scanner leader lock contended"
-                );
+                match classify_scanner_leader_lock_failure(&e) {
+                    ScannerLeaderLockFailure::Contended => {
+                        record_scanner_cycle_schedule_role("follower");
+                        record_scanner_leader_lock_state("contended");
+                        global_metrics().record_scanner_leader_liveness("contended", false, "").await;
+                        debug!(
+                            target: "rustfs::scanner",
+                            event = EVENT_SCANNER_LOCK_STATE,
+                            component = LOG_COMPONENT_SCANNER,
+                            subsystem = LOG_SUBSYSTEM_RUNTIME,
+                            lock_name = "leader.lock",
+                            state = "contended",
+                            "Scanner leader lock contended"
+                        );
+                    }
+                    ScannerLeaderLockFailure::Failed(error) => {
+                        record_scanner_leader_lock_state("acquire_failed");
+                        global_metrics()
+                            .record_scanner_leader_liveness("acquire_failed", false, error.to_string())
+                            .await;
+                        error!(
+                            target: "rustfs::scanner",
+                            event = EVENT_SCANNER_LOCK_STATE,
+                            component = LOG_COMPONENT_SCANNER,
+                            subsystem = LOG_SUBSYSTEM_RUNTIME,
+                            lock_name = "leader.lock",
+                            state = "acquire_failed",
+                            error = %error,
+                            "Scanner leader lock acquisition failed"
+                        );
+                    }
+                }
                 return Ok(());
             }
         },

--- a/crates/scanner/src/scanner/tests.rs
+++ b/crates/scanner/src/scanner/tests.rs
@@ -4626,19 +4626,56 @@ fn scanner_cycle_schedule_status_reports_effective_backoff() {
 
     let status = scanner_cycle_schedule_status();
 
+    assert_eq!(status.execution_role, "leader");
+    assert!(status.effective_interval_available);
     assert_eq!(status.effective_interval_seconds, 86_401);
     assert!(status.clean_idle_backoff_enabled);
     assert_eq!(status.clean_idle_backoff_multiplier, 2_048);
     assert!(status.superseded_retry_backoff_enabled);
     assert_eq!(status.superseded_cycles, 7);
 
+    record_scanner_cycle_schedule_role("follower");
+    let status = scanner_cycle_schedule_status();
+    assert_eq!(status.execution_role, "follower");
+    assert!(!status.effective_interval_available);
+    assert_eq!(status.effective_interval_seconds, 0);
+
     reset_scanner_cycle_schedule();
     let status = scanner_cycle_schedule_status();
+    assert_eq!(status.execution_role, "unknown");
+    assert!(!status.effective_interval_available);
     assert_eq!(status.effective_interval_seconds, 0);
     assert!(!status.clean_idle_backoff_enabled);
     assert_eq!(status.clean_idle_backoff_multiplier, 1);
     assert!(!status.superseded_retry_backoff_enabled);
     assert_eq!(status.superseded_cycles, 0);
+}
+
+#[test]
+fn scanner_leader_lock_failure_classifies_only_timeout_as_expected_contention() {
+    let timeout = LockError::timeout(".rustfs.sys/leader.lock@latest", Duration::from_secs(5));
+    assert!(matches!(
+        classify_scanner_leader_lock_failure(&timeout),
+        ScannerLeaderLockFailure::Contended
+    ));
+
+    let failures = [
+        LockError::internal("lock service unavailable"),
+        LockError::network(
+            "leader lock transport unavailable",
+            std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "connection refused"),
+        ),
+        LockError::QuorumNotReached {
+            required: 3,
+            achieved: 1,
+        },
+    ];
+    for failure in &failures {
+        assert!(matches!(
+            classify_scanner_leader_lock_failure(failure),
+            ScannerLeaderLockFailure::Failed(_)
+        ));
+    }
 }
 
 #[test]

--- a/rustfs/src/admin/handlers/scanner.rs
+++ b/rustfs/src/admin/handlers/scanner.rs
@@ -389,6 +389,8 @@ mod tests {
         );
 
         let encoded = serde_json::to_value(response).expect("scanner status should serialize");
+        assert_eq!(encoded["cycle_schedule"]["execution_role"], "unknown");
+        assert_eq!(encoded["cycle_schedule"]["effective_interval_available"], false);
         assert_eq!(encoded["cycle_schedule"]["effective_interval_seconds"], 0);
         assert_eq!(encoded["cycle_schedule"]["clean_idle_backoff_enabled"], false);
         assert_eq!(encoded["cycle_schedule"]["clean_idle_backoff_multiplier"], 1);


### PR DESCRIPTION
## Related Issues

Fixes #6482
Fixes #6483

## Summary of Changes

- expose the scanner execution role and effective-interval availability so follower nodes no longer present a local zero value as an effective schedule
- classify only leader-lock timeouts as expected follower contention, clear the stale last-error field for that state, and preserve typed acquisition failures as `acquire_failed`
- add regression coverage for leader, follower, unknown, contention, and genuine lock-failure status contracts

## Verification

- `rustfmt --edition 2024 --check crates/scanner/src/scanner.rs crates/scanner/src/scanner/tests.rs rustfs/src/admin/handlers/scanner.rs`
- `cargo test -p rustfs-scanner scanner_cycle_schedule_status_reports_effective_backoff -- --nocapture`
- `cargo test -p rustfs-scanner scanner_leader_lock_failure_classifies_only_timeout_as_expected_contention -- --nocapture`
- `cargo clippy -p rustfs-scanner --lib --tests -- -D warnings`
- `git diff --check`

## Impact

The Admin scanner status adds two backward-compatible JSON fields under `cycle_schedule`: `execution_role` and `effective_interval_available`. Existing fields remain unchanged. Scanner scheduling and leader election behavior are unchanged.

## Additional Notes

N/A
