### PR TITLE
test(keycloak): fix Keycloak OIDC live fixture

### DIFF
--- a/scripts/test/fixtures/keycloak-rustfs-ci-realm.json
+++ b/scripts/test/fixtures/keycloak-rustfs-ci-realm.json
@@ -27,6 +27,8 @@
     {
       "id": "00000000-0000-0000-0000-000000000001",
       "username": "alice",
+      "firstName": "Alice",
+      "lastName": "RustFS",
       "email": "alice@example.test",
       "emailVerified": true,
       "enabled": true,

--- a/scripts/test/oidc_keycloak_live.sh
+++ b/scripts/test/oidc_keycloak_live.sh
@@ -128,14 +128,17 @@ token_for_client() {
   local client_id="$1"
   local client_secret="$2"
   local response_file="${WORK_DIR}/token-${client_id}.json"
-  curl --noproxy '*' -fsS "${ISSUER}/protocol/openid-connect/token" \
+  if ! curl --noproxy '*' -sS --fail-with-body "${ISSUER}/protocol/openid-connect/token" \
     --data-urlencode grant_type=password \
     --data-urlencode "client_id=${client_id}" \
     --data-urlencode "client_secret=${client_secret}" \
     --data-urlencode username=alice \
     --data-urlencode password=alice-password \
     --data-urlencode scope=openid \
-    >"${response_file}"
+    >"${response_file}"; then
+    cat "${response_file}" >&2
+    return 1
+  fi
   python3 - "${response_file}" "${ISSUER}" "${client_id}" <<'PY'
 import base64
 import json


### PR DESCRIPTION
The first fresh run of #6562 reached Keycloak, then failed with `resolve_required_actions`: the imported test user was missing required profile fields.

This adds first/last name to that fixture. It also preserves the token endpoint response on failure so the next provider-side error is reported directly instead of being hidden by a JSON decode traceback.

Static checks: actionlint, shellcheck, bash -n, JSON parse, diff check. Two independent exact-head reviews passed. The fresh OIDC Keycloak workflow is the execution gate.

Refs rustfs/backlog#1897