### PR TITLE
fix(ci): clear remaining merged main Clippy lints

### DIFF
--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -3275,9 +3275,8 @@ fn successful_delete_audit_objects(
         .objects
         .iter()
         .zip(successful_results)
-        .filter_map(|(requested, successful)| {
-            successful.then(|| AuditObjectVersion::new(requested.key.clone(), requested.version_id.clone()))
-        })
+        .filter(|(_, successful)| *successful)
+        .map(|(requested, _)| AuditObjectVersion::new(requested.key.clone(), requested.version_id.clone()))
         .collect()
 }
 

--- a/rustfs/src/connect/client.rs
+++ b/rustfs/src/connect/client.rs
@@ -64,7 +64,7 @@ pub(crate) enum RotationAttempt {
 }
 
 enum SingleRequest {
-    Response(CredentialResponse),
+    Response(Box<CredentialResponse>),
     Unavailable {
         status: Option<StatusCode>,
         retry_after: Option<Duration>,
@@ -329,7 +329,7 @@ impl ConnectClient {
         let path = format!("clusterDevices/{}:rotateCredential", credential.uid);
         let url = self.url(&path)?;
         let response = match self.send_once(StatusCode::OK, client.post(url).json(&body)).await? {
-            SingleRequest::Response(response) => response,
+            SingleRequest::Response(response) => *response,
             SingleRequest::Unavailable { status, retry_after } => {
                 return Ok(RotationAttempt::Unavailable { status, retry_after });
             }
@@ -520,7 +520,9 @@ impl ConnectClient {
         };
         let status = response.status();
         if status == success {
-            return decode_response(response).await.map(SingleRequest::Response);
+            return decode_response(response)
+                .await
+                .map(|response| SingleRequest::Response(Box::new(response)));
         }
         if matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) {
             let reason = decode_reason(response).await;


### PR DESCRIPTION
Fixes the two remaining deterministic Clippy failures on main:

- replace the bulk-delete audit `filter_map(bool::then)` with `filter` plus `map`
- box the large successful-response variant in the private Connect request enum

Direct rustfmt, static guard scripts, test-wiring check, and `git diff --check` pass. Fresh CI provides the compile verification.