### PR TITLE
fix(connect): ignore directory link-count churn

### DIFF
--- a/rustfs/src/connect/inventory.rs
+++ b/rustfs/src/connect/inventory.rs
@@ -1083,10 +1083,10 @@ fn unix_regular_file_is_secure(owner: u32, mode: u32, links: u64, process: u32) 
 
 #[cfg(target_os = "linux")]
 #[allow(dead_code)] // Used by the crate-private stopped-server reader.
-fn file_identity(file: &fs::File) -> Result<(u64, u64, u64), InventoryError> {
+fn file_identity(file: &fs::File) -> Result<(u64, u64), InventoryError> {
     use std::os::unix::fs::MetadataExt as _;
     let metadata = file.metadata().map_err(|_| InventoryError::StateIo)?;
-    Ok((metadata.dev(), metadata.ino(), metadata.nlink()))
+    Ok((metadata.dev(), metadata.ino()))
 }
 
 #[cfg(target_os = "linux")]

--- a/rustfs/src/connect/runtime.rs
+++ b/rustfs/src/connect/runtime.rs
@@ -607,6 +607,9 @@ mod tests {
             _lock: lock,
         };
 
+        // Directory link counts change when unrelated sibling directories
+        // come and go; that must not look like an anchored path replacement.
+        std::fs::create_dir(temp.path().join("unrelated-sibling")).expect("unrelated sibling directory");
         drop(runtime);
         assert!(matches!(store.try_runtime_lock(), Err(InventoryError::AlreadyRunning)));
         release.send(()).expect("release inventory task");


### PR DESCRIPTION
Directory child churn changes nlink without replacing the anchored path. Compare directory identity by device and inode, while keeping regular-file link safety checks, and make the runtime-lock regression deterministic.