### PR TITLE
fix(ci): repair post-merge test gates

### DIFF
--- a/crates/ecstore/src/disk/fs.rs
+++ b/crates/ecstore/src/disk/fs.rs
@@ -270,10 +270,7 @@ impl BucketExistenceCache {
 static BUCKET_EXISTENCE_CACHE: std::sync::LazyLock<BucketExistenceCache> =
     std::sync::LazyLock::new(|| BucketExistenceCache::new(Duration::from_secs(60)));
 
-<<<<<<< HEAD
-=======
 /// Cached access check - reduces statx syscalls
->>>>>>> origin/main
 pub async fn cached_access(path: impl AsRef<Path>) -> io::Result<()> {
     let path_buf = path.as_ref().to_path_buf();
 

--- a/crates/ecstore/src/disk/fs.rs
+++ b/crates/ecstore/src/disk/fs.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use std::{
+    collections::HashMap,
     fs::Metadata,
-    path::Path,
-    sync::{Arc, OnceLock},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex, OnceLock},
+    time::{Duration, Instant},
 };
 use tokio::{
     fs::{self, File},
@@ -223,6 +225,75 @@ pub fn rename_std(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()
 #[tracing::instrument(level = "debug", skip_all)]
 pub async fn read_file(path: impl AsRef<Path>) -> io::Result<Vec<u8>> {
     fs::read(path.as_ref()).await
+}
+
+// Bucket existence checks are frequent on object paths; keep short-lived results local.
+struct BucketExistenceCache {
+    cache: Mutex<HashMap<PathBuf, (Instant, bool)>>,
+    ttl: Duration,
+}
+
+impl BucketExistenceCache {
+    fn new(ttl: Duration) -> Self {
+        Self {
+            cache: Mutex::new(HashMap::new()),
+            ttl,
+        }
+    }
+
+    fn check_exists(&self, path: &PathBuf) -> Option<bool> {
+        let mut cache = self.cache.lock().ok()?;
+        if let Some((timestamp, exists)) = cache.get(path) {
+            if timestamp.elapsed() < self.ttl {
+                return Some(*exists);
+            }
+            cache.remove(path);
+        }
+        None
+    }
+
+    fn record(&self, path: PathBuf, exists: bool) {
+        if let Ok(mut cache) = self.cache.lock() {
+            cache.insert(path, (Instant::now(), exists));
+        }
+    }
+
+    fn invalidate(&self, path: &PathBuf) {
+        if let Ok(mut cache) = self.cache.lock() {
+            cache.remove(path);
+        }
+    }
+}
+
+static BUCKET_EXISTENCE_CACHE: std::sync::LazyLock<BucketExistenceCache> =
+    std::sync::LazyLock::new(|| BucketExistenceCache::new(Duration::from_secs(60)));
+
+pub async fn cached_access(path: impl AsRef<Path>) -> io::Result<()> {
+    let path_buf = path.as_ref().to_path_buf();
+
+    if let Some(exists) = BUCKET_EXISTENCE_CACHE.check_exists(&path_buf) {
+        if exists {
+            return Ok(());
+        }
+        return Err(io::Error::new(io::ErrorKind::NotFound, "bucket not found (cached)"));
+    }
+
+    let result = fs::metadata(&path_buf).await;
+
+    match &result {
+        Ok(_) => BUCKET_EXISTENCE_CACHE.record(path_buf, true),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            BUCKET_EXISTENCE_CACHE.record(path_buf, false);
+        }
+        _ => {}
+    }
+
+    result?;
+    Ok(())
+}
+
+pub fn invalidate_bucket_cache(path: impl AsRef<Path>) {
+    BUCKET_EXISTENCE_CACHE.invalidate(&path.as_ref().to_path_buf());
 }
 
 #[cfg(test)]
@@ -593,81 +664,4 @@ mod tests {
         // Should be different files
         assert!(!same_file(&metadata1, &metadata2));
     }
-}
-
-// Bucket existence cache - reduces statx syscalls for repeated bucket checks
-use std::collections::HashMap;
-use std::path::PathBuf;
-use std::sync::Mutex;
-use std::time::{Duration, Instant};
-
-/// Cache for bucket directory existence checks.
-struct BucketExistenceCache {
-    cache: Mutex<HashMap<PathBuf, (Instant, bool)>>,
-    ttl: Duration,
-}
-
-impl BucketExistenceCache {
-    fn new(ttl: Duration) -> Self {
-        Self {
-            cache: Mutex::new(HashMap::new()),
-            ttl,
-        }
-    }
-
-    fn check_exists(&self, path: &PathBuf) -> Option<bool> {
-        let mut cache = self.cache.lock().ok()?;
-        if let Some((timestamp, exists)) = cache.get(path) {
-            if timestamp.elapsed() < self.ttl {
-                return Some(*exists);
-            }
-            cache.remove(path);
-        }
-        None
-    }
-
-    fn record(&self, path: PathBuf, exists: bool) {
-        if let Ok(mut cache) = self.cache.lock() {
-            cache.insert(path, (Instant::now(), exists));
-        }
-    }
-
-    fn invalidate(&self, path: &PathBuf) {
-        if let Ok(mut cache) = self.cache.lock() {
-            cache.remove(path);
-        }
-    }
-}
-
-static BUCKET_EXISTENCE_CACHE: std::sync::LazyLock<BucketExistenceCache> =
-    std::sync::LazyLock::new(|| BucketExistenceCache::new(Duration::from_secs(60)));
-
-/// Cached access check - reduces statx syscalls
-pub async fn cached_access(path: impl AsRef<Path>) -> io::Result<()> {
-    let path_buf = path.as_ref().to_path_buf();
-
-    if let Some(exists) = BUCKET_EXISTENCE_CACHE.check_exists(&path_buf) {
-        if exists {
-            return Ok(());
-        } else {
-            return Err(io::Error::new(io::ErrorKind::NotFound, "bucket not found (cached)"));
-        }
-    }
-
-    let result = fs::metadata(&path_buf).await;
-
-    match &result {
-        Ok(_) => BUCKET_EXISTENCE_CACHE.record(path_buf, true),
-        Err(e) if e.kind() == io::ErrorKind::NotFound => {
-            BUCKET_EXISTENCE_CACHE.record(path_buf, false);
-        }
-        _ => {}
-    }
-
-    result?;
-    Ok(())
-}
-
-pub fn invalidate_bucket_cache(path: impl AsRef<Path>) {
-    BUCKET_EXISTENCE_CACHE.invalidate(&path.as_ref().to_path_buf());
 }

--- a/crates/ecstore/src/services/rebalance/entry.rs
+++ b/crates/ecstore/src/services/rebalance/entry.rs
@@ -1385,9 +1385,6 @@ mod tests {
     async fn real_rebalance_run_fence_loss_blocks_multipart_publication() {
         const REBALANCE_ID: &str = "rebalance-multipart-commit-fence";
         let bucket = crate::disk::RUSTFS_META_BUCKET;
-        let (_temp_dirs, store, _unused_store) =
-            crate::services::rebalance::test_two_pool_stores(Some(active_rebalance_meta(REBALANCE_ID))).await;
-        prepare_rebalance_test_volumes(store.as_ref()).await;
         for (object, pause, staged_commit) in [
             (
                 "rebalance-multipart-new-upload-fence",
@@ -1401,6 +1398,9 @@ mod tests {
             ),
             ("rebalance-multipart-completion-fence", MultipartCommitPause::BeforeQuotaRename, None),
         ] {
+            let (_temp_dirs, store, _unused_store) =
+                crate::services::rebalance::test_two_pool_stores(Some(active_rebalance_meta(REBALANCE_ID))).await;
+            prepare_rebalance_test_volumes(store.as_ref()).await;
             let source_set = store.pools[0].get_disks_by_key(object);
             let target_set = store.pools[1].get_disks_by_key(object);
             let upload = source_set

--- a/crates/ecstore/src/services/rebalance/rebalance_unit_tests.rs
+++ b/crates/ecstore/src/services/rebalance/rebalance_unit_tests.rs
@@ -2685,7 +2685,10 @@ async fn test_start_rebalance_for_id_rejects_changed_metadata() {
         .await
         .expect_err("staged start must not start changed metadata");
 
-    assert!(err.to_string().contains("rebalance metadata changed before start"));
+    assert!(
+        err.to_string()
+            .contains("stale rebalance worker rejected during start rebalance")
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Repair post-merge CI gates on the current main baseline. Move the bucket existence cache implementation before the filesystem test module so clippy accepts the module layout, isolate the multipart rebalance fence scenarios with fresh storage fixtures, and align the activation-fence test assertion with the current stale-worker error contract.

## Verification
- `cargo fmt --all --check`
- `cargo clippy --locked -p rustfs-ecstore --lib -- -D warnings`
- `cargo clippy --locked -p rustfs -p rustfs-ecstore --all-targets --features rio-v2 -- -D warnings`
- `cargo test --locked -p rustfs-ecstore --lib services::rebalance::entry::tests::real_rebalance_run_fence_loss_blocks_multipart_publication -- --exact --nocapture`
- `cargo test --locked -p rustfs-ecstore --lib services::rebalance::rebalance_unit_tests::test_start_rebalance_for_id_rejects_changed_metadata -- --exact --nocapture`
- `git diff --check`

## Impact
Restores clippy and rebalance test gates. Runtime behavior is unchanged; the rebalance edits only improve test isolation and update an assertion to the current error contract.

## Additional Notes
This PR is based on the latest main and supersedes the unmerged follow-up work after #6504.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the CLA document (https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
