### PR TITLE
fix(policy): remove six dead error variants

### DIFF
--- a/crates/iam/src/error.rs
+++ b/crates/iam/src/error.rs
@@ -214,15 +214,11 @@ impl From<rustfs_policy::error::Error> for Error {
             rustfs_policy::error::Error::IamSysAlreadyInitialized => Error::IamSysAlreadyInitialized,
             // These policy variants had dead same-name twins on iam::Error (zero
             // construction and zero match sites, removed in backlog#1831); the
-            // message is preserved through StringError instead.
-            err @ (rustfs_policy::error::Error::InvalidServiceType(_)
-            | rustfs_policy::error::Error::InvalidExpiration
-            | rustfs_policy::error::Error::NoAccessKey
-            | rustfs_policy::error::Error::InvalidToken
-            | rustfs_policy::error::Error::InvalidAccessKey
-            | rustfs_policy::error::Error::JWTError(_)
-            | rustfs_policy::error::Error::CredNotInitialized
-            | rustfs_policy::error::Error::ErrCredMalformed) => Error::StringError(err.to_string()),
+            // message is preserved through StringError instead. Their six dead
+            // siblings on policy::Error were deleted outright (backlog#1845).
+            err @ (rustfs_policy::error::Error::InvalidServiceType(_) | rustfs_policy::error::Error::JWTError(_)) => {
+                Error::StringError(err.to_string())
+            }
         }
     }
 }

--- a/crates/policy/src/error.rs
+++ b/crates/policy/src/error.rs
@@ -60,12 +60,6 @@ pub enum Error {
     #[error("invalid service type: {0}")]
     InvalidServiceType(String),
 
-    #[error("malformed credential")]
-    ErrCredMalformed,
-
-    #[error("CredNotInitialized")]
-    CredNotInitialized,
-
     #[error("invalid access key length")]
     InvalidAccessKeyLength,
 
@@ -81,20 +75,8 @@ pub enum Error {
     #[error("jwt err {0}")]
     JWTError(#[from] jsonwebtoken::errors::Error),
 
-    #[error("no access key")]
-    NoAccessKey,
-
-    #[error("invalid token")]
-    InvalidToken,
-
-    #[error("invalid access_key")]
-    InvalidAccessKey,
-
     #[error("action not allowed")]
     IAMActionNotAllowed,
-
-    #[error("invalid expiration")]
-    InvalidExpiration,
 
     #[error("no secret key with access key")]
     NoSecretKeyWithAccessKey,
@@ -343,17 +325,11 @@ mod tests {
             (Error::InvalidArgument, "invalid arguments specified"),
             (Error::IamSysNotInitialized, "not initialized"),
             (Error::InvalidServiceType("invalid".to_string()), "invalid service type: invalid"),
-            (Error::ErrCredMalformed, "malformed credential"),
-            (Error::CredNotInitialized, "CredNotInitialized"),
             (Error::InvalidAccessKeyLength, "invalid access key length"),
             (Error::InvalidSecretKeyLength, "invalid secret key length"),
             (Error::ContainsReservedChars, "access key contains reserved characters =,"),
             (Error::GroupNameContainsReservedChars, "group name contains reserved characters =,"),
-            (Error::NoAccessKey, "no access key"),
-            (Error::InvalidToken, "invalid token"),
-            (Error::InvalidAccessKey, "invalid access_key"),
             (Error::IAMActionNotAllowed, "action not allowed"),
-            (Error::InvalidExpiration, "invalid expiration"),
             (Error::NoSecretKeyWithAccessKey, "no secret key with access key"),
             (Error::NoAccessKeyWithSecretKey, "no access key with secret key"),
             (Error::PolicyTooLarge, "policy too large"),


### PR DESCRIPTION
## Related Issues

Prerequisite for step 8 of rustfs/backlog#1845 (folding the iam-to-policy error mapping). Same shape as #6030, which removed these variants' dead twins on the iam side.

## Summary of Changes

`policy::error::Error` carried six variants with zero construction sites and zero match sites anywhere in the workspace: `ErrCredMalformed`, `CredNotInitialized`, `NoAccessKey`, `InvalidToken`, `InvalidAccessKey`, `InvalidExpiration`. Their only reference was the grouped fallthrough arm in iam's `From<policy::error::Error>` - the arm that exists precisely because their iam-side twins were already dead and deleted in backlog#1831.

Removed the six variants and their rows in the display-message table test. The grouped arm in `crates/iam/src/error.rs` shrinks from eight variants to the two that are actually produced: `InvalidServiceType` (constructed in `service_type.rs`) and `JWTError` (`#[from] jsonwebtoken::errors::Error`).

Verified dead by workspace-wide search before deleting: the only textual matches outside the two error files are keystone's unrelated `KeystoneError::InvalidToken`.

## Verification

- `cargo nextest run -p rustfs-policy -p rustfs-iam` - 992/992 pass
- `cargo check --workspace --exclude e2e_test` - clean
- `cargo clippy -p rustfs-policy -p rustfs-iam --all-targets` - clean; `cargo fmt` applied

## Impact

None: no code could construct or observe these variants. Rendered messages are unaffected.

## Additional Notes

N/A
