### PR TITLE
fix(tests): raise recursion limit for rustfs e2e crates

### DIFF
--- a/rustfs/tests/admin_diagnostic_capability_e2e.rs
+++ b/rustfs/tests/admin_diagnostic_capability_e2e.rs
@@ -6,6 +6,8 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+#![recursion_limit = "256"]
+
 use bytes::Bytes;
 use chrono::Utc;
 use futures::stream;

--- a/rustfs/tests/embedded_select_snapshot_test.rs
+++ b/rustfs/tests/embedded_select_snapshot_test.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{

--- a/rustfs/tests/embedded_test.rs
+++ b/rustfs/tests/embedded_test.rs
@@ -17,6 +17,8 @@
 // This test starts a RustFS server in-process and exercises it via the
 // standard AWS S3 SDK — exactly as you would in your own integration tests.
 
+#![recursion_limit = "256"]
+
 use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::{Client, Config};


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Added crate-level `#![recursion_limit = "256"]` to three RustFS integration test crates that overflowed the compiler query depth limit.
- Kept the change scoped to the failing test crates: `admin_diagnostic_capability_e2e`, `embedded_select_snapshot_test`, and `embedded_test`.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs --test admin_diagnostic_capability_e2e --no-run`
- `cargo test -p rustfs --test embedded_select_snapshot_test --no-run`
- `cargo test -p rustfs --test embedded_test --no-run`

## Impact
No runtime behavior change. This only allows the affected integration test crates to compile when async type layout queries exceed the default recursion depth.

## Additional Notes
The targeted test builds passed on macOS with the existing linker `__eh_frame section too large` warning.
