### PR TITLE
ci(nightly): build on sm-standard-4

### DIFF
--- a/.github/workflows/nightly-gnu.yml
+++ b/.github/workflows/nightly-gnu.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   build:
     name: Build x86_64 GNU
-    runs-on: sm-standard-2
+    runs-on: sm-standard-4
     timeout-minutes: 150
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"


### PR DESCRIPTION
The nightly GNU build job lost communication with its runner mid-compile on the busy `sm-standard-2` fleet (compile is heavy and the fleet is shared). Move the build to the larger `sm-standard-4` runners to reduce starve/termination flakes.

Only `.github/workflows/nightly-gnu.yml` is changed (1 line); the KMS lanes and alert job stay as-is.