### PR TITLE
fix(startup): avoid blocking on resync reconcile

### DIFF
--- a/rustfs/src/connect/offline/bundle_writer.rs
+++ b/rustfs/src/connect/offline/bundle_writer.rs
@@ -335,7 +335,7 @@ fn valid_payload(collector: OfflineCollector, value: &serde_json::Value) -> bool
                 && object.get("totalBytes").and_then(serde_json::Value::as_u64).is_some()
                 && object.get("underPressure").and_then(serde_json::Value::as_bool).is_some()
         }),
-        OfflineCollector::FilesystemSummary => value.as_array().is_some_and(ordered_strings),
+        OfflineCollector::FilesystemSummary => value.as_array().is_some_and(|values| ordered_strings(values.as_slice())),
         OfflineCollector::NetworkSummary => value.as_object().is_some_and(|object| {
             object.len() == 2
                 && object.get("bondCount").and_then(serde_json::Value::as_u64).is_some()

--- a/rustfs/src/startup_bucket_metadata.rs
+++ b/rustfs/src/startup_bucket_metadata.rs
@@ -14,42 +14,46 @@
 
 use crate::storage_api::startup::bucket_metadata::contract::bucket::{BucketOperations, BucketOptions};
 use crate::storage_api::startup::bucket_metadata::{
-    ECStore, get_global_replication_pool, init_bucket_metadata_sys, reconcile_bucket_resync_target_intents,
-    try_migrate_bucket_metadata, try_migrate_iam_config,
+    ECStore, Error as StorageError, Result as StorageResult, get_global_replication_pool, init_bucket_metadata_sys,
+    reconcile_bucket_resync_target_intents, try_migrate_bucket_metadata, try_migrate_iam_config,
 };
 use std::{
-    io::{Error, Result},
+    io::{Error as IoError, Result as IoResult},
     sync::Arc,
 };
 use tokio_util::sync::CancellationToken;
 
-pub(crate) async fn init_embedded_bucket_metadata_runtime(store: Arc<ECStore>, ctx: &CancellationToken) -> Result<Vec<String>> {
+const EVENT_REPLICATION_RESYNC_STARTUP_BACKGROUND_FAILED: &str = "replication_resync_startup_background_failed";
+const LOG_COMPONENT_STARTUP_BUCKET_METADATA: &str = "startup_bucket_metadata";
+const LOG_SUBSYSTEM_REPLICATION: &str = "replication";
+
+pub(crate) async fn init_embedded_bucket_metadata_runtime(store: Arc<ECStore>, ctx: &CancellationToken) -> IoResult<Vec<String>> {
     let buckets_list = store
         .list_bucket(&BucketOptions {
             no_metadata: true,
             ..Default::default()
         })
         .await
-        .map_err(|err| Error::other(format!("list_bucket: {err}")))?;
+        .map_err(|err| IoError::other(format!("list_bucket: {err}")))?;
 
     let buckets: Vec<String> = buckets_list.into_iter().map(|v| v.name).collect();
 
     try_migrate_bucket_metadata(store.clone()).await;
     init_bucket_metadata_sys(store.clone(), buckets.clone()).await;
     try_migrate_iam_config(store).await;
-    reconcile_bucket_resync_target_intents(&buckets, ctx).await?;
+    spawn_bucket_resync_startup_reconcile(buckets.clone(), ctx.clone(), false);
 
     Ok(buckets)
 }
 
-pub(crate) async fn init_bucket_metadata_runtime(store: Arc<ECStore>, ctx: CancellationToken) -> Result<Vec<String>> {
+pub(crate) async fn init_bucket_metadata_runtime(store: Arc<ECStore>, ctx: CancellationToken) -> IoResult<Vec<String>> {
     let buckets_list = store
         .list_bucket(&BucketOptions {
             no_metadata: true,
             ..Default::default()
         })
         .await
-        .map_err(Error::other)?;
+        .map_err(IoError::other)?;
 
     let buckets: Vec<String> = buckets_list.into_iter().map(|v| v.name).collect();
 
@@ -57,11 +61,60 @@ pub(crate) async fn init_bucket_metadata_runtime(store: Arc<ECStore>, ctx: Cance
 
     try_migrate_iam_config(store.clone()).await;
     init_bucket_metadata_sys(store, buckets.clone()).await;
-    reconcile_bucket_resync_target_intents(&buckets, &ctx).await?;
-
-    if let Some(pool) = get_global_replication_pool() {
-        pool.init_resync(ctx, buckets.clone()).await?;
-    }
+    spawn_bucket_resync_startup_reconcile(buckets.clone(), ctx, true);
 
     Ok(buckets)
+}
+
+fn spawn_bucket_resync_startup_reconcile(buckets: Vec<String>, ctx: CancellationToken, init_resync_after_reconcile: bool) {
+    tokio::spawn(async move {
+        if let Err(error) = run_bucket_resync_startup_reconcile(buckets, ctx, init_resync_after_reconcile).await {
+            if !report_bucket_resync_startup_background_error(&error) {
+                return;
+            }
+            tracing::error!(
+                event = EVENT_REPLICATION_RESYNC_STARTUP_BACKGROUND_FAILED,
+                component = LOG_COMPONENT_STARTUP_BUCKET_METADATA,
+                subsystem = LOG_SUBSYSTEM_REPLICATION,
+                result = "failed",
+                init_resync_after_reconcile,
+                error = %error,
+                "Bucket metadata startup resync reconcile failed in background"
+            );
+        }
+    });
+}
+
+async fn run_bucket_resync_startup_reconcile(
+    buckets: Vec<String>,
+    ctx: CancellationToken,
+    init_resync_after_reconcile: bool,
+) -> StorageResult<()> {
+    reconcile_bucket_resync_target_intents(&buckets, &ctx).await?;
+
+    if init_resync_after_reconcile {
+        let Some(pool) = get_global_replication_pool() else {
+            return Err(StorageError::other("replication pool is not initialized"));
+        };
+        pool.init_resync(ctx, buckets).await?;
+    }
+
+    Ok(())
+}
+
+fn report_bucket_resync_startup_background_error(error: &StorageError) -> bool {
+    !matches!(error, StorageError::OperationCanceled)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn startup_resync_background_error_reporting_skips_shutdown() {
+        assert!(!report_bucket_resync_startup_background_error(&StorageError::OperationCanceled));
+        assert!(report_bucket_resync_startup_background_error(&StorageError::other(
+            "replication pool is not initialized"
+        )));
+    }
 }

--- a/rustfs/src/storage_api.rs
+++ b/rustfs/src/storage_api.rs
@@ -227,8 +227,8 @@ pub(crate) mod startup {
         }
 
         pub(crate) use crate::storage::storage_api::{
-            ECStore, get_global_replication_pool, init_bucket_metadata_sys, reconcile_bucket_resync_target_intents,
-            try_migrate_bucket_metadata, try_migrate_iam_config,
+            ECStore, Error, Result, get_global_replication_pool, init_bucket_metadata_sys,
+            reconcile_bucket_resync_target_intents, try_migrate_bucket_metadata, try_migrate_iam_config,
         };
     }
 


### PR DESCRIPTION
## Related Issues
Fixes #6573.
Tracks rustfs/backlog#2018.

## Summary of Changes
Move startup replication resync target reconcile out of the critical startup path. Startup now schedules the reconcile work in a background task, and the normal server path starts resync recovery only after that background reconcile succeeds. This keeps lock contention on `.rustfs.sys/bucket-targets/<bucket>/transaction.lock` from making a joining node exit fatally while preserving the existing resync ordering.

Also expose the storage error/result types through the existing startup bucket-metadata facade and fix a Linux-only `Option::is_some_and` function pointer mismatch found while building the validation binary.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `make architecture-migration-check`
- `./scripts/check_logging_guardrails.sh`
- `cargo check -p rustfs --lib`
- `make pre-pr` reached nextest after passing formatting, guard scripts, log analyzer rules, and clippy; local sandboxed nextest failed on listener-bind permission errors in unrelated site-replication tests.
- `make test` was rerun outside the sandbox; the listener-bind failures did not reproduce, but the run stopped on an unrelated offline collector timeout after 2,753 passing tests because nextest fail-fast cancelled the remaining tests.
- Linux profiling build of `rustfs @b81a927f64c3ceb958818c98abef35aa5122c772` succeeded with rustc 1.98.0.
- Deployed the profiling build to a private four-node Linux validation cluster with `RUSTFS_OBJECT_LOCK_ACQUIRE_TIMEOUT=30`; all nodes reported the new commit and `/minio/health/live` plus `/minio/health/ready` returned 200.
- During a bounded mixed PUT/GET/STAT workload, restarted one node; the node rejoined on the first restart, the workload completed with only transient 503/iam-not-ready responses during restart, and recent service logs contained no `FATAL`, lock acquisition timeout, or startup resync reconcile failure entries.

## Impact
Node startup no longer fails hard on transient bucket-target metadata transaction lock contention during replication resync target reconcile. Actual resync target metadata reconciliation still runs and retains its retry/cancellation behavior, but it is no longer a startup readiness gate.

## Additional Notes
No disk format, S3 API, wire protocol, or operator configuration compatibility changes are intended.
