### PR TITLE
test(connect): match offline enrollment rejection

### DIFF
--- a/scripts/check_offline_enrollment_e2e.sh
+++ b/scripts/check_offline_enrollment_e2e.sh
@@ -69,7 +69,7 @@ then
     echo 'offline enrollment E2E gate: production CLI accepted the E2E root' >&2
     exit 1
 fi
-grep -Fq 'the offline enrollment trust chain is not issued by a root pinned in this build' \
+grep -Fq 'rustfs-cli: the trust chain is not issued by a root pinned in this build' \
     "${task_root}/production.stderr" \
     || { echo 'offline enrollment E2E gate: production CLI failed for the wrong reason' >&2; exit 1; }
 test ! -e "${task_root}/production-response.json" \


### PR DESCRIPTION
## Summary

- match the boundary gate to the production CLI rejection it actually emits
- keep the dedicated E2E acceptance and rejected-response absence checks unchanged

## Validation

- bash syntax
- ShellCheck
- diff check
- two independent reviews of the exact head

Cargo execution is delegated to remote CI because local Rust builds are disabled for disk safety.

Closes #6674