### PR TITLE
fix(quota): reconcile matching scanner usage

### DIFF
--- a/crates/ecstore/src/data_usage/mod.rs
+++ b/crates/ecstore/src/data_usage/mod.rs
@@ -2145,6 +2145,13 @@ async fn replace_bucket_usage_memory_from_info_if_generation(data_usage_info: &D
                     candidate.insert(preserved);
                     continue;
                 }
+                if existing.authoritative && existing.dirty && bucket_usage_counts_match(&existing.usage, &candidate.get().usage)
+                {
+                    // Matching core counts make the complete scanner snapshot
+                    // equivalent for every field tracked by process-local
+                    // mutations, even when its timestamp predates the request.
+                    continue;
+                }
                 if existing.authoritative && existing.usage_updated_at > usage_updated_at {
                     candidate.insert(existing.clone());
                     continue;


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Release the conservative delete hold when a complete scanner snapshot matches every quota-relevant core count in the process-local cache.
- Keep preserving dirty memory state when scanner counts differ, while allowing reconciliation even if the aggregate scanner timestamp predates the request timestamp.

## Verification

- `CARGO_INCREMENTAL=0 cargo test -p rustfs-ecstore data_usage::tests::negative_delta_waits_for_set_reconciliation --lib -- --exact`
- `cargo fmt --all --check`
- `git diff --check`

## Impact

Quota usage now converges downward after a complete matching scanner snapshot. There are no API, wire-format, persistence-format, deployment, or configuration changes.

## Additional Notes

- Correctness: reconciliation requires matching size, object, version, and delete-marker counts; mismatched snapshots remain conservative.
- Concurrency and durability: the existing cache write lock and persistence flow are unchanged.
- Compatibility: the change is process-local and adds no serialized state.
- Performance: the path adds one comparison using fields already available in memory.
- Test coverage: the focused regression verifies that a matching scanner snapshot releases a pending delete despite an earlier scanner timestamp.
- Failure reproduced in the full merge gate of https://github.com/rustfs/rustfs/actions/runs/32718299541.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
