### PR TITLE
test(ecstore): avoid virtual timeout for sync batch

### DIFF
--- a/crates/ecstore/src/disk/os.rs
+++ b/crates/ecstore/src/disk/os.rs
@@ -6370,8 +6370,15 @@ mod tests {
         .await
         .expect("second waiter should enqueue during the configured wait budget");
         tokio::time::advance(wait_budget).await;
-        tokio::task::yield_now().await;
-        file_sync_probe::wait_for_active(1).await;
+        let batch_deadline = std::time::Instant::now() + Duration::from_secs(30);
+        while file_sync_probe::group_batches().is_empty() {
+            assert!(
+                std::time::Instant::now() < batch_deadline,
+                "timed out waiting for the wait-budget group batch; counts={:?}",
+                file_fdatasync_group_commit_counts_for_test()
+            );
+            tokio::task::yield_now().await;
+        }
 
         assert_eq!(
             file_sync_probe::group_batches(),


### PR DESCRIPTION
## Related Issues

rustfs/backlog#1897

## Summary of Changes

- wait for the actual fdatasync group-batch record in the paused-time test
- use a wall-clock deadline instead of a Tokio virtual-time timeout around blocking work
- keep the exact two-waiter batch, sync result, directory fsync, and cleanup assertions unchanged

## Verification

- `rustfmt --edition 2024 --check crates/ecstore/src/disk/os.rs`
- `git diff --check`
- two independent exact-head static reviews: PASS

## Impact

Test-only. This removes a race where paused virtual time reached 30 seconds before the blocking probe was scheduled.

## Additional Notes

- Correctness, simplicity, test coverage, and concurrency/durability: PASS
- Compatibility and CI oracle boundary: PASS
- Local Cargo was skipped because the host is below the disk safety gate; fresh CI is required.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
