### PR TITLE
docs(ecstore): correct get_lock_acquire_timeout doc comment

### DIFF
--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -1559,8 +1559,8 @@ impl SetDisks {
     }
 }
 
-/// Get lock acquire timeout from environment variable RUSTFS_LOCK_ACQUIRE_TIMEOUT (in seconds)
-/// Defaults to 30 seconds if not set or invalid
+/// Get lock acquire timeout from environment variable RUSTFS_OBJECT_LOCK_ACQUIRE_TIMEOUT (in seconds)
+/// Defaults to 5 seconds if not set or invalid
 /// Lock acquisition timeout. Cached: this is consulted on every object
 /// lock acquisition and `std::env::var` takes a process-global lock. In test
 /// builds the env var is read directly so `temp_env` overrides take effect.


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

The doc comment on `get_lock_acquire_timeout` in `crates/ecstore/src/set_disk/mod.rs` names `RUSTFS_LOCK_ACQUIRE_TIMEOUT` with a 30-second default, but the function reads `rustfs_config::ENV_OBJECT_LOCK_ACQUIRE_TIMEOUT` / `DEFAULT_OBJECT_LOCK_ACQUIRE_TIMEOUT`, i.e. `RUSTFS_OBJECT_LOCK_ACQUIRE_TIMEOUT` with a 5-second default. Since `RUSTFS_LOCK_ACQUIRE_TIMEOUT` is a real, separate knob read by the lock and scanner crates, following the comment produces no error and no warning — the setting is silently ignored on this path. We hit this while diagnosing lock-acquisition failures on bucket metadata transaction locks: we set the documented variable and concluded from the unchanged timeout that the setting was not being applied, until reading the function body explained it.

This corrects both halves of the comment to match the code. The sibling doc comments in the scanner crate (`crates/scanner/src/scanner.rs`, `crates/scanner/src/scanner_io/cache.rs`) already name their variable and default correctly and are untouched.

## Verification

- `cargo fmt --all --check` (clean)
- `git diff --check` (clean)
- `./scripts/check_doc_paths.sh` (passed)

Comment-only change with no runtime, build, or test effect, verified per the documentation tier in `AGENTS.md` (compilation, Clippy, tests, and the `pre-commit`/`pre-pr` gates are skipped for this tier).

## Impact

Documentation only. Operators reading the source to tune the object lock acquire timeout now find the variable the code actually reads and its real default.

## Additional Notes

N/A
