### PR TITLE
fix(audit): include deleted objects in bulk audit entries

### DIFF
--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -125,6 +125,7 @@ use http::{HeaderMap, HeaderValue, StatusCode};
 use md5::{Digest as Md5Digest, Md5};
 use metrics::{counter, histogram};
 use pin_project_lite::pin_project;
+use rustfs_audit::ObjectVersion as AuditObjectVersion;
 use rustfs_concurrency::GetObjectQueueSnapshot;
 use rustfs_config::MI_B;
 use rustfs_filemeta::{NULL_VERSION_ID, RestoreStatusOps, parse_restore_obj_status};
@@ -3264,6 +3265,20 @@ impl<T: Send + 'static> Drop for EagerPutCommitOwner<T> {
             }
         });
     }
+}
+
+fn successful_delete_audit_objects(
+    delete: &s3s::dto::Delete,
+    successful_results: impl IntoIterator<Item = bool>,
+) -> Vec<AuditObjectVersion> {
+    delete
+        .objects
+        .iter()
+        .zip(successful_results)
+        .filter_map(|(requested, successful)| {
+            successful.then(|| AuditObjectVersion::new(requested.key.clone(), requested.version_id.clone()))
+        })
+        .collect()
 }
 
 fn normalize_delete_objects_version_id(
@@ -8694,6 +8709,13 @@ impl DefaultObjectUsecase {
             deleted: Some(deleted),
             errors: Some(errors),
             ..Default::default()
+        };
+        let helper = if helper.wants_audit_object_info() {
+            let audit_objects =
+                successful_delete_audit_objects(&delete, delete_results.iter().map(|result| result.delete_object.is_some()));
+            helper.audit_objects(audit_objects)
+        } else {
+            helper
         };
 
         let replication_deletes = if replicate_deletes {
@@ -18007,6 +18029,63 @@ mod tests {
             .expect_err("an uninitialized store should be reported after non-force admission");
         assert_eq!(err.code(), &S3ErrorCode::InternalError);
         assert_eq!(err.message(), Some("Not init"));
+    }
+
+    #[test]
+    fn delete_objects_audit_details_include_only_successful_request_entries() {
+        let requested = vec![
+            ObjectIdentifier {
+                key: "first-key".to_string(),
+                version_id: None,
+                ..Default::default()
+            },
+            ObjectIdentifier {
+                key: "denied-key".to_string(),
+                version_id: Some(Uuid::new_v4().to_string()),
+                ..Default::default()
+            },
+            ObjectIdentifier {
+                key: "versioned-key".to_string(),
+                version_id: Some("requested-version".to_string()),
+                ..Default::default()
+            },
+        ];
+
+        let objects = successful_delete_audit_objects(
+            &Delete {
+                objects: requested,
+                quiet: Some(true),
+            },
+            [true, false, true],
+        );
+
+        assert_eq!(
+            objects,
+            vec![
+                AuditObjectVersion::new("first-key".to_string(), None),
+                AuditObjectVersion::new("versioned-key".to_string(), Some("requested-version".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn delete_objects_audit_details_are_empty_when_every_entry_fails() {
+        let requested = vec![ObjectIdentifier {
+            key: "failed-key".to_string(),
+            version_id: None,
+            ..Default::default()
+        }];
+
+        assert!(
+            successful_delete_audit_objects(
+                &Delete {
+                    objects: requested,
+                    quiet: None,
+                },
+                [false]
+            )
+            .is_empty()
+        );
     }
 
     #[test]

--- a/rustfs/src/storage/helper.rs
+++ b/rustfs/src/storage/helper.rs
@@ -22,6 +22,7 @@ use hashbrown::HashMap;
 use http::StatusCode;
 use metrics::counter;
 use rustfs_audit::{
+    ObjectVersion,
     entity::{ApiDetails, ApiDetailsBuilder, AuditEntryBuilder},
     global::AuditLogger,
 };
@@ -246,6 +247,11 @@ impl OperationHelper {
         matches!(self, Self::Enabled(state) if state.event_builder.is_some())
     }
 
+    /// True when the audit entry can include object details.
+    pub fn wants_audit_object_info(&self) -> bool {
+        matches!(self, Self::Enabled(state) if state.audit_builder.is_some())
+    }
+
     #[cfg(test)]
     pub(crate) fn event_args(&self) -> Option<rustfs_notify::EventArgs> {
         match self {
@@ -260,6 +266,17 @@ impl OperationHelper {
             && let Some(builder) = state.event_builder.take()
         {
             state.event_builder = Some(builder.object(convert_ecstore_object_info(object_info)));
+        }
+        self
+    }
+
+    /// Sets nonempty object details on the audit entry.
+    pub fn audit_objects(mut self, objects: Vec<ObjectVersion>) -> Self {
+        if !objects.is_empty()
+            && let Self::Enabled(state) = &mut self
+            && state.audit_builder.is_some()
+        {
+            state.api_builder = state.api_builder.clone().objects(objects);
         }
         self
     }
@@ -432,6 +449,7 @@ mod tests {
     use base64::Engine as _;
     use http::{Extensions, HeaderMap, HeaderValue, Method, Uri};
     use metrics::{Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Metadata, SharedString, Unit};
+    use rustfs_audit::ObjectVersion;
     use rustfs_credentials::Credentials;
     use rustfs_s3_ops::S3Operation;
     use rustfs_s3_types::EventName;
@@ -551,6 +569,49 @@ mod tests {
                 assert_eq!(event_args.object.name, "prefix/issue-2292.txt");
                 assert_eq!(event_args.version_id, "version-123");
                 assert_eq!(event_args.req_params.get("principalId").map(String::as_str), Some("notifyTag"));
+            },
+        );
+    }
+
+    #[test]
+    fn operation_helper_adds_objects_to_audit_details() {
+        with_vars(
+            [
+                (rustfs_config::ENV_NOTIFY_ENABLE, Some("false")),
+                (rustfs_config::ENV_AUDIT_ENABLE, Some("true")),
+            ],
+            || {
+                refresh_notify_module_enabled();
+                refresh_audit_module_enabled();
+
+                let input = DeleteObjectTaggingInput::builder()
+                    .bucket("test-bucket".to_string())
+                    .key("test-key".to_string())
+                    .build()
+                    .expect("delete object tagging input should build");
+                let req = build_request(input, Method::DELETE, Uri::from_static("/test-bucket"));
+                let objects = vec![
+                    ObjectVersion::new("first-key".to_string(), None),
+                    ObjectVersion::new("second-key".to_string(), Some("version-123".to_string())),
+                ];
+                let mut empty_helper = OperationHelper::new(&req, EventName::ObjectRemovedDelete, S3Operation::DeleteObjects)
+                    .audit_objects(Vec::new());
+                let OperationHelper::Enabled(empty_state) = &mut empty_helper else {
+                    panic!("helper should be enabled when the audit switch is on");
+                };
+                assert!(empty_state.api_builder.0.objects.is_none());
+                empty_state.audit_builder.take();
+
+                let result = Ok(S3Response::new(DeleteObjectTaggingOutput::default()));
+                let mut helper = OperationHelper::new(&req, EventName::ObjectRemovedDelete, S3Operation::DeleteObjects)
+                    .audit_objects(objects.clone())
+                    .complete(&result);
+
+                let OperationHelper::Enabled(state) = &mut helper else {
+                    panic!("helper should be enabled when the audit switch is on");
+                };
+                let audit_entry = state.audit_builder.take().expect("audit builder should exist").build();
+                assert_eq!(audit_entry.api.objects, Some(objects));
             },
         );
     }


### PR DESCRIPTION
## Related Issues

Fixes #6589.

## Summary of Changes

Populate `api.objects` on successful S3 `DeleteObjects` audit entries with only the request entries whose storage outcomes succeeded. Preserve each requested object key and optional version ID, including for quiet requests.

Keep `api.objects` omitted when every entry fails, and avoid constructing the audit object list when auditing is disabled.

## Verification

- `cargo fmt --all --check`
- `cargo test -p rustfs audit_details`
- `cargo test -p rustfs-audit`
- `git diff --check`

## Impact

Global audit consumers can identify successfully deleted objects from a `DeleteObjects` entry. The JSON change is additive for successful batches; failed or denied entries are not represented as deleted, and empty success lists remain omitted.

S3 responses, bucket notifications, replication behavior, and individual `DeleteObject` audit entries are unchanged.

## Additional Notes

The audit entry records the version ID supplied in the request rather than a generated delete-marker version ID.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
