### PR TITLE
fix(multipart): enforce complete part number limit

### DIFF
--- a/crates/e2e_test/src/security_boundary_test.rs
+++ b/crates/e2e_test/src/security_boundary_test.rs
@@ -87,7 +87,7 @@ async fn test_large_xml_body_rejection() -> Result<(), Box<dyn Error + Send + Sy
     Ok(())
 }
 
-/// Excessive multipart parts must be rejected.
+/// Multipart completion must reject part numbers above the 10,000-part limit.
 #[tokio::test]
 async fn test_excessive_multipart_parts() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
@@ -107,11 +107,24 @@ async fn test_excessive_multipart_parts() -> Result<(), Box<dyn Error + Send + S
 
     let upload_id = create_result.upload_id().expect("upload_id should be present").to_string();
 
-    // Try to complete with too many parts (should be rejected).
-    let mut parts = Vec::new();
-    for i in 1..=10001 {
-        parts.push(CompletedPart::builder().part_number(i).e_tag(format!("etag-{i}")).build());
-    }
+    // Upload one real control part so a generic missing-part rejection cannot
+    // masquerade as enforcement of the 10,000-part boundary.
+    let uploaded = client
+        .upload_part()
+        .bucket(&bucket_name)
+        .key("test-large")
+        .upload_id(&upload_id)
+        .part_number(1)
+        .body(ByteStream::from_static(b"valid-control-part"))
+        .send()
+        .await?;
+    let parts = vec![
+        CompletedPart::builder()
+            .part_number(1)
+            .e_tag(uploaded.e_tag().expect("uploaded part should return an ETag"))
+            .build(),
+        CompletedPart::builder().part_number(10001).e_tag("out-of-range").build(),
+    ];
 
     let result = client
         .complete_multipart_upload()
@@ -132,7 +145,16 @@ async fn test_excessive_multipart_parts() -> Result<(), Box<dyn Error + Send + S
         .await;
     let _ = client.delete_bucket().bucket(&bucket_name).send().await;
 
-    assert!(result.is_err(), "Server should reject excessive multipart parts");
+    let error = result.expect_err("server should reject a completion part number above 10000");
+    let service_error = error
+        .as_service_error()
+        .expect("part-limit rejection must be an S3 service error");
+    assert_eq!(service_error.code(), Some("InvalidPart"), "unexpected part-limit error: {error:?}");
+    assert_eq!(
+        service_error.message(),
+        Some("Part number 10001 must be between 1 and 10000"),
+        "completion must fail at the part-number boundary, not a later missing-part check"
+    );
 
     env.stop_server();
     Ok(())

--- a/rustfs/src/app/multipart_usecase.rs
+++ b/rustfs/src/app/multipart_usecase.rs
@@ -30,7 +30,9 @@ use super::storage_api::multipart_usecase::bucket::{
 use super::storage_api::multipart_usecase::compression::{is_disk_compressible, is_multipart_disk_compression_enabled};
 #[cfg(test)]
 use super::storage_api::multipart_usecase::contract::http::HTTPPreconditions;
-use super::storage_api::multipart_usecase::contract::multipart::{CompletePart, MultipartOperations as _, MultipartUploadResult};
+use super::storage_api::multipart_usecase::contract::multipart::{
+    CompletePart, MAX_MULTIPART_PART_NUMBER, MultipartOperations as _, MultipartUploadResult,
+};
 use super::storage_api::multipart_usecase::contract::object::{ObjectIO as _, ObjectOperations as _};
 use super::storage_api::multipart_usecase::contract::range::HTTPRangeSpec;
 use super::storage_api::multipart_usecase::data_usage::{
@@ -153,6 +155,16 @@ fn validate_copy_source_range_not_exceeds(range_spec: &HTTPRangeSpec, object_siz
 }
 
 fn validate_complete_multipart_parts(parts: &[CompletePart]) -> S3Result<()> {
+    if let Some(part) = parts
+        .iter()
+        .find(|part| !(1..=MAX_MULTIPART_PART_NUMBER as usize).contains(&part.part_num))
+    {
+        return Err(S3Error::with_message(
+            S3ErrorCode::InvalidPart,
+            format!("Part number {} must be between 1 and {MAX_MULTIPART_PART_NUMBER}", part.part_num),
+        ));
+    }
+
     if parts.windows(2).any(|window| window[0].part_num >= window[1].part_num) {
         return Err(s3_error!(InvalidPartOrder, "Part numbers must be strictly increasing"));
     }
@@ -2502,6 +2514,26 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(err.code(), &S3ErrorCode::InvalidPartOrder);
+    }
+
+    #[test]
+    fn validate_complete_multipart_parts_enforces_part_number_range() {
+        validate_complete_multipart_parts(&[CompletePart {
+            part_num: MAX_MULTIPART_PART_NUMBER as usize,
+            ..Default::default()
+        }])
+        .expect("part number 10000 must remain valid");
+
+        for part_num in [0, MAX_MULTIPART_PART_NUMBER as usize + 1] {
+            let err = validate_complete_multipart_parts(&[CompletePart {
+                part_num,
+                ..Default::default()
+            }])
+            .expect_err("out-of-range complete part number must be rejected");
+            assert_eq!(err.code(), &S3ErrorCode::InvalidPart);
+            let expected = format!("Part number {part_num} must be between 1 and {MAX_MULTIPART_PART_NUMBER}");
+            assert_eq!(err.message(), Some(expected.as_str()));
+        }
     }
 
     #[test]

--- a/rustfs/src/app/storage_api.rs
+++ b/rustfs/src/app/storage_api.rs
@@ -1181,6 +1181,7 @@ pub(crate) mod multipart_usecase {
 
         pub(crate) mod multipart {
             pub(crate) use super::super::super::storage_contracts::{CompletePart, MultipartOperations, MultipartUploadResult};
+            pub(crate) use crate::storage::storage_api::s3_api_consumer::multipart::contract::multipart::MAX_MULTIPART_PART_NUMBER;
         }
 
         pub(crate) mod object {


### PR DESCRIPTION
Rejects CompleteMultipartUpload part numbers outside 1..=10000 before storage lookup and adds unit/E2E boundary oracles. Related to rustfs/backlog#1897.