### PR TITLE
fix(table-catalog): classify storage quorum as unavailable

### DIFF
--- a/rustfs/src/table_catalog/mod.rs
+++ b/rustfs/src/table_catalog/mod.rs
@@ -383,6 +383,9 @@ fn is_missing_storage_error(err: &StorageError) -> bool {
 }
 
 fn storage_error_to_catalog(action: &str, err: StorageError) -> TableCatalogStoreError {
+    if err.is_quorum_error() {
+        return TableCatalogStoreError::Unavailable(format!("{action}: {err}"));
+    }
     match err {
         StorageError::ObjectNotFound(bucket, object) => TableCatalogStoreError::NotFound(format!("{action}: {bucket}/{object}")),
         StorageError::BucketNotFound(bucket) => TableCatalogStoreError::NotFound(format!("{action}: bucket {bucket}")),

--- a/rustfs/src/table_catalog/tests.rs
+++ b/rustfs/src/table_catalog/tests.rs
@@ -60,6 +60,33 @@ fn catalog_lock_authority_failures_are_typed_as_unavailable() {
 }
 
 #[test]
+fn catalog_storage_quorum_failures_are_typed_as_unavailable() {
+    for error in [
+        StorageError::ErasureReadQuorum,
+        StorageError::ErasureWriteQuorum,
+        StorageError::InsufficientReadQuorum(".rustfs.sys".to_string(), "snapshot.json".to_string()),
+        StorageError::InsufficientWriteQuorum(".rustfs.sys".to_string(), "snapshot.json".to_string()),
+        StorageError::NamespaceLockQuorumUnavailable {
+            mode: "read",
+            bucket: ".rustfs.sys".to_string(),
+            object: "s3tables/catalog/strong-backing/snapshot.json".to_string(),
+            required: 2,
+            achieved: 0,
+        },
+    ] {
+        assert_matches!(
+            storage_error_to_catalog("stat catalog object", error),
+            TableCatalogStoreError::Unavailable(_)
+        );
+    }
+
+    assert_matches!(
+        storage_error_to_catalog("stat catalog object", StorageError::FileCorrupt),
+        TableCatalogStoreError::Internal(_)
+    );
+}
+
+#[test]
 fn reserved_table_object_key_matches_exact_prefix_and_children_only() {
     assert!(is_reserved_table_object_key(".rustfs-table"));
     assert!(is_reserved_table_object_key(".rustfs-table/"));


### PR DESCRIPTION
## Related Issues

Follow-up to https://github.com/rustfs/rustfs/issues/6505 and https://github.com/rustfs/rustfs/pull/6506.

## Summary of Changes

Maps ECStore quorum failures returned by table catalog object operations to `TableCatalogStoreError::Unavailable` before the generic internal-error mapping.

Adds regression coverage for erasure read/write quorum, insufficient read/write quorum, and namespace-lock quorum failures while preserving corruption as an internal error.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo check --locked -p rustfs --tests`
- Four-node durable-strong peer-partition rehearsal with 16 logical volumes

## Impact

Table catalog operations that cannot obtain storage quorum now return the existing stable Iceberg REST `503` unavailable response instead of an incorrect `500`. Conflict behavior remains `409`, and non-quorum storage failures remain internal errors.

## Additional Notes

The live rehearsal verified survivor commit progress, isolated-writer fail-closed behavior without catalog publication, recovery absence, post-heal stale-token rejection, four-node convergence, PyIceberg reload and scan, and catalog cleanup.
