### PR TITLE
fix(ci): make s3s footprint ratchet count the tree, not stdin

### DIFF
--- a/scripts/check_s3s_footprint.sh
+++ b/scripts/check_s3s_footprint.sh
@@ -4,10 +4,18 @@
 # acceptance criteria recorded in rustfs/backlog#1733).
 #
 # The migration's goal is to shrink the direct s3s surface, so new code must
-# not grow it. Two counters are ratcheted, baselines verified on 2026-08-05:
+# not grow it. Two counters are ratcheted (verification dates live next to the
+# baseline values below):
 #
-#   - files referencing s3s paths:  rg -l "$S3S_PATH_PATTERN" --type rust (files)
-#   - s3_error! invocation lines:   rg -c 's3_error!' --type rust    (summed)
+#   - files referencing s3s paths:  rg -l "$S3S_PATH_PATTERN" --type rust . (files)
+#   - s3_error! invocation lines:   rg -c 's3_error!' --type rust .   (summed)
+#
+# Every rg invocation MUST pass an explicit path ('.' for repo-wide): without
+# one, rg searches stdin instead of the tree whenever stdin is a readable
+# pipe — which is exactly what GitHub Actions attaches to run steps — and
+# silently counts 0 (observed on run 32978746357, where both repo-wide
+# counters read 0 and were waved through as "shrank"). The sanity assertions
+# below fail hard if that ever regresses.
 #
 # Either count exceeding its baseline fails the check with the offending
 # delta. Baselines are LOWER-ONLY: when a PR shrinks the footprint, lower the
@@ -22,10 +30,15 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-# Baselines verified on 2026-08-11. Lower-only; see header.
+# Baselines verified on 2026-08-26. Lower-only; see header.
 # Excludes crates/e2e_test/ — test infrastructure legitimately uses s3s
 # to verify S3 behavior and does not widen the production s3s surface.
-S3S_IMPORT_FILES_BASELINE=208
+# 208 → 215 on 2026-08-26: PR #6670 mechanically split
+# rustfs/src/app/object_usecase.rs into 8 per-operation modules (net +7
+# files, zero new s3s code — the same handler-layer surface redistributed).
+# The file counter is split-sensitive; the s3_error! line counter confirms
+# no growth (unchanged at 1620).
+S3S_IMPORT_FILES_BASELINE=215
 S3_ERROR_LINES_BASELINE=1620
 # ecstore-scoped ratchet (rustfs/backlog#1842): the storage engine must not
 # know S3 wire/DTO types (ARCHITECTURE.md invariant 4). The S3-*consuming*
@@ -51,8 +64,9 @@ run_rg_to() {
     fi
 }
 
-run_rg_to "$TMP_DIR/import_files" -l "$S3S_PATH_PATTERN" --type rust $E2E_TEST_GLOB
-run_rg_to "$TMP_DIR/error_lines" -c 's3_error!' --type rust $E2E_TEST_GLOB
+# Explicit '.' path is load-bearing — see header. Never drop it.
+run_rg_to "$TMP_DIR/import_files" -l "$S3S_PATH_PATTERN" --type rust "$E2E_TEST_GLOB" .
+run_rg_to "$TMP_DIR/error_lines" -c 's3_error!' --type rust "$E2E_TEST_GLOB" .
 run_rg_to "$TMP_DIR/ecstore_files" -l "$S3S_PATH_PATTERN" --type rust crates/ecstore/src
 
 s3s_import_files="$(grep -c . "$TMP_DIR/import_files" || true)"
@@ -65,6 +79,28 @@ for value in "$s3s_import_files" "$s3_error_lines" "$s3s_ecstore_files"; do
         exit 1
     fi
 done
+
+# Sanity assertions: a counter reading 0 while its baseline is positive, or
+# the repo-wide file count dropping below the ecstore-scoped one (a strict
+# subset of it), means the counter itself broke — most likely rg searching
+# stdin instead of the tree (see header) — not that the footprint shrank.
+# Fail hard rather than waving the ratchet through. If the footprint ever
+# genuinely reaches zero, lower the baseline to 0 in the same PR.
+sanity_nonzero() {
+    local label="$1" count="$2" baseline="$3"
+    if ((count == 0 && baseline > 0)); then
+        echo "error: $label counted 0 with a baseline of $baseline — the counter is" >&2
+        echo "  broken (rg likely searched stdin; every rg call needs an explicit path)." >&2
+        exit 1
+    fi
+}
+sanity_nonzero "files importing s3s" "$s3s_import_files" "$S3S_IMPORT_FILES_BASELINE"
+sanity_nonzero "s3_error! invocation lines" "$s3_error_lines" "$S3_ERROR_LINES_BASELINE"
+if ((s3s_import_files < s3s_ecstore_files)); then
+    echo "error: repo-wide s3s file count ($s3s_import_files) is below the ecstore-scoped" >&2
+    echo "  count ($s3s_ecstore_files); the repo-wide counter is broken (see header)." >&2
+    exit 1
+fi
 
 status=0
 
@@ -87,9 +123,9 @@ check_ratchet() {
 }
 
 check_ratchet "files importing s3s" "$s3s_import_files" "$S3S_IMPORT_FILES_BASELINE" \
-    "rg -l '$S3S_PATH_PATTERN' --type rust $E2E_TEST_GLOB"
+    "rg -l '$S3S_PATH_PATTERN' --type rust $E2E_TEST_GLOB ."
 check_ratchet "s3_error! invocation lines" "$s3_error_lines" "$S3_ERROR_LINES_BASELINE" \
-    "rg -c 's3_error!' --type rust $E2E_TEST_GLOB"
+    "rg -c 's3_error!' --type rust $E2E_TEST_GLOB ."
 check_ratchet "ecstore files referencing s3s" "$s3s_ecstore_files" "$S3S_ECSTORE_FILES_BASELINE" \
     "rg -l '$S3S_PATH_PATTERN' --type rust crates/ecstore/src"
 


### PR DESCRIPTION
## Related Issues

References rustfs/backlog#1677 (review finding F1), rustfs/backlog#1733, rustfs/backlog#1842. Guard failure observed on main run 32978746357 (Quick Checks job 98209826133).

## Summary of Changes

The s3s footprint ratchet has been silently disabled on CI: on run 32978746357 the two repo-wide counters both read 0 and were waved through as "shrank" (-208 files / -1620 lines), while the ecstore-scoped counter correctly read 39. Root cause: the two repo-wide `rg` invocations passed no explicit path, and ripgrep searches **stdin** instead of the tree whenever stdin is a readable pipe — which is exactly what GitHub Actions attaches to `run` steps. The ecstore invocation passed `crates/ecstore/src` explicitly and was unaffected. Reproduced locally with `printf '' | bash scripts/check_s3s_footprint.sh` (counts 0/0/39 before the fix); CI runs rg 15.2.0 and local 15.1.0 behave identically, so this is the stdin heuristic, not a version difference.

Fixes:

- Both repo-wide `rg` calls now pass an explicit `.` path (and the e2e glob variable is quoted). A header comment documents why the path is load-bearing.
- New sanity assertions fail the check hard instead of passing it when a counter breaks again: any counter reading 0 while its baseline is positive, or the repo-wide file count dropping below the ecstore-scoped count (a strict subset of it), aborts with an explanatory error.
- While the guard was dead, PR #6670 mechanically split `rustfs/src/app/object_usecase.rs` into 8 per-operation modules under `rustfs/src/app/object/`, which raised the file count from 208 to 215 (net +7) without adding any s3s code — the same handler-layer surface redistributed across more files. The `s3_error!` line counter is unchanged at 1620, confirming no growth, and the concurrent `crates/ecstore/src/client/object_api_utils.rs` → `crates/ecstore/src/object_api/object_api_utils.rs` move is net 0. `S3S_IMPORT_FILES_BASELINE` is raised to 215 with a comment recording this provenance; the other two baselines (1620 / 39) match reality and are unchanged.

Both `.github/workflows/ci.yml` and `.github/workflows/ci-docs-only.yml` invoke `./scripts/check_s3s_footprint.sh`, so the in-script fix covers both without workflow edits. An audit of the other guard scripts found no other path-less `rg` invocation (the remaining candidates are all pipeline receivers where stdin input is intentional).

## Verification

- `printf '' | bash scripts/check_s3s_footprint.sh` (CI stdin simulation): counts 215/1620/39 and passes; before the fix the same invocation counted 0/0/39.
- Injection test: a variant of the script with the explicit `.` paths removed, run with pipe stdin, now aborts via the sanity assertion ("counted 0 with a baseline of 215") instead of passing.
- `shellcheck scripts/check_s3s_footprint.sh`: clean.
- `make fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check error-other-ratchet-check tokio-io-uring-check extension-schema-check body-cache-whitelist-check s3s-footprint-check fips-wording-check embedded-secrets-check test-wiring-check doc-paths-check planning-docs-check`: all pass (the change is shell-only; no Rust code touched).

## Impact

CI guard behavior only: the repo-wide s3s ratchet counters actually count again on GitHub Actions, and any future silent-zero regression fails the job instead of passing it. No runtime, API, or deployment impact.

## Additional Notes

The baseline raise is not a ratchet loosening in substance: the +7 is purely the file-split arithmetic of PR #6670 and the line-based counter proves the s3s surface did not grow. Lower-only discipline resumes from 215.
