### PR TITLE
fix(ci): repair main test regressions

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,7 @@
 # nextest configuration for RustFS.
 #
+experimental = ["setup-scripts"]
+
 # Serialize the ecstore tests that share the process-wide disk registry or
 # exercise a multi-disk commit handoff across nextest process boundaries.
 #
@@ -44,7 +46,17 @@ e2e-reliability = { max-threads = 1 }
 e2e-inline-boundaries = { max-threads = 1 }
 e2e-cluster-nightly = { max-threads = 1 }
 
+# These exact regression scenarios build deep async storage futures that exceed
+# libtest's 2 MiB spawned-thread stack on Linux. Give only their test processes
+# the same 32 MiB stack already used by the crate's dedicated large-stack tests.
+[scripts.setup.ecstore-large-stack]
+command = ['sh', '-c', 'echo RUST_MIN_STACK=33554432 >> "$NEXTEST_ENV"']
+
 # --- default profile (local): serialize the flaky groups, never retry --------
+[[profile.default.scripts]]
+filter = 'package(rustfs-ecstore) & test(/^(bucket::lifecycle::bucket_lifecycle_ops::tests::manual_transition_worker_result_recovery_marks_unknown_for_corrupt_marker|services::rebalance::entry::tests::real_rebalance_run_fence_loss_blocks_multipart_publication|store::init::tests::(decommission_entry_(allows_free_version_consumed_before_source_lock|rejects_subquorum_free_version_conflict_and_retains_source|skips_cleanup_only_marker_when_free_version_is_present)|prepared_tier_delete_recovery_(checks_later_pool_then_commits_after_source_removal|finds_directory_source_on_encoded_set|retains_journal_on_source_metadata_error)|tier_mutation_peer_handler_applies_prepare_commit_and_abort_idempotently|transition_response_loss_persists_unknown_outcome_for_provider_recovery|transition_transaction_recovery_(drops_record_after_confirmed_local_commit|keeps_cleanup_pending_local_commit)))$/)'
+setup = 'ecstore-large-stack'
+
 [[profile.default.overrides]]
 filter = 'package(rustfs-ecstore) & (test(concurrent_resend_same_part_commits_one_generation) | test(concurrent_config_writes_from_separate_nodes_do_not_lose_writes) | test(/^store::bucket::tests::bucket_delete_(mark_delete|purge_removes|default_s3_delete)/))'
 test-group = 'ecstore-serial-flaky'
@@ -133,6 +145,10 @@ fail-fast = false
 # Tests that pass only after a quarantine retry are marked `flaky` here — that
 # marker is the observable signal the flake policy is built around.
 path = "junit.xml"
+
+[[profile.ci.scripts]]
+filter = 'package(rustfs-ecstore) & test(/^(bucket::lifecycle::bucket_lifecycle_ops::tests::manual_transition_worker_result_recovery_marks_unknown_for_corrupt_marker|services::rebalance::entry::tests::real_rebalance_run_fence_loss_blocks_multipart_publication|store::init::tests::(decommission_entry_(allows_free_version_consumed_before_source_lock|rejects_subquorum_free_version_conflict_and_retains_source|skips_cleanup_only_marker_when_free_version_is_present)|prepared_tier_delete_recovery_(checks_later_pool_then_commits_after_source_removal|finds_directory_source_on_encoded_set|retains_journal_on_source_metadata_error)|tier_mutation_peer_handler_applies_prepare_commit_and_abort_idempotently|transition_response_loss_persists_unknown_outcome_for_provider_recovery|transition_transaction_recovery_(drops_record_after_confirmed_local_commit|keeps_cleanup_pending_local_commit)))$/)'
+setup = 'ecstore-large-stack'
 
 # ===========================================================================
 # QUARANTINE — flaky tests granted retries = 2 under the ci profile ONLY.

--- a/crates/e2e_test/src/quota_test.rs
+++ b/crates/e2e_test/src/quota_test.rs
@@ -155,6 +155,22 @@ impl QuotaTestEnv {
         Ok(stats.get("current_usage").and_then(|v| v.as_u64()).unwrap_or(0))
     }
 
+    async fn wait_for_bucket_usage(&self, expected: u64) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+        let convergence = async {
+            loop {
+                let usage = self.get_bucket_usage().await?;
+                if usage == expected {
+                    return Ok::<u64, Box<dyn std::error::Error + Send + Sync>>(usage);
+                }
+                sleep(Duration::from_millis(100)).await;
+            }
+        };
+        match timeout(Duration::from_secs(30), convergence).await {
+            Ok(result) => result,
+            Err(_) => Err(format!("bucket usage did not converge to {expected} bytes within 30 seconds").into()),
+        }
+    }
+
     pub async fn set_bucket_quota_for(
         &self,
         bucket: &str,
@@ -444,8 +460,8 @@ mod integration_tests {
             .send()
             .await?;
 
-        // Check updated usage
-        let updated_usage = env.get_bucket_usage().await?;
+        // A completed scanner generation releases the conservative quota floor after a delete.
+        let updated_usage = env.wait_for_bucket_usage(256 * 1024).await?;
         assert_eq!(updated_usage, 256 * 1024);
 
         env.cleanup_bucket().await?;

--- a/rustfs/src/auth.rs
+++ b/rustfs/src/auth.rs
@@ -430,7 +430,7 @@ pub async fn check_key_valid_with_context(
                     reason = "account_disabled",
                     "Access key validation rejected"
                 );
-                return Err(s3_error!(InvalidRequest, "ErrAccessKeyDisabled"));
+                return Err(s3_error!(InvalidAccessKeyId, "check key failed"));
             }
 
             warn!(


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Return the same public access-key error for disabled and unknown IAM credentials while retaining the internal masked rejection reason.
- Wait for scanner-backed quota usage to converge after object deletion before asserting the exact value.
- Give only the 12 known deep ECStore regression tests a 32 MiB test-thread stack under both default and CI nextest profiles.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo build -p rustfs --locked`
- `cargo clippy -p rustfs --lib --locked -- -D warnings`
- `cargo test -p e2e_test admin_iam_crud_test::test_admin_user_policy_service_account_crud_lifecycle --locked -- --exact --nocapture`
- `cargo nextest show-config version --profile ci --no-pager`
- Confirmed the anchored nextest filter matches exactly the 12 SIGABRT tests from the failing main run.

## Impact

Disabled IAM users now receive `InvalidAccessKeyId` instead of `InvalidRequest`, matching unknown-key behavior and avoiding an account-status distinction. Production quota accounting is unchanged. The larger stack is scoped to exact test names and does not add retries or skip assertions.

## Additional Notes

Correctness, security, and compatibility review: the public disabled-key response is normalized with the unknown-key path, while masked internal diagnostics still distinguish the reason. No successful authentication path or persisted format changes.

Test coverage and simplicity review: the quota wait is bounded to 30 seconds and asserts the exact converged value; the nextest setup is limited to the 12 observed stack overflows in both profiles, with no retry or quarantine changes.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
