### PR TITLE
test(diagnose): run binary smoke in CI

### DIFF
--- a/rustfs/tests/diagnose_e2e.rs
+++ b/rustfs/tests/diagnose_e2e.rs
@@ -215,11 +215,8 @@ fn cli_parses_diagnose_and_keeps_legacy_server_routing() {
     assert!(matches!(legacy, Ok(CommandResult::Server(_))));
 }
 
-/// True-binary smoke test. Ignored by default: building the full rustfs
-/// binary is expensive; run locally with
-/// `cargo test -p rustfs --test diagnose_e2e -- --ignored`.
+/// True-binary smoke test for the user-facing diagnose command.
 #[test]
-#[ignore = "builds the full rustfs binary; run with -- --ignored"]
 fn binary_smoke_diagnose_json() {
     let dir = tempfile::tempdir().expect("tempdir");
     std::fs::write(dir.path().join("rustfs.log"), quorum_and_faulty_lines()).expect("write");


### PR DESCRIPTION
## Related Issues

rustfs/backlog#1897

## Summary

Run the existing true-binary `rustfs diagnose --format json` smoke test in the default suite instead of leaving it permanently ignored.

## Verification

- `rustfmt --edition 2024 --check rustfs/tests/diagnose_e2e.rs`
- `git diff --check`
- fresh CI will execute the binary smoke through the regular test lane

## Impact

Test-only; production code is unchanged.