### PR TITLE
fix(e2e): box delete object errors

### DIFF
--- a/crates/e2e_test/src/object_lock/common.rs
+++ b/crates/e2e_test/src/object_lock/common.rs
@@ -238,7 +238,7 @@ pub async fn delete_object_with_bypass(
     key: &str,
     version_id: Option<&str>,
     bypass_governance: bool,
-) -> Result<(), SdkError<DeleteObjectError>> {
+) -> Result<(), Box<SdkError<DeleteObjectError>>> {
     let mut request = client
         .delete_object()
         .bucket(bucket)
@@ -249,7 +249,7 @@ pub async fn delete_object_with_bypass(
         request = request.version_id(vid);
     }
 
-    request.send().await?;
+    request.send().await.map_err(Box::new)?;
     info!("Deleted object {} (bypass: {})", key, bypass_governance);
     Ok(())
 }

--- a/crates/e2e_test/src/object_lock/object_lock_test.rs
+++ b/crates/e2e_test/src/object_lock/object_lock_test.rs
@@ -24,6 +24,8 @@
 //! - PutObjectRetention modification restrictions
 //! - Default bucket retention is applied to new objects
 
+use std::borrow::Borrow;
+
 use super::common::*;
 use aws_sdk_s3::Client;
 use aws_sdk_s3::error::{ProvideErrorMetadata, SdkError};
@@ -70,19 +72,21 @@ fn retention_timestamp(days: i64) -> aws_sdk_s3::primitives::DateTime {
         .expect("retention timestamp should parse")
 }
 
-fn assert_access_denied<T, E>(result: Result<T, SdkError<E>>, context: &str)
+fn assert_access_denied<T, E, R>(result: Result<T, R>, context: &str)
 where
     T: std::fmt::Debug,
     E: ProvideErrorMetadata + std::fmt::Debug,
+    R: Borrow<SdkError<E>> + std::fmt::Debug,
 {
     let error = result.expect_err(context);
+    let sdk_error = error.borrow();
     assert_eq!(
-        error.raw_response().map(|response| response.status().as_u16()),
+        sdk_error.raw_response().map(|response| response.status().as_u16()),
         Some(403),
         "{context}: expected HTTP 403, got: {error:?}"
     );
     assert_eq!(
-        error.as_service_error().and_then(ProvideErrorMetadata::code),
+        sdk_error.as_service_error().and_then(ProvideErrorMetadata::code),
         Some("AccessDenied"),
         "{context}: expected AccessDenied, got: {error:?}"
     );


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Box the typed DeleteObject SDK error returned by the Object Lock E2E helper.
- Keep exact HTTP status and service error assertions compatible with both boxed and unboxed SDK errors.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo clippy -p e2e_test --all-targets --all-features --locked -- -D warnings`

## Impact

Test-only change. No production, API, deployment, or configuration impact.

## Additional Notes

Fixes the main Clippy failure without weakening lint policy.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
