### PR TITLE
test(heal): wait for versioned fixture copies

### DIFF
--- a/crates/heal/tests/heal_b5_versioned_regression_test.rs
+++ b/crates/heal/tests/heal_b5_versioned_regression_test.rs
@@ -160,6 +160,22 @@ fn xl_meta_path(obj_dir: &Path) -> PathBuf {
     obj_dir.join("xl.meta")
 }
 
+async fn wait_for_two_version_copies(disks: &[PathBuf], bucket: &str, object: &str) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if disks.iter().all(|disk| {
+                let object_dir = object_dir(disk, bucket, object);
+                xl_meta_path(&object_dir).exists() && count_part_files(&object_dir) >= 2
+            }) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("PUT rename tails must converge before wiping the versioned fixture");
+}
+
 fn recreate_heal_opts() -> HealOpts {
     // Mirrors the proven-working object heal opts in
     // `heal_integration_test::test_heal_format_with_data`.
@@ -289,6 +305,7 @@ mod serial_tests {
         let data_v2 = versioned_test_data(20);
         let v1 = put_versioned(&ecstore, bucket, object, &data_v1).await; // OLD, non-latest
         let v2 = put_versioned(&ecstore, bucket, object, &data_v2).await; // latest
+        wait_for_two_version_copies(&disk_paths, bucket, object).await;
 
         // ── Pre-wipe: prove the fixture actually has 2 versions on disk[0] ──
         let obj_dir0 = object_dir(&disk_paths[0], bucket, object);


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Wait for both versioned PUT rename tails to materialize two shard files on every fixture disk before wiping disk 0.
- Keep the existing pre-wipe, heal, restored-shard, and version-content assertions unchanged.
- Bound the fixture wait to five seconds so a real write convergence failure still fails closed.

## Verification

- `CARGO_INCREMENTAL=0 cargo test -p rustfs-heal --test heal_b5_versioned_regression_test serial_tests::test_heal_old_nonlatest_version_after_disk_wipe -- --exact`
- The exact final test binary passed 10 additional consecutive executions.
- `cargo fmt --all --check`
- `git diff --check`

## Impact

Test-only. This removes a false failure when early-ack PUT returns before background shard rename tails finish; heal production behavior and assertions are unchanged.

## Additional Notes

- The main CI failure occurred before disk corruption or heal execution: the fixture expected two `part.*` files on disk 0 and observed one.
- The bounded wait follows the existing fixture convergence pattern added in #6549, which did not cover this B5 versioned test.
- Correctness review: the wait requires `xl.meta` plus both version shards on every disk, times out instead of skipping, and preserves all exact post-heal oracles.
- Simplicity review: one test helper and one call are the complete production-independent diff.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
