### PR TITLE
fix(ci): complete Keycloak live test profile

### DIFF
--- a/scripts/test/fixtures/keycloak-rustfs-ci-realm.json
+++ b/scripts/test/fixtures/keycloak-rustfs-ci-realm.json
@@ -27,9 +27,12 @@
     {
       "id": "00000000-0000-0000-0000-000000000001",
       "username": "alice",
+      "firstName": "Alice",
+      "lastName": "CI",
       "email": "alice@example.test",
       "emailVerified": true,
       "enabled": true,
+      "requiredActions": [],
       "credentials": [
         {
           "type": "password",

--- a/scripts/test/oidc_keycloak_live.sh
+++ b/scripts/test/oidc_keycloak_live.sh
@@ -128,14 +128,26 @@ token_for_client() {
   local client_id="$1"
   local client_secret="$2"
   local response_file="${WORK_DIR}/token-${client_id}.json"
-  curl --noproxy '*' -fsS "${ISSUER}/protocol/openid-connect/token" \
+  local http_status
+  if ! http_status="$(curl --noproxy '*' -sS \
+    -o "${response_file}" \
+    -w '%{http_code}' \
+    "${ISSUER}/protocol/openid-connect/token" \
     --data-urlencode grant_type=password \
     --data-urlencode "client_id=${client_id}" \
     --data-urlencode "client_secret=${client_secret}" \
     --data-urlencode username=alice \
     --data-urlencode password=alice-password \
-    --data-urlencode scope=openid \
-    >"${response_file}"
+    --data-urlencode scope=openid)"; then
+    echo "Keycloak token request failed for client ${client_id}" >&2
+    cat "${response_file}" >&2 2>/dev/null || true
+    return 1
+  fi
+  if [[ "${http_status}" != 200 ]]; then
+    echo "Keycloak token request for client ${client_id} returned HTTP ${http_status}" >&2
+    cat "${response_file}" >&2
+    return 1
+  fi
   python3 - "${response_file}" "${ISSUER}" "${client_id}" <<'PY'
 import base64
 import json


### PR DESCRIPTION
## Summary

- complete the imported Keycloak test user's required profile fields
- explicitly keep required actions empty for direct password-grant testing
- report token endpoint HTTP status and response body before JWT parsing

## Root cause

The main `OIDC Keycloak Live` run failed with Keycloak 26 `resolve_required_actions` / `Account is not fully set up`. The imported `alice` fixture lacked the default required first/last name attributes, so the token endpoint returned HTTP 400 and the script then emitted a secondary JSON parse error.

## Validation

- `python3 -m json.tool scripts/test/fixtures/keycloak-rustfs-ci-realm.json`
- fixture assertions for `firstName`, `lastName`, and empty `requiredActions`
- `bash -n scripts/test/oidc_keycloak_live.sh`
- `shellcheck scripts/test/oidc_keycloak_live.sh`
- `git diff --check`

Live Docker verification is delegated to the `OIDC Keycloak Live` PR workflow because Docker is unavailable in the local environment.
