### PR TITLE
chore(deps): finish cargo shear cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
+checksum = "5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f"
 dependencies = [
  "digest 0.11.3",
 ]
@@ -1629,7 +1629,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
 ]
 
 [[package]]
@@ -1648,7 +1648,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
 ]
 
 [[package]]
@@ -2003,7 +2003,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "inout 0.1.4",
 ]
 
@@ -2463,7 +2463,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -2488,11 +2488,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
  "typenum",
 ]
 
@@ -3758,7 +3758,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -4021,7 +4021,7 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff 0.13.1",
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
  "group 0.13.0",
  "hkdf 0.12.4",
  "pem-rfc7468 0.7.0",
@@ -4466,9 +4466,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -4481,7 +4481,7 @@ version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "337d46834ee672ab3e48caca2cb0c78cc174fb12b3a68d0d88f99a0519a5e36e"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
  "rustversion",
  "typenum",
 ]
@@ -5516,7 +5516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding 0.3.3",
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
 ]
 
 [[package]]
@@ -6967,7 +6967,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http 1.5.0",
@@ -9621,7 +9621,6 @@ dependencies = [
  "reqwest",
  "rmp",
  "rmp-serde",
- "rustfs-checksums",
  "rustfs-common",
  "rustfs-concurrency",
  "rustfs-config",
@@ -9645,9 +9644,7 @@ dependencies = [
  "rustfs-s3-client",
  "rustfs-s3-types",
  "rustfs-scanner-contracts",
- "rustfs-signer",
  "rustfs-storage-api",
- "rustfs-tls-runtime",
  "rustfs-uring",
  "rustfs-utils",
  "rustix",
@@ -9992,7 +9989,6 @@ dependencies = [
  "metrics",
  "metrics-util",
  "proptest",
- "rustfs-common",
  "rustfs-config",
  "rustfs-replication",
  "rustfs-scanner-contracts",
@@ -11141,7 +11137,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct 0.2.0",
  "der 0.7.10",
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
  "pkcs8 0.10.2",
  "subtle",
  "zeroize",
@@ -12119,7 +12115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,7 +199,7 @@ serde_urlencoded = "0.7.1"
 # releases.
 aes-gcm = { version = "=0.11.1" }
 argon2 = { version = "=0.6.0-rc.8" }
-blake2 = "=0.11.0-rc.6"
+blake2 = "=0.11.0"
 chacha20poly1305 = { version = "=0.11.0" }
 crc-fast = "1.10.0"
 hmac = { version = "0.13.0" }

--- a/crates/ecstore/Cargo.toml
+++ b/crates/ecstore/Cargo.toml
@@ -25,13 +25,6 @@ keywords = ["erasure-coding", "storage", "rustfs", "Minio", "solomon"]
 categories = ["web-programming", "development-tools", "filesystem"]
 documentation = "https://docs.rs/rustfs-ecstore/latest/rustfs_ecstore/"
 
-[package.metadata.cargo-shear]
-ignored = [
-    "rustfs-checksums",
-    "rustfs-signer",
-    "rustfs-tls-runtime",
-]
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lints]
 workspace = true
@@ -51,7 +44,6 @@ hotpath = [
     "hotpath/async-channel",
     "hotpath/parking_lot",
     "hotpath/reqwest-0-13",
-    "rustfs-checksums/hotpath",
     "rustfs-common/hotpath",
     "rustfs-concurrency/hotpath",
     "rustfs-config/hotpath",
@@ -69,16 +61,13 @@ hotpath = [
     "rustfs-rio/hotpath",
     "rustfs-rio-v2?/hotpath",
     "rustfs-s3-types/hotpath",
-    "rustfs-signer/hotpath",
     "rustfs-storage-api/hotpath",
-    "rustfs-tls-runtime/hotpath",
     "rustfs-utils/hotpath",
     "rustfs-crypto/hotpath",
 ]
 hotpath-alloc = [
     "hotpath",
     "hotpath/hotpath-alloc",
-    "rustfs-checksums/hotpath-alloc",
     "rustfs-common/hotpath-alloc",
     "rustfs-concurrency/hotpath-alloc",
     "rustfs-config/hotpath-alloc",
@@ -96,16 +85,13 @@ hotpath-alloc = [
     "rustfs-rio/hotpath-alloc",
     "rustfs-rio-v2?/hotpath-alloc",
     "rustfs-s3-types/hotpath-alloc",
-    "rustfs-signer/hotpath-alloc",
     "rustfs-storage-api/hotpath-alloc",
-    "rustfs-tls-runtime/hotpath-alloc",
     "rustfs-utils/hotpath-alloc",
     "rustfs-crypto/hotpath-alloc",
 ]
 hotpath-cpu = [
     "hotpath",
     "hotpath/hotpath-cpu",
-    "rustfs-checksums/hotpath-cpu",
     "rustfs-common/hotpath-cpu",
     "rustfs-concurrency/hotpath-cpu",
     "rustfs-config/hotpath-cpu",
@@ -123,9 +109,7 @@ hotpath-cpu = [
     "rustfs-rio/hotpath-cpu",
     "rustfs-rio-v2?/hotpath-cpu",
     "rustfs-s3-types/hotpath-cpu",
-    "rustfs-signer/hotpath-cpu",
     "rustfs-storage-api/hotpath-cpu",
-    "rustfs-tls-runtime/hotpath-cpu",
     "rustfs-utils/hotpath-cpu",
     "rustfs-crypto/hotpath-cpu",
 ]
@@ -140,10 +124,7 @@ rustfs-filemeta.workspace = true
 rustfs-utils = { workspace = true, features = ["full"] }
 rustfs-rio.workspace = true
 rustfs-rio-v2 = { workspace = true, optional = true }
-rustfs-signer.workspace = true
 rustfs-storage-api.workspace = true
-rustfs-tls-runtime.workspace = true
-rustfs-checksums.workspace = true
 rustfs-config = { workspace = true, features = ["notify", "audit", "server-config-model"] }
 rustfs-concurrency.workspace = true
 rustfs-credentials = { workspace = true }

--- a/crates/lifecycle/Cargo.toml
+++ b/crates/lifecycle/Cargo.toml
@@ -25,15 +25,11 @@ keywords = ["lifecycle", "storage", "rustfs", "Minio"]
 categories = ["web-programming", "development-tools", "filesystem"]
 documentation = "https://docs.rs/rustfs-lifecycle/latest/rustfs_lifecycle/"
 
-[package.metadata.cargo-shear]
-ignored = ["rustfs-common"]
-
 [features]
 default = []
 hotpath = [
     "hotpath/hotpath",
     "hotpath/tokio",
-    "rustfs-common/hotpath",
     "rustfs-config/hotpath",
     "rustfs-replication/hotpath",
     "rustfs-storage-api/hotpath",
@@ -41,7 +37,6 @@ hotpath = [
 hotpath-alloc = [
     "hotpath",
     "hotpath/hotpath-alloc",
-    "rustfs-common/hotpath-alloc",
     "rustfs-config/hotpath-alloc",
     "rustfs-replication/hotpath-alloc",
     "rustfs-storage-api/hotpath-alloc",
@@ -49,7 +44,6 @@ hotpath-alloc = [
 hotpath-cpu = [
     "hotpath",
     "hotpath/hotpath-cpu",
-    "rustfs-common/hotpath-cpu",
     "rustfs-config/hotpath-cpu",
     "rustfs-replication/hotpath-cpu",
     "rustfs-storage-api/hotpath-cpu",
@@ -59,7 +53,6 @@ hotpath-cpu = [
 hotpath.workspace = true
 async-trait.workspace = true
 metrics.workspace = true
-rustfs-common.workspace = true
 rustfs-scanner-contracts.workspace = true
 rustfs-config = { workspace = true, features = ["constants"] }
 rustfs-replication.workspace = true


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Update `blake2` from the release candidate to the stable `0.11.0` release.
- Remove `rustfs-ecstore` and `rustfs-lifecycle` dependency edges that cargo-shear now confirms are unnecessary.
- Refresh `Cargo.lock` for the resulting dependency graph.

## Verification
- `cargo shear --locked --deny-warnings --format json`
- `cargo fmt --all --check`
- `git diff --check origin/main..HEAD`
- `CARGO_TARGET_DIR=<temporary target dir> cargo check -p rustfs-ecstore --all-features --lib`
- `CARGO_TARGET_DIR=<temporary target dir> cargo check -p rustfs --bin rustfs`

## Impact
No runtime behavior change expected. This reduces unused manifest dependency edges and moves `blake2` to the stable 0.11.0 release.

## Additional Notes
`cargo check -p rustfs --bin rustfs` emitted the existing duplicate `rustfs-cli.rs` bin target manifest warning.
