### PR TITLE
test(ilm): isolate suspended restore stack

### DIFF
--- a/rustfs/src/app/lifecycle_transition_api_test.rs
+++ b/rustfs/src/app/lifecycle_transition_api_test.rs
@@ -2240,10 +2240,27 @@ async fn restore_object_usecase_reports_ongoing_conflict() {
     get_barrier.release();
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 #[ignore = "global-state ILM integration test: runs serialized in the CI ILM Integration (serial) lane, see ci.yml test-ilm-integration-serial and rustfs/backlog#4879"]
-async fn restore_object_usecase_completes_suspended_null_version_in_place() {
+#[test]
+fn restore_object_usecase_completes_suspended_null_version_in_place() {
+    std::thread::Builder::new()
+        .name("lifecycle-restore-suspended-null".to_string())
+        .stack_size(32 * 1024 * 1024)
+        .spawn(|| {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("suspended null-version restore test runtime should build");
+
+            runtime.block_on(restore_object_usecase_completes_suspended_null_version_in_place_inner());
+        })
+        .expect("suspended null-version restore test thread should spawn")
+        .join()
+        .expect("suspended null-version restore test thread should finish");
+}
+
+async fn restore_object_usecase_completes_suspended_null_version_in_place_inner() {
     let (_disk_paths, ecstore) = setup_test_env().await;
     let usecase = DefaultObjectUsecase::from_global();
     let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Run the suspended null-version restore integration test on a dedicated 32 MiB stack.
- Use a current-thread Tokio runtime so the restore copy-back task shares the enlarged stack.
- Preserve the original serialized, ignored ILM test behavior and assertions.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo test -p rustfs --lib app::lifecycle_transition_api_test::restore_object_usecase_completes_suspended_null_version_in_place --locked -- --ignored --exact --nocapture`
- The exact regression passed twice, including after rebasing onto the latest `main`.

## Impact

- Test-only change; no production, API, configuration, or deployment impact.
- Prevents the serial ILM integration lane from aborting when the deep restore future exceeds the default test worker stack.

## Additional Notes

- The failing CI job aborted with a stack overflow and SIGABRT after 31 earlier ILM tests passed; it was not an assertion or timeout failure.
- The restore future was already boxed, so the dedicated current-thread runtime follows the existing large-stack test pattern in this file and also covers detached copy-back work.
- The broad local gate was not rerun after earlier runner-volume pressure; verification was intentionally limited to formatting, diff validation, and the exact regression test.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
