### PR TITLE
test(scanner): align pristine startup fixtures

### DIFF
--- a/crates/scanner/src/scanner/tests.rs
+++ b/crates/scanner/src/scanner/tests.rs
@@ -33,6 +33,10 @@ use tokio::time::{Duration, advance};
 const TEST_DEFAULT_SCANNER_CYCLE_SECS: u64 = 24 * 60 * 60;
 
 async fn setup_scanner_cycle_store() -> (tempfile::TempDir, Arc<ECStore>) {
+    setup_scanner_cycle_store_with_usage_baseline(true).await
+}
+
+async fn setup_scanner_cycle_store_with_usage_baseline(seed_usage_baseline: bool) -> (tempfile::TempDir, Arc<ECStore>) {
     init_ecstore_config_for_scanner_tests();
     let temp_dir = tempfile::tempdir().expect("scanner cycle test directory should be created");
     let mut endpoints = Vec::new();
@@ -69,14 +73,16 @@ async fn setup_scanner_cycle_store() -> (tempfile::TempDir, Arc<ECStore>) {
     .await
     .expect("scanner cycle test ECStore should initialize");
     init_bucket_metadata_sys_for_scanner_tests(store.clone()).await;
-    save_config(
-        store.clone(),
-        DATA_USAGE_OBJ_NAME_PATH.as_str(),
-        serde_json::to_vec(&complete_usage_with_bucket_count(Some(std::time::SystemTime::UNIX_EPOCH), 0))
-            .expect("scanner cycle usage baseline should encode"),
-    )
-    .await
-    .expect("scanner cycle usage baseline should persist");
+    if seed_usage_baseline {
+        save_config(
+            store.clone(),
+            DATA_USAGE_OBJ_NAME_PATH.as_str(),
+            serde_json::to_vec(&complete_usage_with_bucket_count(Some(std::time::SystemTime::UNIX_EPOCH), 0))
+                .expect("scanner cycle usage baseline should encode"),
+        )
+        .await
+        .expect("scanner cycle usage baseline should persist");
+    }
 
     (temp_dir, store)
 }
@@ -2148,7 +2154,7 @@ async fn scanner_usage_floor_fails_closed_on_zero_byte_usage_objects() {
         let appearing = Arc::new(MemoryConfigStore::default());
         appearing.insert_after_gets.lock().await.insert(key, Vec::new());
 
-        let err = persisted_usage_floor(appearing)
+        let err = persisted_usage_floor_for_startup(appearing, true)
             .await
             .expect_err("an empty usage object appearing during confirmation must prevent pristine bootstrap");
         assert!(
@@ -2171,7 +2177,7 @@ async fn scanner_usage_floor_fails_closed_when_usage_appears_during_pristine_con
     let store = Arc::new(MemoryConfigStore::default());
     insert_usage_after_first_legacy_backup_read(store.as_ref()).await;
 
-    let err = persisted_usage_floor(store)
+    let err = persisted_usage_floor_for_startup(store, true)
         .await
         .expect_err("an appearing usage snapshot must prevent pristine bootstrap");
     assert!(err.to_string().contains("changed while confirming pristine state"));
@@ -2212,7 +2218,7 @@ fn scanner_pristine_cycle_state_requires_no_durable_progress() {
 
 #[tokio::test]
 async fn scanner_pristine_bootstrap_allows_first_bucket_to_win_startup() {
-    let (_temp_dir, store) = setup_scanner_cycle_store().await;
+    let (_temp_dir, store) = setup_scanner_cycle_store_with_usage_baseline(false).await;
     let cycle = CurrentCycle::default();
     let revision = DataUsageCacheRevision::Missing;
 


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Run pristine-state race fixtures through the explicit startup path that permits a missing usage floor.

Allow the scanner cycle fixture to omit its normal authoritative usage baseline so the first-bucket bootstrap test starts from the state it claims to exercise.

## Verification

- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## Impact

No production behavior change. Three scanner tests now exercise the intended pristine startup state and confirmation path.

## Additional Notes

The failing main job showed two race tests exiting before pristine confirmation and one bootstrap test starting with an authoritative fixture baseline.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
