### PR TITLE
fix(ecstore): heap-allocate durable ILM receipt futures

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/transition_transaction.rs
+++ b/crates/ecstore/src/bucket/lifecycle/transition_transaction.rs
@@ -586,7 +586,10 @@ pub(crate) async fn save_transition_transaction_record(
         transition_transaction_record_object_name(transaction.transaction_id).map_err(transition_transaction_store_error)?;
     let data = transaction.encode().map_err(transition_transaction_store_error)?;
     config_boundary::save_config(api.clone(), &object, data.clone()).await?;
-    api.record_durable_ilm_decommission_progress(&object, &data).await
+    // Box::pin: the durable-receipt state machine is large and sits on the
+    // already-deep transition worker poll chain; keeping it inline overflows
+    // the default 2 MiB tokio worker stack in debug builds.
+    Box::pin(api.record_durable_ilm_decommission_progress(&object, &data)).await
 }
 
 pub(crate) async fn load_transition_transaction_record(
@@ -605,7 +608,8 @@ pub(crate) async fn delete_transition_transaction_record(
     let object =
         transition_transaction_record_object_name(transaction.transaction_id).map_err(transition_transaction_store_error)?;
     let data = transaction.encode().map_err(transition_transaction_store_error)?;
-    api.record_durable_ilm_decommission_terminal(&object, &data).await?;
+    // Box::pin: see save_transition_transaction_record.
+    Box::pin(api.record_durable_ilm_decommission_terminal(&object, &data)).await?;
     match config_boundary::delete_config(api, &object).await {
         Ok(()) | Err(Error::ConfigNotFound) => Ok(()),
         Err(err) => Err(err),


### PR DESCRIPTION
## Related Issues
N/A (main-side regression surfaced while triaging PR #6470 CI; see the ILM lane triage comment there).

## Summary of Changes
`git bisect 1.0.0-rc.3..1ec1a8d90` identifies 34bbc1adb (#6369) as the first-bad commit for the deterministic SIGABRT stack overflow in `app::lifecycle_transition_api_test::compensation_driven_complete_multipart_upload_still_transitions`. #6369 awaits `record_durable_ilm_decommission_progress/terminal` inline from `save_transition_transaction_record` / `delete_transition_transaction_record`; those durable-receipt state machines are large, and they sit on the already-deep transition worker poll chain (worker -> transition -> transaction record -> `delete_config` -> full store delete fanout), overflowing the default 2 MiB tokio worker stack in debug builds in under a second. 41546dee5 already unblocked the test by moving it onto a dedicated 32 MiB thread; this change removes the underlying stack growth with `Box::pin` on both calls, so every caller of the transaction-record helpers keeps its previous stack headroom (verified: with 41546dee5 locally reverted, the test passes on a plain 2 MiB tokio worker with this fix alone).

## Verification
- `cargo nextest run -p rustfs -j1 --run-ignored ignored-only -E 'package(rustfs) and test(compensation_driven)'` — 5/5 pass (including the previously overflowing test)
- Same repro test with 41546dee5 locally reverted (plain 2 MiB `#[tokio::test]` worker) — passes with this fix alone; SIGABRT without it
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings` — workspace green
- Bisect evidence: good at 450ec7f66, first bad at 34bbc1adb (#6369); reproduced at 1ec1a8d90 and at d293ed71e before 41546dee5 landed

## Impact
No behavioral change; the two futures are heap-allocated instead of inlined into the caller state machine. One extra allocation per transition-transaction record save/delete, negligible against the surrounding config-object I/O.

## Additional Notes
Pre-existing and unrelated: `services::rebalance::entry::tests::real_rebalance_run_fence_loss_blocks_multipart_publication` fails identically at its introducing commit 73cd1b5be (#6400) on macOS (`ObjectNotFound(".rustfs.sys", "rebalance-multipart-part-fence")`).
