### PR TITLE
test(e2e): require remaining 404 absence oracles

### DIFF
--- a/crates/e2e_test/src/delete_object_no_content_length_test.rs
+++ b/crates/e2e_test/src/delete_object_no_content_length_test.rs
@@ -155,8 +155,13 @@ mod tests {
             .key(key)
             .version_id(version_id)
             .send()
-            .await;
-        assert!(get_deleted_version.is_err(), "explicitly deleted version should no longer be readable");
+            .await
+            .expect_err("explicitly deleted version should no longer be readable");
+        assert_eq!(
+            get_deleted_version.raw_response().map(|response| response.status().as_u16()),
+            Some(404),
+            "explicitly deleted version absence probe must return HTTP 404, got {get_deleted_version:?}"
+        );
 
         Ok(())
     }

--- a/crates/e2e_test/src/existing_object_tag_policy_test.rs
+++ b/crates/e2e_test/src/existing_object_tag_policy_test.rs
@@ -463,8 +463,18 @@ async fn test_e2e_sts_session_policy_delete_objects_object_prefix_only() -> Resu
     assert_eq!(error.key(), Some(denied_key));
     assert_eq!(error.code(), Some("AccessDenied"));
 
-    let allowed_head = parent_client.head_object().bucket(&bucket).key(allowed_key).send().await;
-    assert!(allowed_head.is_err(), "allowed-prefix object should have been deleted");
+    let allowed_head = parent_client
+        .head_object()
+        .bucket(&bucket)
+        .key(allowed_key)
+        .send()
+        .await
+        .expect_err("allowed-prefix object should have been deleted");
+    assert_eq!(
+        allowed_head.raw_response().map(|response| response.status().as_u16()),
+        Some(404),
+        "allowed-prefix object absence probe must return HTTP 404, got {allowed_head:?}"
+    );
 
     parent_client
         .head_object()

--- a/crates/e2e_test/src/ssec_copy_test.rs
+++ b/crates/e2e_test/src/ssec_copy_test.rs
@@ -276,9 +276,17 @@ async fn copy_object_rotates_ssec_key_and_drops_source_encryption_metadata() -> 
             .await
             .expect_err("invalid source SSE-C parameters must reject CopyObject");
         assert_secret_absent(&format!("{error:?}"), &[&source_key, &wrong_key]);
-        assert!(
-            client.head_object().bucket(bucket).key(&failed_target).send().await.is_err(),
-            "a rejected CopyObject must not create its target"
+        let absence = client
+            .head_object()
+            .bucket(bucket)
+            .key(&failed_target)
+            .send()
+            .await
+            .expect_err("a rejected CopyObject must not create its target");
+        assert_eq!(
+            absence.raw_response().map(|response| response.status().as_u16()),
+            Some(404),
+            "rejected CopyObject absence probe must return HTTP 404, got {absence:?}"
         );
     }
     env.stop_server();
@@ -464,9 +472,17 @@ async fn multipart_copy_requires_keys_on_every_stage_and_abort_leaves_no_object(
             abort_attempts_before + 1,
             "each failed multipart copy must issue exactly one wire-level abort attempt"
         );
-        assert!(
-            client.head_object().bucket(bucket).key(&failed_target).send().await.is_err(),
-            "an aborted failed multipart copy must leave no completed object"
+        let absence = client
+            .head_object()
+            .bucket(bucket)
+            .key(&failed_target)
+            .send()
+            .await
+            .expect_err("an aborted failed multipart copy must leave no completed object");
+        assert_eq!(
+            absence.raw_response().map(|response| response.status().as_u16()),
+            Some(404),
+            "aborted multipart copy absence probe must return HTTP 404, got {absence:?}"
         );
     }
     env.stop_server();


### PR DESCRIPTION
Makes four remaining object-absence probes require HTTP 404 so network and server failures cannot satisfy the assertions. Related to rustfs/backlog#1897.