### PR TITLE
docs(architecture): adjudicate the io-metrics leaf dependency on the s3-ops contract crate

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,8 +115,13 @@ default build (lifecycle:
 1. **Layers flow downward.** Server → Admin/App → Storage → ecstore → rio/io-core.
    No upward imports.
 
-2. **Leaf crates have zero internal dependencies.** `config`, `credentials`, `crypto`,
-   `io-metrics`, and `madmin` should depend only on external crates.
+2. **Leaf crates depend only on external crates, with one adjudicated exception.**
+   `config`, `credentials`, `crypto`, `io-metrics`, and `madmin` take no internal
+   dependency except `io-metrics → rustfs-s3-ops` (transitively `rustfs-s3-types`),
+   a pure contract crate with no I/O and no global state. Adjudicated in
+   rustfs/backlog#1834 and pinned by the leaf allowlist in
+   `scripts/check_architecture_migration_rules.sh`; any other internal dependency
+   fails the guard ([crate boundaries](docs/architecture/crate-boundaries.md)).
    - ✅ RESOLVED: the historical `utils → config` and `common → filemeta`/`madmin`
      edges were removed; do not reintroduce them (see Known Structural Issues).
 

--- a/docs/architecture/crate-boundaries.md
+++ b/docs/architecture/crate-boundaries.md
@@ -35,6 +35,19 @@ wire types still live in `rustfs-filemeta`. This keeps the temporary dependency
 centralized until those wire contracts can move without introducing a
 `rustfs-replication` / `rustfs-storage-api` cycle.
 
+Leaf crates carry exactly one adjudicated allowed edge:
+`io-metrics -> rustfs-s3-ops` (transitively `rustfs-s3-types`). Both are pure
+contract crates — types and enums only, no I/O, no global state, no non-contract
+internal dependencies — so `io-metrics` reuses the `S3Operation` vocabulary
+instead of copying it. The allowance covers that edge and nothing else: the
+leaf-crate allowlist in `scripts/check_architecture_migration_rules.sh` fails any
+other `rustfs-*` dependency in `config`, `credentials`, `crypto`, `io-metrics`,
+or `madmin`. Adjudicated in
+[`rustfs/backlog#1834`](https://github.com/rustfs/backlog/issues/1834); a further
+exception must meet the same criterion — pure contract crate, no I/O, no globals,
+no non-contract internal dependencies — and land its guard allowlist entry
+alongside the dependency.
+
 Dependency direction also applies to compile-time source reads:
 `include_str!`/`include!` of a `.rs` file must not resolve outside the
 including crate's own directory (`scripts/check_layer_dependencies.sh`

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -5448,9 +5448,11 @@ require_source_contains \
 # --- Leaf crates must stay free of internal dependencies (backlog#1834) ---
 # ARCHITECTURE.md invariant 2 names config, credentials, crypto, io-metrics,
 # and madmin as leaf crates that depend only on external crates. Allowlist:
-# io-metrics -> rustfs-s3-ops (contract crate; leaf-allowance adjudication is
-# tracked as backlog#1834 PR2). Adding any other rustfs-* dependency to a leaf
-# crate needs a maintainer decision, not a quiet Cargo.toml edit.
+# io-metrics -> rustfs-s3-ops. That edge is DECIDED in backlog#1834: allowed as a
+# pure-contract-crate exception (types/enums only, no I/O, no globals, no
+# non-contract internal deps), narrowed to exactly this edge. Adding any other
+# rustfs-* dependency to a leaf crate needs its own adjudication, not a quiet
+# Cargo.toml edit.
 LEAF_CRATE_DEP_HITS_FILE="${TMP_DIR}/leaf_crate_dep_hits.txt"
 : >"$LEAF_CRATE_DEP_HITS_FILE"
 (
@@ -5472,7 +5474,7 @@ LEAF_CRATE_DEP_HITS_FILE="${TMP_DIR}/leaf_crate_dep_hits.txt"
 )
 
 if [[ -s "$LEAF_CRATE_DEP_HITS_FILE" ]]; then
-  report_failure "leaf crates (config/credentials/crypto/io-metrics/madmin) must not depend on internal rustfs-* crates (allowlist: io-metrics -> rustfs-s3-ops, backlog#1834): $(paste -sd '; ' "$LEAF_CRATE_DEP_HITS_FILE")"
+  report_failure "leaf crates (config/credentials/crypto/io-metrics/madmin) must not depend on internal rustfs-* crates (sole adjudicated exception, decided in backlog#1834: io-metrics -> rustfs-s3-ops, a pure contract crate; any new edge needs its own adjudication): $(paste -sd '; ' "$LEAF_CRATE_DEP_HITS_FILE")"
 fi
 
 # --- ecstore module-level lint blankets (backlog#1823 step 9) ---


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1834 (PR2, the final item). PR1 #6051, PR3 #6052, PR4 #6061, PR5 #6154, and PR6 #6053 are merged.

## Summary of Changes

Documents the adjudication that the leaf crate `io-metrics` may depend on the pure contract crate `rustfs-s3-ops` — the decision the guard allowlist from PR3 has been holding a slot for.

The decision, narrowly: `rustfs-s3-ops` is a 532-line single-file vocabulary crate (the `S3Operation` enum family) whose only dependencies are the external `hotpath` instrumentation crate and `rustfs-s3-types` (itself a pure serde-types crate with no internal dependencies). No I/O, no global state, no process-wide singletons. Without this edge, io-metrics would have to duplicate the S3 operation vocabulary — exactly the copy-instead-of-reuse pattern the rustfs/backlog#1820 program exists to eliminate. The allowance covers exactly the edge `io-metrics -> rustfs-s3-ops`; the leaf-dependency guard fails any other `rustfs-*` dependency in any of the five leaf crates, and the documented criterion for a future exception is: pure contract crate (types/enums only, no I/O, no globals, no non-contract internal deps) plus a guard allowlist entry landed in the same PR.

Three files:

- `ARCHITECTURE.md` invariant 2: now states leaf crates depend only on external crates with this one adjudicated exception; the existing RESOLVED bullet is untouched.
- `docs/architecture/crate-boundaries.md`: a peer paragraph in the Dependency Direction section (alongside the existing storage-api/filemeta allowance) registering the edge, the criterion, and the guard that pins it.
- `scripts/check_architecture_migration_rules.sh`: comment and failure message no longer say the adjudication is pending; they state it is decided and that any new edge needs its own adjudication. Comment/string text only — stripping comments from old and new script and diffing leaves exactly one differing line (the `report_failure` message string), and `bash -n` passes.

## Verification

- `bash scripts/check_architecture_migration_rules.sh` — pass
- `bash scripts/check_doc_paths.sh` — pass
- `bash scripts/check_layer_dependencies.sh` — pass
- No Rust code touched; no cargo run needed.

## Impact

Closes out rustfs/backlog#1834: the leaf-crate invariant, its one exception, and the ratchet rule are now consistent across the architecture doc, the boundary register, and the guard that enforces them.

## Additional Notes

Part of the pre-1.0 cleanup program tracked in rustfs/backlog#1820.
