### PR TITLE
fix(tests): restrict Connect state tempdirs

### DIFF
--- a/rustfs/tests/connect_registration.rs
+++ b/rustfs/tests/connect_registration.rs
@@ -427,10 +427,13 @@ fn secure_tempdir() -> tempfile::TempDir {
         .expect("test home directory must resolve without symlink components");
     fs::set_permissions(&home, fs::Permissions::from_mode(0o700))
         .expect("test home directory permissions must be restricted to the process owner");
-    tempfile::Builder::new()
+    let temp = tempfile::Builder::new()
         .prefix(".connect-registration-")
         .tempdir_in(home)
-        .expect("temporary directory inside the protected home directory")
+        .expect("temporary directory inside the protected home directory");
+    fs::set_permissions(temp.path(), fs::Permissions::from_mode(0o700))
+        .expect("temporary state root permissions must be restricted to the process owner");
+    temp
 }
 
 fn stage_next_identity(temp: &tempfile::TempDir) -> DeviceIdentity {


### PR DESCRIPTION
Fixes the remaining main CI Connect failures by forcing the test state root to mode 0700 instead of inheriting runner umask 022. Static validation passed; the failing sftp lane is the regression oracle. Related to rustfs/backlog#1897.