### PR TITLE
fix(ci): suppress macOS-only dead-code warning for INVENTORY_UID

### DIFF
--- a/rustfs/tests/connect_registration.rs
+++ b/rustfs/tests/connect_registration.rs
@@ -57,6 +57,7 @@ const TOKEN_UID: &str = "0198f4b0-6f00-7b60-9271-7d8e9fa0b1c5";
 const FRESH_TOKEN_UID: &str = "0198f4b0-7f00-7c70-a381-8e9fa0b1c2d6";
 const SECOND_TOKEN_UID: &str = "0198f4b0-8f00-7d80-b491-9fa0b1c2d3e7";
 const UNRELATED_TOKEN_UID: &str = "0198f4b0-9f00-7e90-85a1-afb1c2d3e4f8";
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 const INVENTORY_UID: &str = "0198f4b0-af00-7fa0-96b1-bfc1d2e3f509";
 
 struct TestPki {


### PR DESCRIPTION
## Problem

Hourly validation (`cargo clippy --all-targets -- -D warnings`) fails on macOS with:

```
error: constant `INVENTORY_UID` is never used
  --> rustfs/tests/connect_registration.rs:60:7
```

`INVENTORY_UID` is only referenced inside `#[cfg(target_os = "linux")]` test functions (`inventory_first_recovers_a_saved_reenrollment_before_telemetry` and `inventory_retries_with_the_new_credential_after_concurrent_rotation`), so on macOS the constant appears unused and `-D dead-code` turns it into a hard error.

## Fix

Add `#[cfg_attr(not(target_os = "linux"), allow(dead_code))]` to the constant.

## Verification

- `cargo fmt --all --check` passes.
- `cargo check --workspace` passes.
- The `await_holding_lock` warnings in the same file were already fixed in `eaf0d4da8` (block-scoped guards).

Baseline: `8f0d4a20d`
