### PR TITLE
docs(architecture): record the S3 client extraction and reword invariant 4

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -93,7 +93,7 @@ refactors.
 | Domain | Current workspace crates | Responsibility |
 |--------|--------------------------|----------------|
 | Foundation | `checksums`, `common`, `config`, `data-usage`, `heal-contracts`, `scanner-contracts`, `utils` | Shared configuration, data-usage models, heal/scanner domain contracts, utilities, and checksums. |
-| I/O and storage | `concurrency`, `ecstore`, `filemeta`, `heal`, `io-core`, `io-metrics`, `lifecycle`, `lock`, `object-capacity`, `object-data-cache`, `replication`, `rio`, `rio-v2`, `scanner`, `storage-api` | Erasure-coded object storage, metadata, recovery, lifecycle, replication, locking, cache, and I/O pipelines. |
+| I/O and storage | `concurrency`, `ecstore`, `filemeta`, `heal`, `io-core`, `io-metrics`, `lifecycle`, `lock`, `object-capacity`, `object-data-cache`, `replication`, `rio`, `rio-v2`, `s3-client`, `scanner`, `storage-api` | Erasure-coded object storage, metadata, recovery, lifecycle, replication, locking, cache, I/O pipelines, and the engine-side S3 client for remote tier/transition targets. |
 | Security and identity | `credentials`, `crypto`, `iam`, `keystone`, `kms`, `policy`, `security-governance`, `signer`, `tls-runtime`, `trusted-proxies` | Credentials, authentication, authorization, encryption, key management, TLS, and security contracts. |
 | Protocols and contracts | `extension-schema`, `madmin`, `protos`, `protocols`, `s3-ops`, `s3-types`, `s3select-api`, `s3select-query` | Admin, inter-node, S3, S3 Select, and optional protocol contracts. |
 | Operations and integration | `audit`, `notify`, `obs`, `targets`, `zip` | Auditing, observability, event delivery, notification targets, and archive support. |
@@ -138,15 +138,19 @@ default build (lifecycle:
      `BackpressureSettings` copy that lingered in io-metrics was removed
      (rustfs/backlog#1833).
 
-4. **ecstore does not know about HTTP or S3 protocol details.** It operates on
-   storage-level abstractions (objects, buckets, disks, pools).
-   - ⚠️ VIOLATED: 58 files under `crates/ecstore/src` reference `s3s`
-     (`rg -l 's3s' crates/ecstore/src | wc -l`), `crates/ecstore/src/client/`
-     is a ~9.4K-line embedded S3 HTTP client, and `crates/ecstore/Cargo.toml`
-     depends on `s3s`, `http`, `hyper`/`hyper-util`/`hyper-rustls`, and
-     `reqwest`. Target state: the engine's need to act as an S3 client
-     (tiering, replication targets) is served by an extracted client crate,
-     and ecstore holds no wire or DTO types.
+4. **ecstore does not *serve* HTTP or the S3 wire protocol.** It operates on
+   storage-level abstractions (objects, buckets, disks, pools) and holds no
+   wire or DTO types of the serving surface. *Consuming* remote S3-compatible
+   endpoints (ILM tier warm backends, transition targets) is a legitimate
+   engine capability, but it lives in the dedicated `rustfs-s3-client` crate
+   (`crates/s3-client`, extracted from the formerly embedded
+   `crates/ecstore/src/client/` by rustfs/backlog#1842), not inside ecstore.
+   - ⚠️ PARTIALLY VIOLATED: serving-side `s3s` references remain in ecstore
+     (bucket metadata/replication/lifecycle DTOs and error mapping). The
+     count is ratcheted shrink-only by `scripts/check_s3s_footprint.sh`
+     (`S3S_ECSTORE_FILES_BASELINE`; the `object_lock` module was converted to
+     storage-level types as the first ratchet step). Target state: the
+     baseline reaches zero and ecstore's `Cargo.toml` drops `s3s`.
 
 5. **The `rustfs` binary crate is the only place that wires everything together.**
    Individual crates should be testable in isolation.

--- a/docs/architecture/ecstore-module-split-plan.md
+++ b/docs/architecture/ecstore-module-split-plan.md
@@ -13,6 +13,7 @@ and rollback steps.
 | Bucket replication | `crates/ecstore/src/bucket/replication/` | 15,619 lines | Contracts extracted; runtime move pending |
 | Set disks | `crates/ecstore/src/set_disk/` | state carrier plus operation modules | Keep in ECStore |
 | Public ECStore facade | `crates/ecstore/src/api/mod.rs` | broad compatibility surface | Shrink only through guarded PRs |
+| Embedded S3 client | `crates/s3-client/` (`rustfs-s3-client`) | ~8.4K lines | Extracted (rustfs/backlog#1842) |
 
 Measured 2026-08-12: the whole crate is 265 files / ~288K lines (roughly half
 is inline `#[cfg(test)]` code). The largest single files are `disk/local.rs`
@@ -36,6 +37,12 @@ The file split inside `set_disk/` is already operation-oriented: read, write,
 list, multipart, lock, heal, and replication code live in separate modules.
 The remaining large surface is the shared `SetDisks` state and cross-cutting
 contracts, not only file layout.
+
+## Completed: S3 Client Extraction (rustfs/backlog#1842)
+
+`crates/ecstore/src/client/` was a ~8.4K-line hand-written S3 HTTP client the engine uses to *consume* remote S3-compatible endpoints (ILM tier warm backends, transition targets). It was a legitimate engine capability misfiled inside the engine: it pulled `s3s`/`hyper` wire types into ecstore against ARCHITECTURE.md invariant 4, which distinguishes serving the S3 wire protocol (forbidden in ecstore) from consuming it (allowed, but in a dedicated crate).
+
+The extraction landed as: pure move of the 21 client modules to `crates/s3-client` (`rustfs-s3-client`) with a temporary re-export shim, then direct `rustfs_s3_client::` imports and shim deletion. The two server-side modules historically misfiled under `client/` stayed in ecstore and moved to their real homes: `object_api_utils.rs` under `object_api/`, `object_handlers_common.rs` under `bucket/lifecycle/` (behind the `replication_sink` boundary). The remaining serving-side `s3s` references in ecstore are ratcheted shrink-only by the `S3S_ECSTORE_FILES_BASELINE` counter in `scripts/check_s3s_footprint.sh`; per-module conversions to storage-level types (first: `bucket/object_lock/`) lower the baseline in the same change.
 
 ## Non-Negotiable Rules
 


### PR DESCRIPTION
## Related Issues

rustfs/backlog#1842 (PR4, final step of the plan: documentation). Stacked on #6668 (PR3); merge #6666 and #6668 first — this PR's own diff is the last commit.

## Summary of Changes

- ARCHITECTURE.md invariant 4 now states the serving-vs-consuming distinction the adversarial ruling asked for: ecstore must not serve HTTP/S3 wire types, while consuming remote S3-compatible endpoints (tier warm backends, transition targets) is a legitimate engine capability that lives in the extracted `rustfs-s3-client` crate. The violation note is updated from the pre-extraction snapshot (58 files, embedded 9.4K-line client) to the current ratcheted state (shrink-only `S3S_ECSTORE_FILES_BASELINE` in `scripts/check_s3s_footprint.sh`; `object_lock` converted first), and the crate map gains `s3-client`.
- `docs/architecture/ecstore-module-split-plan.md` gets the client-directory entry the plan was missing: a Current Shape row and a completed-extraction section describing the pure-move + shim + direct-import sequence and the re-homing of the two misfiled server-side modules.

## Verification

- `./scripts/check_doc_paths.sh` and `./scripts/check_architecture_migration_rules.sh` pass (the split-plan wording avoids the PR-type token rule).

## Impact

Documentation only.

## Additional Notes

N/A