### PR TITLE
fix(api): preserve typed upload digest errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10802,8 +10802,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 [[package]]
 name = "s3s"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "652451a66fefda01a13dc7df24aa2af9e70c7058f98bc08fe2f7c552eaa9f1e3"
+source = "git+https://github.com/rustfs/s3s.git?rev=5f22e8d0a37e83f531f653024aac11c72586479a#5f22e8d0a37e83f531f653024aac11c72586479a"
 dependencies = [
  "arc-swap",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -293,7 +293,7 @@ rustify = { version = "0.7", default-features = false }
 rustix = { version = "1.1.4" }
 rust-embed = { version = "8.12.0" }
 rustc-hash = { version = "2.1.3" }
-s3s = { version = "0.15.0", features = ["minio"] }
+s3s = { git = "https://github.com/rustfs/s3s.git", rev = "5f22e8d0a37e83f531f653024aac11c72586479a", version = "0.15.0", features = ["minio"] }
 serial_test = "4.0.1"
 shadow-rs = { default-features = false, version = "2.0.0" }
 siphasher = "1.0.3"

--- a/crates/rio/src/hash_reader.rs
+++ b/crates/rio/src/hash_reader.rs
@@ -560,7 +560,13 @@ impl AsyncRead for HashReader {
                         let sha256 = hex_simd::encode_to_string(hasher.finalize(), hex_simd::AsciiCase::Lower);
                         if sha256 != *expected_sha256 {
                             error!("SHA256 mismatch, expected={:?}, actual={:?}", expected_sha256, sha256);
-                            return Poll::Ready(Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "SHA256 mismatch")));
+                            return Poll::Ready(Err(std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                crate::errors::Sha256Mismatch {
+                                    expected_sha256: expected_sha256.clone(),
+                                    calculated_sha256: sha256,
+                                },
+                            )));
                         }
                     }
 
@@ -772,6 +778,30 @@ mod tests {
         let etag = hash_reader.try_resolve_etag();
         assert!(etag.is_none());
         assert_eq!(buf, data);
+    }
+
+    #[tokio::test]
+    async fn sha256_mismatch_retains_typed_io_error_source() {
+        let data = b"tampered payload";
+        let expected_sha256 = "0".repeat(64);
+        let reader = BufReader::new(Cursor::new(&data[..]));
+        let mut hash_reader =
+            HashReader::from_stream(reader, data.len() as i64, data.len() as i64, None, Some(expected_sha256.clone()), false)
+                .expect("operation should succeed");
+
+        let error = hash_reader
+            .read_to_end(&mut Vec::new())
+            .await
+            .expect_err("SHA256 mismatch should fail");
+        let mismatch = error
+            .get_ref()
+            .and_then(|source| source.downcast_ref::<crate::Sha256Mismatch>())
+            .expect("SHA256 mismatch should remain typed");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(mismatch.expected_sha256, expected_sha256);
+        assert_eq!(mismatch.calculated_sha256.len(), 64);
+        assert_ne!(mismatch.calculated_sha256, mismatch.expected_sha256);
     }
 
     #[tokio::test]

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -235,22 +235,6 @@ use crate::app::object_traffic_health::ObjectTrafficHealth;
 type S3StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 fn s3s_body_error_to_io(err: StdError) -> io::Error {
-    match err.to_string().as_str() {
-        "UploadStreamError: Sha256Mismatch" => {
-            return io::Error::new(
-                io::ErrorKind::InvalidData,
-                rustfs_rio::ChecksumMismatch {
-                    want: AMZ_CONTENT_SHA256.to_string(),
-                    got: "payload sha256".to_string(),
-                },
-            );
-        }
-        "UploadStreamError: Incomplete" | "UploadStreamError: LengthMismatch" => {
-            return io::Error::new(io::ErrorKind::UnexpectedEof, rustfs_rio::IncompleteBody { remaining: 0 });
-        }
-        _ => {}
-    }
-
     io::Error::other(err)
 }
 
@@ -16248,6 +16232,43 @@ mod tests {
             zero_copy_eager_put_path_status(2 * 1024 * 1024, &headers, false, false, true),
             PUT_EAGER_STATUS_EXTRACT
         );
+    }
+
+    #[test]
+    fn s3s_body_error_to_io_preserves_upload_stream_error_source() {
+        let error = s3s_body_error_to_io(Box::new(s3s::UploadStreamError::Sha256Mismatch));
+
+        assert!(matches!(
+            error
+                .get_ref()
+                .and_then(|source| source.downcast_ref::<s3s::UploadStreamError>()),
+            Some(s3s::UploadStreamError::Sha256Mismatch)
+        ));
+    }
+
+    #[tokio::test]
+    async fn read_small_put_body_maps_upload_stream_sha256_mismatch_to_bad_digest() {
+        let body = StreamReader::new(futures::stream::iter(vec![Err::<Bytes, std::io::Error>(s3s_body_error_to_io(Box::new(
+            s3s::UploadStreamError::Sha256Mismatch,
+        )))]));
+
+        let error = read_small_put_body_exact_direct(body, 1)
+            .await
+            .expect_err("SHA256 mismatch should reject the small PUT body");
+
+        assert_eq!(error.code(), &S3ErrorCode::BadDigest);
+    }
+
+    #[tokio::test]
+    async fn read_zero_copy_put_body_maps_upload_stream_sha256_mismatch_to_bad_digest() {
+        let body = futures::stream::iter(vec![Err::<Bytes, s3s::UploadStreamError>(s3s::UploadStreamError::Sha256Mismatch)]);
+
+        let error = match read_zero_copy_put_body_exact(body, 1).await {
+            Ok(_) => panic!("SHA256 mismatch should reject the zero-copy PUT body"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.code(), &S3ErrorCode::BadDigest);
     }
 
     struct FragmentedBody {

--- a/rustfs/src/error.rs
+++ b/rustfs/src/error.rs
@@ -225,6 +225,28 @@ where
     false
 }
 
+fn error_chain_has_upload_stream_sha256_mismatch(err: &(dyn std::error::Error + 'static)) -> bool {
+    if matches!(err.downcast_ref::<s3s::UploadStreamError>(), Some(s3s::UploadStreamError::Sha256Mismatch)) {
+        return true;
+    }
+
+    if let Some(io_err) = err.downcast_ref::<std::io::Error>()
+        && let Some(inner) = io_err.get_ref()
+        && error_chain_has_upload_stream_sha256_mismatch(inner)
+    {
+        return true;
+    }
+
+    let mut current = err.source();
+    while let Some(err) = current {
+        if matches!(err.downcast_ref::<s3s::UploadStreamError>(), Some(s3s::UploadStreamError::Sha256Mismatch)) {
+            return true;
+        }
+        current = err.source();
+    }
+    false
+}
+
 impl From<ApiError> for S3Error {
     fn from(err: ApiError) -> Self {
         let mut s3e = S3Error::with_message(err.code, err.message);
@@ -237,11 +259,13 @@ impl From<ApiError> for S3Error {
 
 impl From<StorageError> for ApiError {
     fn from(err: StorageError) -> Self {
-        // Special handling for Io errors that may contain ChecksumMismatch
+        // Preserve typed client-provided digest failures across I/O boundaries.
         if let StorageError::Io(ref io_err) = err
             && let Some(inner) = io_err.get_ref()
             && (inner.downcast_ref::<rustfs_rio::ChecksumMismatch>().is_some()
-                || inner.downcast_ref::<rustfs_rio::BadDigest>().is_some())
+                || inner.downcast_ref::<rustfs_rio::BadDigest>().is_some()
+                || inner.downcast_ref::<rustfs_rio::Sha256Mismatch>().is_some()
+                || error_chain_has_upload_stream_sha256_mismatch(inner))
         {
             return ApiError {
                 code: S3ErrorCode::BadDigest,
@@ -362,9 +386,12 @@ impl From<HTTPRangeError> for ApiError {
 
 impl From<std::io::Error> for ApiError {
     fn from(err: std::io::Error) -> Self {
-        // Check if the error is a ChecksumMismatch (BadDigest)
+        // Map client-provided digest mismatches to BadDigest.
         if let Some(inner) = err.get_ref() {
-            if error_chain_has_type::<rustfs_rio::ChecksumMismatch>(inner) || error_chain_has_type::<rustfs_rio::BadDigest>(inner)
+            if error_chain_has_type::<rustfs_rio::ChecksumMismatch>(inner)
+                || error_chain_has_type::<rustfs_rio::BadDigest>(inner)
+                || error_chain_has_type::<rustfs_rio::Sha256Mismatch>(inner)
+                || error_chain_has_upload_stream_sha256_mismatch(inner)
             {
                 return ApiError {
                     code: S3ErrorCode::BadDigest,
@@ -458,6 +485,67 @@ mod tests {
             let downcast_io_error = source.downcast_ref::<IoError>();
             assert!(downcast_io_error.is_some());
             assert_eq!(downcast_io_error.unwrap().kind(), kind);
+        }
+    }
+
+    #[test]
+    fn sha256_mismatch_io_errors_map_to_bad_digest() {
+        let io_error = IoError::new(
+            ErrorKind::InvalidData,
+            rustfs_rio::Sha256Mismatch {
+                expected_sha256: "expected".to_string(),
+                calculated_sha256: "calculated".to_string(),
+            },
+        );
+        let api_error = ApiError::from(io_error);
+        assert_eq!(api_error.code, S3ErrorCode::BadDigest);
+        assert_eq!(api_error.message, ApiError::error_code_to_message(&S3ErrorCode::BadDigest));
+
+        let storage_error = StorageError::Io(IoError::new(
+            ErrorKind::InvalidData,
+            rustfs_rio::Sha256Mismatch {
+                expected_sha256: "expected".to_string(),
+                calculated_sha256: "calculated".to_string(),
+            },
+        ));
+        let api_error = ApiError::from(storage_error);
+        assert_eq!(api_error.code, S3ErrorCode::BadDigest);
+        assert_eq!(api_error.message, ApiError::error_code_to_message(&S3ErrorCode::BadDigest));
+    }
+
+    #[test]
+    fn upload_stream_sha256_mismatch_maps_to_bad_digest() {
+        let api_error = ApiError::from(IoError::other(s3s::UploadStreamError::Sha256Mismatch));
+        assert_eq!(api_error.code, S3ErrorCode::BadDigest);
+        assert_eq!(api_error.message, ApiError::error_code_to_message(&S3ErrorCode::BadDigest));
+
+        let api_error = ApiError::from(StorageError::Io(IoError::other(s3s::UploadStreamError::Sha256Mismatch)));
+        assert_eq!(api_error.code, S3ErrorCode::BadDigest);
+        assert_eq!(api_error.message, ApiError::error_code_to_message(&S3ErrorCode::BadDigest));
+    }
+
+    #[test]
+    fn other_upload_stream_errors_do_not_map_to_bad_digest() {
+        let errors = [
+            s3s::UploadStreamError::Underlying(Box::new(IoError::other("underlying body error"))),
+            s3s::UploadStreamError::LengthMismatch,
+            s3s::UploadStreamError::Incomplete,
+        ];
+
+        for error in errors {
+            let api_error = ApiError::from(IoError::other(error));
+            assert_eq!(api_error.code, S3ErrorCode::InternalError);
+        }
+
+        let errors = [
+            s3s::UploadStreamError::Underlying(Box::new(IoError::other("underlying body error"))),
+            s3s::UploadStreamError::LengthMismatch,
+            s3s::UploadStreamError::Incomplete,
+        ];
+
+        for error in errors {
+            let api_error = ApiError::from(StorageError::Io(IoError::other(error)));
+            assert_eq!(api_error.code, S3ErrorCode::InternalError);
         }
     }
 


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Preserve typed upload body errors through small-eager, zero-copy, compressed, extract, and regular streaming PUT adapters.
- Match only `UploadStreamError::Sha256Mismatch` when converting request errors to S3 `BadDigest`; `Underlying`, `LengthMismatch`, and `Incomplete` remain non-digest errors.
- Preserve the typed `rustfs_rio::Sha256Mismatch` source from `HashReader` and map it through direct and storage I/O conversions.
- Use an `s3s 0.15.0` child commit that only exports the existing upload stream error enum, retaining the version adopted by main.
- Add focused coverage for source retention, eager body paths, both API conversion paths, and every non-digest upload stream variant.

## Verification

- `CARGO_INCREMENTAL=0 cargo test -p rustfs upload_stream_ --lib`
- `CARGO_INCREMENTAL=0 cargo test -p rustfs sha256_mismatch_ --lib`
- `CARGO_INCREMENTAL=0 cargo test -p rustfs read_small_put_body_exact_direct_rejects_error_after_partial_read --lib`
- `CARGO_INCREMENTAL=0 cargo test -p rustfs-rio sha256_mismatch_retains_typed_io_error_source --lib`
- `cargo metadata --locked --format-version 1`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo fmt --all --check` in the s3s worktree
- `CARGO_INCREMENTAL=0 cargo check -p s3s --lib --locked` in the s3s worktree
- `git diff --check` in the s3s worktree

## Impact

Tampered signed payloads are classified through typed errors and return the standard S3 `BadDigest` response. Other upload stream variants no longer depend on error display text and are not reclassified as digest failures.

## Additional Notes

- Correctness and compatibility review: the source chain reaches both direct and storage I/O mappings, only the exact SHA256 mismatch variant returns `BadDigest`, and the dependency remains `s3s 0.15.0`.
- Simplicity, coverage, and performance review: the adapter removes string formatting and payload-independent branching, adds no body copy or I/O, and focused tests cover every changed branch.
- The pinned [s3s commit](https://github.com/rustfs/s3s/commit/5f22e8d0a37e83f531f653024aac11c72586479a) is a one-line public re-export directly on top of upstream `v0.15.0`.
- Full `make pre-pr` was not run locally because the focused build left 26 GiB free and the repository-wide matrix can exceed that remaining artifact headroom. GitHub Actions provides the full gate.
- Rollback is a direct revert of this change.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
