### PR TITLE
test(ci): stabilize main fixture paths

### DIFF
--- a/crates/iam/tests/minio_iam_migration_test.rs
+++ b/crates/iam/tests/minio_iam_migration_test.rs
@@ -94,7 +94,6 @@ async fn minio_permanent_identities_survive_migration_and_repeated_iam_loads() {
     let temp_dir = tempfile::TempDir::with_prefix("rustfs_minio_iam_migration_").expect("temp directory must be created");
     let env = rustfs_test_utils::TestECStoreEnv::builder()
         .base_dir(temp_dir.path())
-        .init_bucket_metadata(false)
         .build()
         .await;
     env.make_bucket(LEGACY_META_BUCKET, false).await;

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -190,8 +190,7 @@ impl TestECStoreEnvBuilder {
     }
 
     /// Whether to run `init_bucket_metadata_sys` after the store comes up
-    /// (default `true`, as the heal bootstraps did). The IAM bootstrap test
-    /// opts out to preserve its historical semantics.
+    /// (default `true`, as the heal bootstraps did).
     pub fn init_bucket_metadata(mut self, yes: bool) -> Self {
         self.init_bucket_metadata = yes;
         self

--- a/rustfs/src/app/capacity_dirty_scope_test.rs
+++ b/rustfs/src/app/capacity_dirty_scope_test.rs
@@ -193,8 +193,13 @@ async fn heal_object_marks_missing_shard_disk_dirty_for_capacity_manager() {
 
     let _ = manager.get_dirty_disks().await;
 
-    let object_root = disk_paths[0].join(&bucket_name).join("test").join("heal.bin");
-    let missing_part = find_part_file(&object_root, "part.1").expect("part file on first disk");
+    let (missing_disk, missing_part) = disk_paths
+        .iter()
+        .find_map(|disk_path| {
+            let object_root = disk_path.join(&bucket_name).join("test").join("heal.bin");
+            find_part_file(&object_root, "part.1").map(|part| (disk_path, part))
+        })
+        .expect("part file on an erasure disk");
     fs::remove_file(&missing_part).await.expect("remove shard to force heal");
 
     let heal_opts = HealOpts {
@@ -219,7 +224,7 @@ async fn heal_object_marks_missing_shard_disk_dirty_for_capacity_manager() {
         .into_iter()
         .map(|disk| stdfs::canonicalize(&disk.drive_path).unwrap().to_string_lossy().into_owned())
         .collect();
-    let expected_missing_disk = stdfs::canonicalize(&disk_paths[0]).unwrap().to_string_lossy().into_owned();
+    let expected_missing_disk = stdfs::canonicalize(missing_disk).unwrap().to_string_lossy().into_owned();
 
     assert!(
         error.is_none() || actual_paths.contains(&expected_missing_disk),

--- a/rustfs/src/connect/registration_bootstrap.rs
+++ b/rustfs/src/connect/registration_bootstrap.rs
@@ -434,7 +434,8 @@ mod tests {
     };
 
     fn secure_tempdir() -> tempfile::TempDir {
-        let home = std::path::PathBuf::from(std::env::var_os("HOME").expect("test requires a protected home directory"));
+        let home = std::fs::canonicalize(std::env::var_os("HOME").expect("test requires a protected home directory"))
+            .expect("test home directory must resolve without symlink components");
         tempfile::Builder::new()
             .prefix(".connect-registration-bootstrap-")
             .tempdir_in(home)

--- a/rustfs/tests/connect_registration_bootstrap.rs
+++ b/rustfs/tests/connect_registration_bootstrap.rs
@@ -278,7 +278,8 @@ fn prepare_inputs(temp: &tempfile::TempDir, root_pem: &str) -> (std::path::PathB
 }
 
 fn secure_tempdir() -> tempfile::TempDir {
-    let home = std::path::PathBuf::from(std::env::var_os("HOME").expect("test requires a protected home directory"));
+    let home = std::fs::canonicalize(std::env::var_os("HOME").expect("test requires a protected home directory"))
+        .expect("test home directory must resolve without symlink components");
     tempfile::Builder::new()
         .prefix(".connect-registration-")
         .tempdir_in(home)


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Resolve the protected home path before creating Connect security fixtures so CI-only symlink components do not invalidate every bootstrap test.
- Initialize bucket metadata before creating the legacy IAM migration bucket through ECStore.
- Remove the heal shard from the disk that actually contains it instead of assuming the first erasure disk owns the selected part.

## Verification

- `cargo fmt --all --check`
- `git diff --check`

## Impact

Test fixtures only. Production runtime behavior, APIs, storage formats, and configuration are unchanged.

## Additional Notes

These failures were reproduced in the Test and Lint, SFTP, and IAM portions of https://github.com/rustfs/rustfs/actions/runs/32718299541.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
