### PR TITLE
perf(runtime): mark Tokio threads as mimalloc threadpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9980,18 +9980,18 @@ dependencies = [
 
 [[package]]
 name = "rustfs-mimalloc"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a406f4aa07084301d485beec873af6dccc8e3f8762da244743df92038b1db1a6"
+checksum = "ed388b8a3d55818c32973ded41df5215d33ee0f574d9ca03f2731b3007c3284b"
 dependencies = [
  "rustfs-mimalloc-sys",
 ]
 
 [[package]]
 name = "rustfs-mimalloc-sys"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3051b819175f58445d4c369a72f0ab88149f3885ba8bea2aff3be01f53fe7cd"
+checksum = "1c507265df958f6b63f8ccdd21819374186bab5dbdcc3f9c5cf8bff4b2e3f5d0"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -365,8 +365,8 @@ russh-sftp = "2.4.0"
 dav-server = "0.11.0"
 
 # Performance Analysis and Memory Profiling
-rustfs-mimalloc = { version = "0.5.0" }
-rustfs-mimalloc-sys = { version = "0.5.0" }
+rustfs-mimalloc = { version = "0.5.1" }
+rustfs-mimalloc-sys = { version = "0.5.1" }
 hotpath = { version = "0.24.0", default-features = false }
 # Snapshot testing for output format regression detection
 insta = { version = "1.48" }

--- a/rustfs/src/server/runtime.rs
+++ b/rustfs/src/server/runtime.rs
@@ -30,6 +30,12 @@ fn compute_default_thread_stack_size() -> usize {
     }
 }
 
+#[inline]
+fn mark_allocator_threadpool_thread() {
+    #[cfg(not(target_os = "windows"))]
+    rustfs_mimalloc::set_current_thread_in_threadpool();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -160,15 +166,19 @@ pub fn tokio_runtime_builder() -> tokio::runtime::Builder {
         rustfs_utils::get_env_usize(rustfs_config::ENV_MAX_IO_EVENTS_PER_TICK, rustfs_config::DEFAULT_MAX_IO_EVENTS_PER_TICK);
     builder.enable_all().max_io_events_per_tick(max_io_events_per_tick);
 
-    // Optional: Simple log of thread start/stop
-    if print_tokio_thread_enable() {
-        builder
-            .on_thread_start(|| {
-                tracing::trace!(thread_id = ?std::thread::current().id(), "worker thread started");
-            })
-            .on_thread_stop(|| {
-                tracing::trace!(thread_id = ?std::thread::current().id(), "worker thread stopped");
-            });
+    let print_tokio_threads = print_tokio_thread_enable();
+    builder.on_thread_start(move || {
+        mark_allocator_threadpool_thread();
+        if print_tokio_threads {
+            tracing::trace!(thread_id = ?std::thread::current().id(), "worker thread started");
+        }
+    });
+
+    // Optional: Simple log of thread stop
+    if print_tokio_threads {
+        builder.on_thread_stop(|| {
+            tracing::trace!(thread_id = ?std::thread::current().id(), "worker thread stopped");
+        });
     }
     if !rustfs_obs::is_production_environment() {
         println!(


### PR DESCRIPTION
## Related Issues

- rustfs/backlog#2025

## Summary of Changes

- Upgrade `rustfs-mimalloc` and `rustfs-mimalloc-sys` from `0.5.0` to `0.5.1`.
- Mark Tokio runtime worker threads as mimalloc threadpool workers by calling `rustfs_mimalloc::set_current_thread_in_threadpool()` from the runtime `on_thread_start` callback.
- Preserve the existing `RUSTFS_RUNTIME_THREAD_PRINT_ENABLED` trace behavior while avoiding multiple `on_thread_start` registrations.
- Keep the hint no-op on Windows, matching RustFS' current mimalloc global allocator platform boundary.

## Verification

- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `cargo check -p rustfs --bins --locked --config 'source.crates-io.replace-with="rsproxy-sparse"'`
- `cargo test -p rustfs default_thread_stack_size_matches_build_profile --locked --config 'source.crates-io.replace-with="rsproxy-sparse"'`
- 4-node multi-disk ABBA smoke on `testing1`: A1 -> B1 -> B2 -> A2, GET-only, 4KiB and 4MiB objects, concurrency 64, 60s per sample, 120s cooldown, all formal samples returned `rc=0`, final cluster restored to main and active.

ABBA summary:

| Phase | Version | Size | Throughput | p99 req | TTFB p99 |
|---|---|---:|---:|---:|---:|
| A1 | main | 4KiB | 48.63 MiB/s | 8.9ms | 9ms |
| B1 | candidate | 4KiB | 49.25 MiB/s | 8.8ms | 9ms |
| B2 | candidate | 4KiB | 49.01 MiB/s | 9.0ms | 9ms |
| A2 | main | 4KiB | 49.51 MiB/s | 9.1ms | 9ms |
| A1 | main | 4MiB | 3530.46 MiB/s | 474.3ms | 411ms |
| B1 | candidate | 4MiB | 5350.02 MiB/s | 278.5ms | 185ms |
| B2 | candidate | 4MiB | 5628.23 MiB/s | 205.8ms | 111ms |
| A2 | main | 4MiB | 5509.51 MiB/s | 285.9ms | 133ms |

## Impact

Tokio runtime worker threads on non-Windows builds now opt into mimalloc's threadpool hint. This is intended to help mimalloc classify long-lived runtime worker threads more accurately for abandoned/reabandoned page handling. The ABBA run shows no 4KiB GET regression and no 4MiB GET regression. The 4MiB candidate samples were in the same high-throughput band as the restored A2 baseline, so this PR should not claim the A1-to-B delta as solely caused by the threadpool hint.

## Additional Notes

The default USTC sparse mirror did not have `rustfs-mimalloc = 0.5.1` indexed during local validation, so the locked update and verification used `rsproxy-sparse`. The final `Cargo.lock` diff is limited to `rustfs-mimalloc` and `rustfs-mimalloc-sys`.

Detailed rollout notes were written back to rustfs/backlog#2025. The remote ABBA candidate commit was the same implementation diff before rebasing this PR branch onto the latest `origin/main`.
