### PR TITLE
test(connect): use protected home for bootstrap fixtures

### DIFF
--- a/rustfs/src/connect/registration_bootstrap.rs
+++ b/rustfs/src/connect/registration_bootstrap.rs
@@ -434,10 +434,11 @@ mod tests {
     };
 
     fn secure_tempdir() -> tempfile::TempDir {
+        let home = std::path::PathBuf::from(std::env::var_os("HOME").expect("test requires a protected home directory"));
         tempfile::Builder::new()
             .prefix(".connect-registration-bootstrap-")
-            .tempdir_in(env!("CARGO_MANIFEST_DIR"))
-            .expect("temporary directory inside the protected checkout")
+            .tempdir_in(home)
+            .expect("temporary directory inside the protected home directory")
     }
 
     fn create_secure_state_tree(state: &Path) {

--- a/rustfs/tests/connect_registration_bootstrap.rs
+++ b/rustfs/tests/connect_registration_bootstrap.rs
@@ -278,10 +278,11 @@ fn prepare_inputs(temp: &tempfile::TempDir, root_pem: &str) -> (std::path::PathB
 }
 
 fn secure_tempdir() -> tempfile::TempDir {
+    let home = std::path::PathBuf::from(std::env::var_os("HOME").expect("test requires a protected home directory"));
     tempfile::Builder::new()
         .prefix(".connect-registration-")
-        .tempdir_in(env!("CARGO_MANIFEST_DIR"))
-        .expect("temporary directory inside the protected checkout")
+        .tempdir_in(home)
+        .expect("temporary directory inside the protected home directory")
 }
 
 fn run_binary(endpoint: String, root: std::path::PathBuf, state: std::path::PathBuf, token: Vec<u8>) -> std::process::Output {


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Create Connect registration bootstrap fixtures under the protected user home instead of the repository checkout.

This preserves full ancestor permission and symlink validation while avoiding shared-writable runner checkout ancestors that production code must reject.

## Verification

- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## Impact

No production behavior change. Connect registration bootstrap tests use an owner-controlled temporary path on Unix runners.

## Additional Notes

The failing main test job reported 13 Connect bootstrap failures with `StateDirectorySecurity`; local path mode inspection confirmed the checkout path had a shared-writable ancestor while the user home did not.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
