### PR TITLE
fix(ci): restore merged main static gates

### DIFF
--- a/crates/ecstore/src/object_api/mod.rs
+++ b/crates/ecstore/src/object_api/mod.rs
@@ -77,6 +77,7 @@ pub(crate) fn has_encrypted_part_layout_marker(metadata: &HashMap<String, String
 }
 
 pub(crate) fn legacy_encrypted_range_seek_enabled() -> bool {
+    // RUSTFS_COMPAT_TODO(backlog-1316): keep the rolling-upgrade kill switch. Remove after the minimum supported release uses the marker protocol.
     // On by default (backlog-1316 Phase A): every misfit direction falls back to the
     // conservative full read — MPUs created without a candidate marker, completions
     // that cannot revalidate the candidate against the data_dir under the uploadId

--- a/crates/kms/src/config_secret.rs
+++ b/crates/kms/src/config_secret.rs
@@ -79,7 +79,13 @@ const SECRET_FIELDS: &[SecretField] = &[
         label: "kms.local.master_key",
     },
     SecretField {
-        segments: &[&["backend_config"], &["VaultKV2", "Vault"], &["auth_method"], &["Token"], &["token"]],
+        segments: &[
+            &["backend_config"],
+            &["VaultKV2", "Vault"],
+            &["auth_method"],
+            &["Token"],
+            &["token"],
+        ],
         label: "kms.vault.token",
     },
     SecretField {
@@ -93,7 +99,13 @@ const SECRET_FIELDS: &[SecretField] = &[
         label: "kms.vault.approle.secret_id",
     },
     SecretField {
-        segments: &[&["backend_config"], &["VaultTransit"], &["auth_method"], &["Token"], &["token"]],
+        segments: &[
+            &["backend_config"],
+            &["VaultTransit"],
+            &["auth_method"],
+            &["Token"],
+            &["token"],
+        ],
         label: "kms.vault_transit.token",
     },
     SecretField {
@@ -279,9 +291,7 @@ fn open_value(label: &str, sealed: &str, secret: &str) -> Result<String> {
     let encoded = sealed
         .strip_prefix(SEALED_VALUE_PREFIX)
         .expect("caller checks the sealed prefix");
-    let payload = BASE64_STANDARD
-        .decode(encoded)
-        .map_err(|_| sealed_value_unreadable(label))?;
+    let payload = BASE64_STANDARD.decode(encoded).map_err(|_| sealed_value_unreadable(label))?;
     if payload.len() <= LOCAL_KMS_MASTER_KEY_SALT_LEN + NONCE_LEN {
         return Err(sealed_value_unreadable(label));
     }

--- a/rustfs/src/admin/handlers/kms_dynamic.rs
+++ b/rustfs/src/admin/handlers/kms_dynamic.rs
@@ -286,20 +286,20 @@ pub async fn load_kms_config() -> Option<KmsConfig> {
         Ok(data) => {
             let (data, unseal_outcome) =
                 match open_persisted_kms_config(&data, rustfs_kms::config_secret::config_secret_from_env().as_deref()) {
-                Ok(opened) => opened,
-                Err(e) => {
-                    error!(
-                        component = LOG_COMPONENT_ADMIN,
-                        subsystem = LOG_SUBSYSTEM_KMS,
-                        event = "kms_config_unseal_failed",
-                        storage_path = KMS_CONFIG_PATH,
-                        result = "config_unseal_failed",
-                        error = %e,
-                        "admin kms dynamic state"
-                    );
-                    return None;
-                }
-            };
+                    Ok(opened) => opened,
+                    Err(e) => {
+                        error!(
+                            component = LOG_COMPONENT_ADMIN,
+                            subsystem = LOG_SUBSYSTEM_KMS,
+                            event = "kms_config_unseal_failed",
+                            storage_path = KMS_CONFIG_PATH,
+                            result = "config_unseal_failed",
+                            error = %e,
+                            "admin kms dynamic state"
+                        );
+                        return None;
+                    }
+                };
             if !unseal_outcome.plaintext.is_empty() {
                 warn!(
                     component = LOG_COMPONENT_ADMIN,
@@ -311,40 +311,40 @@ pub async fn load_kms_config() -> Option<KmsConfig> {
                 );
             }
             match decode_persisted_kms_config(&data) {
-            Ok((config, is_legacy_local)) => {
-                if is_legacy_local {
-                    warn!(
+                Ok((config, is_legacy_local)) => {
+                    if is_legacy_local {
+                        warn!(
+                            component = LOG_COMPONENT_ADMIN,
+                            subsystem = LOG_SUBSYSTEM_KMS,
+                            event = "kms_legacy_local_config_loaded",
+                            storage_path = KMS_CONFIG_PATH,
+                            state = "legacy_config_accepted",
+                            "admin kms dynamic state"
+                        );
+                    }
+                    info!(
                         component = LOG_COMPONENT_ADMIN,
                         subsystem = LOG_SUBSYSTEM_KMS,
-                        event = "kms_legacy_local_config_loaded",
+                        event = "kms_config_loaded",
                         storage_path = KMS_CONFIG_PATH,
-                        state = "legacy_config_accepted",
+                        state = "config_loaded",
                         "admin kms dynamic state"
                     );
+                    Some(config)
                 }
-                info!(
-                    component = LOG_COMPONENT_ADMIN,
-                    subsystem = LOG_SUBSYSTEM_KMS,
-                    event = "kms_config_loaded",
-                    storage_path = KMS_CONFIG_PATH,
-                    state = "config_loaded",
-                    "admin kms dynamic state"
-                );
-                Some(config)
+                Err(e) => {
+                    error!(
+                        component = LOG_COMPONENT_ADMIN,
+                        subsystem = LOG_SUBSYSTEM_KMS,
+                        event = "kms_config_deserialize_failed",
+                        storage_path = KMS_CONFIG_PATH,
+                        result = "config_deserialize_failed",
+                        error = %e,
+                        "admin kms dynamic state"
+                    );
+                    None
+                }
             }
-            Err(e) => {
-                error!(
-                    component = LOG_COMPONENT_ADMIN,
-                    subsystem = LOG_SUBSYSTEM_KMS,
-                    event = "kms_config_deserialize_failed",
-                    storage_path = KMS_CONFIG_PATH,
-                    result = "config_deserialize_failed",
-                    error = %e,
-                    "admin kms dynamic state"
-                );
-                None
-            }
-        }
         }
         Err(e) => {
             // Config not found is normal on first run: `read_config` maps a missing or
@@ -1330,7 +1330,9 @@ mod tests {
         rustfs_kms::KmsConfig {
             backend: rustfs_kms::KmsBackend::VaultKv2,
             backend_config: rustfs_kms::BackendConfig::VaultKv2(Box::new(rustfs_kms::VaultConfig {
-                auth_method: rustfs_kms::VaultAuthMethod::Token { token: token.to_string() },
+                auth_method: rustfs_kms::VaultAuthMethod::Token {
+                    token: token.to_string(),
+                },
                 ..rustfs_kms::VaultConfig::default()
             })),
             ..rustfs_kms::KmsConfig::default()
@@ -1369,7 +1371,10 @@ mod tests {
 
         let bytes = seal_persisted_kms_config(&config, None).expect("warn-only persistence stays allowed");
         let rendered = String::from_utf8(bytes.clone()).expect("persisted config is utf-8 JSON");
-        assert!(rendered.contains("s.vault-root-token"), "without a secret the legacy plaintext format is kept");
+        assert!(
+            rendered.contains("s.vault-root-token"),
+            "without a secret the legacy plaintext format is kept"
+        );
 
         let (opened_bytes, outcome) = open_persisted_kms_config(&bytes, None).expect("plaintext config loads without a secret");
         assert_eq!(outcome.plaintext, vec!["kms.vault.token"]);


### PR DESCRIPTION
## Summary

- format the KMS config-sealing changes merged by #6599
- restore the registered `backlog-1316` compatibility cleanup marker removed by #6598

## Verification

- direct `rustfmt --edition 2024 --check` on all affected files
- `scripts/check_architecture_migration_rules.sh`
- `python3 scripts/check_test_wiring.py`
- `scripts/check_no_planning_docs.sh`
- `git diff --check`

## Impact

Static-gate repair only; behavior is unchanged.