### PR TITLE
feat(mimalloc): add arena diagnostics and configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9235,6 +9235,7 @@ dependencies = [
  "rustfs-log-analyzer",
  "rustfs-madmin",
  "rustfs-mimalloc",
+ "rustfs-mimalloc-sys",
  "rustfs-notify",
  "rustfs-object-capacity",
  "rustfs-object-data-cache",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -352,6 +352,7 @@ dav-server = "0.11.0"
 
 # Performance Analysis and Memory Profiling
 rustfs-mimalloc = { version = "0.5.0" }
+rustfs-mimalloc-sys = { version = "0.5.0" }
 hotpath = { version = "0.24.0", default-features = false }
 # Snapshot testing for output format regression detection
 insta = { version = "1.48" }

--- a/crates/ecstore/src/memory_observability.rs
+++ b/crates/ecstore/src/memory_observability.rs
@@ -1,0 +1,33 @@
+
+/// Check mimalloc arena configuration and log diagnostics
+pub fn log_mimalloc_diagnostics() {
+    #[cfg(feature = "mimalloc")]
+    {
+        use rustfs_mimalloc::MiMalloc;
+        
+        // Check arena_max_object_size
+        let arena_max_obj_size = MiMalloc::option_get_size(
+            rustfs_mimalloc_sys::mi_option_t::mi_option_arena_max_object_size
+        );
+        tracing::info!(
+            arena_max_object_size_bytes = arena_max_obj_size,
+            "mimalloc arena_max_object_size"
+        );
+        
+        // Check if pagemap is enabled
+        let pagemap_commit = MiMalloc::option_is_enabled(
+            rustfs_mimalloc_sys::mi_option_t::mi_option_pagemap_commit
+        );
+        tracing::info!(
+            pagemap_commit = pagemap_commit,
+            "mimalloc pagemap_commit"
+        );
+        
+        // Log version
+        let version = MiMalloc::version();
+        tracing::info!(
+            mimalloc_version = version,
+            "mimalloc version"
+        );
+    }
+}


### PR DESCRIPTION
Based on mimalloc maintainer feedback (microsoft/mimalloc#1372), add diagnostics to check mimalloc arena configuration at runtime. 
Add log_mimalloc_diagnostics function to check arena_max_object_size, pagemap_commit status, and mimalloc version. Ref: rustfs/backlog#2005, microsoft/mimalloc#1372. 

Co-Authored-By: heihutu <heihutu@gmail.com>