### PR TITLE
fix(test-utils): raise recursion limit for lib tests

### DIFF
--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 //! Shared test bootstrap helpers for RustFS integration tests
 //! (backlog#1153 infra-1).
 //!


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Added crate-level `#![recursion_limit = "256"]` to `rustfs-test-utils` so its lib tests compile when async type layout queries exceed the default recursion depth.
- Kept the fix scoped to the crate named in the compiler overflow diagnostic.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-test-utils --lib --no-run`

## Impact
No runtime behavior change. This only affects test crate compilation.

## Additional Notes
This is a follow-up to the already merged RustFS e2e recursion-limit PR.
