### PR TITLE
test(iam): create legacy migration bucket through store

### DIFF
--- a/crates/iam/tests/minio_iam_migration_test.rs
+++ b/crates/iam/tests/minio_iam_migration_test.rs
@@ -97,11 +97,7 @@ async fn minio_permanent_identities_survive_migration_and_repeated_iam_loads() {
         .init_bucket_metadata(false)
         .build()
         .await;
-    for disk_path in &env.disk_paths {
-        tokio::fs::create_dir_all(disk_path.join(LEGACY_META_BUCKET))
-            .await
-            .expect("legacy metadata volume must be created");
-    }
+    env.make_bucket(LEGACY_META_BUCKET, false).await;
 
     let regular_source = json!({
         "version": 1,


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Create the legacy metadata bucket through the ECStore fixture API instead of writing its disk directories directly.

This keeps the bucket existence cache synchronized before the migration seeds and lists legacy IAM objects.

## Verification

- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## Impact

No production behavior change. The MinIO IAM migration integration test now uses the normal bucket mutation boundary.

## Additional Notes

The failing main job could seed the legacy files but migration observed the source volume as absent and persisted no target identity.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
