### PR TITLE
fix(ci): restore merged main Clippy lanes

### DIFF
--- a/crates/ecstore/src/io_support/rio.rs
+++ b/crates/ecstore/src/io_support/rio.rs
@@ -328,7 +328,9 @@ pub struct WriteEncryption {
 /// after every node (and every RustFS warm/replication target that receives
 /// raw ciphertext) runs a release with v2 read support. Reading v2 objects
 /// needs no switch — the decrypt reader dispatches on the frame type byte.
+#[cfg(not(feature = "rio-v2"))]
 pub(crate) const ENV_RUSTFS_ENCRYPTION_FRAME_V2: &str = "RUSTFS_ENCRYPTION_FRAME_V2";
+#[cfg(not(feature = "rio-v2"))]
 pub(crate) const DEFAULT_RUSTFS_ENCRYPTION_FRAME_V2: bool = false;
 
 #[cfg(not(feature = "rio-v2"))]

--- a/crates/kms/src/config_secret.rs
+++ b/crates/kms/src/config_secret.rs
@@ -338,7 +338,7 @@ mod tests {
         serde_json::to_value(&config).expect("config serializes")
     }
 
-    fn token_at<'a>(document: &'a Value) -> &'a str {
+    fn token_at(document: &Value) -> &str {
         document["backend_config"]["VaultKV2"]["auth_method"]["Token"]["token"]
             .as_str()
             .expect("token leaf exists")


### PR DESCRIPTION
Fixes two deterministic main CI failures introduced by the merged queue:

- exclude the legacy frame switch constants when rio-v2 excludes their only production and test users
- elide an unnecessary lifetime in the KMS test helper

Direct rustfmt and `git diff --check` pass. Fresh CI provides the default and rio-v2 Clippy checks.