### PR TITLE
fix(ecstore): migrate test-only client import

### DIFF
--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -700,7 +700,6 @@ mod tests {
             validate_durable_ilm_record,
         },
         bucket::metadata::{BUCKET_LIFECYCLE_CONFIG, BUCKET_VERSIONING_CONFIG},
-        client::transition_api::ReaderImpl,
         config::com,
         core::pools::DecomBucketInfo,
         data_movement::SourceCleanupDeleteBarrier,
@@ -750,6 +749,8 @@ mod tests {
     #[cfg(feature = "test-util")]
     use rustfs_protos::{TIER_MUTATION_RPC_PROTOCOL_VERSION, TierMutationRpcPhase};
     use rustfs_rio::{Checksum, ChecksumType};
+    #[cfg(feature = "test-util")]
+    use rustfs_s3_client::transition_api::ReaderImpl;
     use rustfs_utils::{
         CompressionAlgorithm,
         http::{SUFFIX_COMPRESSION, insert_str},

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -641,6 +641,12 @@ for ecstore_private_module in \
     "mod ${ecstore_private_module};" \
     "ECStore legacy ${ecstore_private_module} root module crate-private visibility"
 done
+ECSTORE_CLIENT_SHIM_IMPORT_HITS_FILE="${TMP_DIR}/ecstore_client_shim_import_hits.txt"
+if rg -n --no-heading --glob '*.rs' 'crate::client::|^[[:space:]]+client::' \
+  "${ROOT_DIR}/crates/ecstore/src" >"${ECSTORE_CLIENT_SHIM_IMPORT_HITS_FILE}"; then
+  report_failure "ECStore client shim imports must use rustfs_s3_client directly"
+  cat "${ECSTORE_CLIENT_SHIM_IMPORT_HITS_FILE}" >&2
+fi
 require_source_line \
   "crates/storage-api/src/lib.rs" \
   "pub use bucket::{BucketInfo, BucketOperations, BucketOptions, DeleteBucketOptions, MakeBucketOptions, SRBucketDeleteOp};" \


### PR DESCRIPTION
## Summary

- import the transition reader directly from rustfs-s3-client in test-util builds
- make the architecture guard reject direct and grouped crate::client imports

## Validation

- rustfmt
- git diff --check
- architecture migration rules
- layer dependency guard
- test wiring checker
- negative shim-import mutation

Fixes the latest main rio-v2 compile failure.