### PR TITLE
test(iam): pin the policy-to-iam error mapping and record the fold verdict

### DIFF
--- a/crates/iam/src/error.rs
+++ b/crates/iam/src/error.rs
@@ -186,6 +186,16 @@ impl From<Error> for IamStorageError {
     }
 }
 
+/// Deliberately a flat, exhaustive mapping rather than a wrapper variant
+/// (backlog#1845 step 8 verdict): folding iam::Error into a
+/// `Policy(Arc<policy::Error>)` wrapper would leave ~140 production
+/// construction/match sites across iam and the admin handlers to migrate in
+/// auth-critical code, and a type alias is blocked by the orphan rule (iam's
+/// `From<IamStorageError>` / io conversions cannot be implemented for a
+/// foreign type). The drift risk the fold aimed at is already covered by the
+/// compiler: this match has no catch-all, so any new policy variant fails the
+/// build here until mapped, and `policy_to_iam_mapping_preserves_messages`
+/// pins that every arm keeps the rendered message intact.
 impl From<rustfs_policy::error::Error> for Error {
     fn from(e: rustfs_policy::error::Error) -> Self {
         match e {
@@ -436,5 +446,51 @@ mod tests {
         for (error, expected_message) in test_cases {
             assert_eq!(error.to_string(), expected_message);
         }
+    }
+
+    #[test]
+    fn policy_to_iam_mapping_preserves_messages() {
+        use rustfs_policy::error::Error as PErr;
+        // One representative per policy::error::Error variant. When a new
+        // variant is added, the exhaustive From match breaks the build first;
+        // extend this list in the same change so the message stays pinned.
+        let representatives: Vec<PErr> = vec![
+            PErr::PolicyError(rustfs_policy::policy::Error::NonResource),
+            PErr::StringError("free-form".to_string()),
+            PErr::NoSuchUser("u".to_string()),
+            PErr::NoSuchAccount("a".to_string()),
+            PErr::NoSuchServiceAccount("sa".to_string()),
+            PErr::NoSuchTempAccount("ta".to_string()),
+            PErr::NoSuchGroup("g".to_string()),
+            PErr::NoSuchPolicy,
+            PErr::PolicyInUse,
+            PErr::GroupNotEmpty,
+            PErr::InvalidArgument,
+            PErr::IamSysNotInitialized,
+            PErr::InvalidServiceType("svc".to_string()),
+            PErr::InvalidAccessKeyLength,
+            PErr::InvalidSecretKeyLength,
+            PErr::ContainsReservedChars,
+            PErr::GroupNameContainsReservedChars,
+            PErr::IAMActionNotAllowed,
+            PErr::NoSecretKeyWithAccessKey,
+            PErr::NoAccessKeyWithSecretKey,
+            PErr::PolicyTooLarge,
+            PErr::Io(std::io::Error::other("io detail")),
+            PErr::IamSysAlreadyInitialized,
+        ];
+
+        for policy_err in representatives {
+            let rendered = policy_err.to_string();
+            let iam_err: Error = policy_err.into();
+            assert_eq!(iam_err.to_string(), rendered, "policy->iam conversion must preserve the rendered message");
+        }
+
+        // The one #[from] payload variant: rendering is preserved end to end.
+        let jwt_err =
+            rustfs_policy::error::Error::from(jsonwebtoken::errors::Error::from(jsonwebtoken::errors::ErrorKind::InvalidToken));
+        let rendered = jwt_err.to_string();
+        let iam_err: Error = jwt_err.into();
+        assert_eq!(iam_err.to_string(), rendered);
     }
 }


### PR DESCRIPTION
## Related Issues

Concludes step 8 of rustfs/backlog#1845. Stacked on #6631 (base branch `overtrue/1845-pr8a-policy-dead-variants`); merge that first.

## Summary of Changes

The plan called for folding `iam::Error` into a `policy::Error` `#[from]` wrapper and deleting the 31-arm hand-written mapping. Implementation-time measurement rejected the fold, and this PR records that verdict in the code and pins the mapping instead:

- **Why the fold loses**: the duplicated variants have ~220 construction/match sites (~140 production) across `crates/iam` and the admin handlers - all auth-critical code - that would every one need migration to a wrapper pattern. The cheaper alias route (`type Error = policy::Error` plus moving the two iam-only variants) is blocked by the orphan rule: iam's `From<IamStorageError>`, `From<serde_json::Error>`, and `From<Error> for io::Error` impls cannot be written for a foreign type without moving them into `rustfs-policy`, which would invert the layering.
- **Why the mapping is safe to keep**: it is exhaustive with no catch-all arm, so adding a policy variant fails the build here until mapped - the silent-drift risk the fold targeted does not exist. After #6631 the lossy grouped arm is down to the two variants actually produced (`InvalidServiceType`, `JWTError`), both message-preserving through `StringError`.
- **What this PR adds**: a doc comment on the `From` impl recording the verdict with the evidence, and `policy_to_iam_mapping_preserves_messages` - a totality test constructing one representative of every `policy::error::Error` variant and asserting the conversion preserves the rendered message, so any future arm that redirects or rewords a variant shows up as a test diff.

## Verification

- `cargo nextest run -p rustfs-iam` - 338/338 pass
- `cargo clippy -p rustfs-iam --all-targets` - clean; `cargo fmt` applied

## Impact

None at runtime; test and documentation only.

## Additional Notes

The verdict and its evidence will also be recorded on rustfs/backlog#1845 at acceptance.
