### PR TITLE
test(e2e): require exact retention errors

### DIFF
--- a/crates/e2e_test/src/object_lock/common.rs
+++ b/crates/e2e_test/src/object_lock/common.rs
@@ -23,6 +23,7 @@
 use aws_sdk_s3::Client;
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::delete_object::DeleteObjectError;
+use aws_sdk_s3::operation::put_object_retention::PutObjectRetentionError;
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{
     DefaultRetention, ObjectLockConfiguration, ObjectLockEnabled, ObjectLockLegalHold, ObjectLockLegalHoldStatus, ObjectLockMode,
@@ -182,11 +183,8 @@ pub async fn put_object_retention(
     mode: ObjectLockRetentionMode,
     retain_until: DateTime<Utc>,
     bypass_governance: bool,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    // AWS SDK requires UTC time without timezone offset (e.g., "2026-01-24T11:20:14Z")
-    let retain_until_str = retain_until.format("%Y-%m-%dT%H:%M:%SZ").to_string();
-    let retain_until_datetime =
-        aws_sdk_s3::primitives::DateTime::from_str(&retain_until_str, aws_sdk_s3::primitives::DateTimeFormat::DateTime)?;
+) -> Result<(), Box<SdkError<PutObjectRetentionError>>> {
+    let retain_until_datetime = aws_sdk_s3::primitives::DateTime::from_secs(retain_until.timestamp());
 
     let retention = ObjectLockRetention::builder()
         .mode(mode.clone())
@@ -204,7 +202,7 @@ pub async fn put_object_retention(
         request = request.version_id(vid);
     }
 
-    request.send().await?;
+    request.send().await.map_err(Box::new)?;
     info!("Put object retention on {} with mode {:?}", key, mode);
     Ok(())
 }

--- a/crates/e2e_test/src/object_lock/object_lock_test.rs
+++ b/crates/e2e_test/src/object_lock/object_lock_test.rs
@@ -1475,7 +1475,7 @@ async fn test_put_retention_compliance_cannot_shorten() {
     )
     .await;
 
-    assert!(shorten_result.is_err(), "Shortening COMPLIANCE retention should fail");
+    assert_access_denied(shorten_result, "Shortening COMPLIANCE retention should fail");
 
     info!("✅ Test passed: Cannot shorten COMPLIANCE retention");
 }
@@ -1598,10 +1598,7 @@ async fn test_put_retention_governance_shorten_requires_bypass() {
     )
     .await;
 
-    assert!(
-        shorten_without_bypass.is_err(),
-        "Shortening GOVERNANCE retention without bypass should fail"
-    );
+    assert_access_denied(shorten_without_bypass, "Shortening GOVERNANCE retention without bypass should fail");
 
     // Shorten with bypass - should succeed
     let shorten_with_bypass = put_object_retention(


### PR DESCRIPTION
## Related Issues

Related: rustfs/backlog#1897

## Summary of Changes

- Preserve the typed PutObjectRetention SDK error in the Object Lock E2E helper.
- Keep the SDK error boxed to satisfy the existing large-error lint boundary.
- Require HTTP 403 and `AccessDenied` when COMPLIANCE or GOVERNANCE retention shortening is rejected.

## Verification

- `rustfmt --edition 2024 crates/e2e_test/src/object_lock/common.rs crates/e2e_test/src/object_lock/object_lock_test.rs`
- `git diff --check dcdaa37b84d03ddbfaa358dea6cb5d9cc6517ef3..047abdefca4fba080a5f936627a8566446c4c634`
- Two independent exact-head reviews: PASS

## Impact

Test-only. Retention shortening tests can no longer pass on transport errors or unrelated S3 responses.

## Additional Notes

No local Cargo build was started while another isolated repository gate owned the build resources. Fresh CI provides compile evidence.
