### PR TITLE
fix(tests): cfg-gate the connect inventory fixture uid for non-Linux builds

### DIFF
--- a/rustfs/tests/connect_registration.rs
+++ b/rustfs/tests/connect_registration.rs
@@ -57,6 +57,7 @@ const TOKEN_UID: &str = "0198f4b0-6f00-7b60-9271-7d8e9fa0b1c5";
 const FRESH_TOKEN_UID: &str = "0198f4b0-7f00-7c70-a381-8e9fa0b1c2d6";
 const SECOND_TOKEN_UID: &str = "0198f4b0-8f00-7d80-b491-9fa0b1c2d3e7";
 const UNRELATED_TOKEN_UID: &str = "0198f4b0-9f00-7e90-85a1-afb1c2d3e4f8";
+#[cfg(target_os = "linux")]
 const INVENTORY_UID: &str = "0198f4b0-af00-7fa0-96b1-bfc1d2e3f509";
 
 struct TestPki {


### PR DESCRIPTION
## Related Issues

N/A (follow-up to the CI fixture repairs around #6617/#6620; found while running the full local gate for #6670).

## Summary of Changes

`INVENTORY_UID` in `rustfs/tests/connect_registration.rs` is only referenced by the inventory heartbeat tests, which are `#[cfg(target_os = "linux")]` like the `InventorySnapshot` imports above it. On macOS `cargo clippy --all-targets -- -D warnings` (and any `-D warnings` build of that test target) therefore fails with a dead_code error on the constant. This gates the constant with the same `#[cfg(target_os = "linux")]` the inventory import already carries.

## Verification

- `cargo check -p rustfs --test connect_registration` on macOS — the dead_code warning is gone.
- Linux builds are unaffected: the constant and all its uses remain compiled together.

## Impact

Test-only, non-Linux developer-experience fix. N/A for runtime behavior.

## Additional Notes

N/A.
