### PR TITLE
fix(iam): raise recursion limit for migration test

### DIFF
--- a/crates/iam/tests/minio_iam_migration_test.rs
+++ b/crates/iam/tests/minio_iam_migration_test.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 mod ecstore_test_compat;
 
 use ecstore_test_compat::fixture::try_migrate_iam_config;


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Added crate-level `#![recursion_limit = "256"]` to `minio_iam_migration_test`.
- Kept the fix scoped to the `rustfs-iam` test crate named in the compiler overflow diagnostic.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-iam --test minio_iam_migration_test --no-run`

## Impact
No runtime behavior change. This only affects test crate compilation.

## Additional Notes
This is a follow-up for another async-heavy test crate that hit the same compiler query depth limit.
