### PR TITLE
fix(guards): catch dotted-form leaf deps, pin madmin to rustfs-signer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,11 +115,13 @@ default build (lifecycle:
 1. **Layers flow downward.** Server → Admin/App → Storage → ecstore → rio/io-core.
    No upward imports.
 
-2. **Leaf crates depend only on external crates, with one adjudicated exception.**
-   `config`, `credentials`, `crypto`, `io-metrics`, and `madmin` take no internal
-   dependency except `io-metrics → rustfs-s3-ops` (transitively `rustfs-s3-types`),
-   a pure contract crate with no I/O and no global state. Adjudicated in
-   rustfs/backlog#1834 and pinned by the leaf allowlist in
+2. **Leaf crates depend only on external crates, with adjudicated exceptions
+   pinned by a guard.** `config`, `credentials`, and `crypto` take no internal
+   dependency. `io-metrics` takes exactly `rustfs-s3-ops` (transitively
+   `rustfs-s3-types`), a pure contract crate with no I/O and no global state —
+   adjudicated in rustfs/backlog#1834. `madmin` left the leaf set when #6166 made
+   it the SigV4-signed admin SDK client; its internal dependency surface is pinned
+   to exactly `rustfs-signer`. Both pins live in the leaf allowlist in
    `scripts/check_architecture_migration_rules.sh`; any other internal dependency
    fails the guard ([crate boundaries](docs/architecture/crate-boundaries.md)).
    - ✅ RESOLVED: the historical `utils → config` and `common → filemeta`/`madmin`

--- a/docs/architecture/crate-boundaries.md
+++ b/docs/architecture/crate-boundaries.md
@@ -39,14 +39,18 @@ Leaf crates carry exactly one adjudicated allowed edge:
 `io-metrics -> rustfs-s3-ops` (transitively `rustfs-s3-types`). Both are pure
 contract crates — types and enums only, no I/O, no global state, no non-contract
 internal dependencies — so `io-metrics` reuses the `S3Operation` vocabulary
-instead of copying it. The allowance covers that edge and nothing else: the
-leaf-crate allowlist in `scripts/check_architecture_migration_rules.sh` fails any
-other `rustfs-*` dependency in `config`, `credentials`, `crypto`, `io-metrics`,
-or `madmin`. Adjudicated in
+instead of copying it. `madmin` is no longer counted a leaf: since #6166 it is
+the SigV4-signed admin SDK client and deliberately depends on `rustfs-signer`;
+the guard pins its internal dependency surface to exactly that edge so it cannot
+quietly grow storage-side dependencies. The leaf-crate allowlist in
+`scripts/check_architecture_migration_rules.sh` fails any other `rustfs-*`
+dependency in `config`, `credentials`, `crypto`, `io-metrics`, or `madmin`, in
+either TOML spelling (`rustfs-x = ...` or `rustfs-x.workspace = true`).
+Adjudicated in
 [`rustfs/backlog#1834`](https://github.com/rustfs/backlog/issues/1834); a further
-exception must meet the same criterion — pure contract crate, no I/O, no globals,
-no non-contract internal dependencies — and land its guard allowlist entry
-alongside the dependency.
+leaf exception must meet the pure-contract criterion — types and enums only, no
+I/O, no globals, no non-contract internal dependencies — and land its guard
+allowlist entry alongside the dependency.
 
 Dependency direction also applies to compile-time source reads:
 `include_str!`/`include!` of a `.rs` file must not resolve outside the

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -5452,13 +5452,17 @@ require_source_contains \
   "SetDisks storage-api HealOperations compile-time coverage test"
 
 # --- Leaf crates must stay free of internal dependencies (backlog#1834) ---
-# ARCHITECTURE.md invariant 2 names config, credentials, crypto, io-metrics,
-# and madmin as leaf crates that depend only on external crates. Allowlist:
+# ARCHITECTURE.md invariant 2 names config, credentials, crypto, and io-metrics
+# as leaf crates that depend only on external crates. Allowlist:
 # io-metrics -> rustfs-s3-ops. That edge is DECIDED in backlog#1834: allowed as a
 # pure-contract-crate exception (types/enums only, no I/O, no globals, no
-# non-contract internal deps), narrowed to exactly this edge. Adding any other
-# rustfs-* dependency to a leaf crate needs its own adjudication, not a quiet
-# Cargo.toml edit.
+# non-contract internal deps), narrowed to exactly this edge.
+# madmin left the leaf set when #6166 made it the SigV4-signed admin SDK client;
+# its internal dependency surface is pinned to exactly rustfs-signer so it cannot
+# quietly grow storage-side dependencies. Adding any other rustfs-* dependency to
+# any of these five crates needs its own adjudication, not a quiet Cargo.toml edit.
+# The pattern matches both TOML dependency spellings: `rustfs-x = ...` and the
+# dotted `rustfs-x.workspace = true` form (which previously escaped this guard).
 LEAF_CRATE_DEP_HITS_FILE="${TMP_DIR}/leaf_crate_dep_hits.txt"
 : >"$LEAF_CRATE_DEP_HITS_FILE"
 (
@@ -5467,20 +5471,26 @@ LEAF_CRATE_DEP_HITS_FILE="${TMP_DIR}/leaf_crate_dep_hits.txt"
     manifest="crates/${leaf}/Cargo.toml"
     [[ -f "$manifest" ]] || continue
     leaf_dep_status=0
-    rg -n --with-filename '^rustfs-[a-z0-9-]+ *=' "$manifest" >"${TMP_DIR}/leaf_dep_raw.txt" || leaf_dep_status=$?
+    rg -n --with-filename '^rustfs-[a-z0-9-]+(\.[a-zA-Z_-]+)* *=' "$manifest" >"${TMP_DIR}/leaf_dep_raw.txt" || leaf_dep_status=$?
     if [[ "$leaf_dep_status" -ne 0 && "$leaf_dep_status" -ne 1 ]]; then
       exit "$leaf_dep_status"
     fi
-    if [[ "$leaf" == "io-metrics" ]]; then
-      rg -v '^[^:]*:[0-9]+:rustfs-s3-ops *=' "${TMP_DIR}/leaf_dep_raw.txt" >>"$LEAF_CRATE_DEP_HITS_FILE" || true
-    else
-      cat "${TMP_DIR}/leaf_dep_raw.txt" >>"$LEAF_CRATE_DEP_HITS_FILE"
-    fi
+    case "$leaf" in
+      io-metrics)
+        rg -v '^[^:]*:[0-9]+:rustfs-s3-ops(\.[a-zA-Z_-]+)* *=' "${TMP_DIR}/leaf_dep_raw.txt" >>"$LEAF_CRATE_DEP_HITS_FILE" || true
+        ;;
+      madmin)
+        rg -v '^[^:]*:[0-9]+:rustfs-signer(\.[a-zA-Z_-]+)* *=' "${TMP_DIR}/leaf_dep_raw.txt" >>"$LEAF_CRATE_DEP_HITS_FILE" || true
+        ;;
+      *)
+        cat "${TMP_DIR}/leaf_dep_raw.txt" >>"$LEAF_CRATE_DEP_HITS_FILE"
+        ;;
+    esac
   done
 )
 
 if [[ -s "$LEAF_CRATE_DEP_HITS_FILE" ]]; then
-  report_failure "leaf crates (config/credentials/crypto/io-metrics/madmin) must not depend on internal rustfs-* crates (sole adjudicated exception, decided in backlog#1834: io-metrics -> rustfs-s3-ops, a pure contract crate; any new edge needs its own adjudication): $(paste -sd '; ' "$LEAF_CRATE_DEP_HITS_FILE")"
+  report_failure "leaf/pinned-dep crates: config/credentials/crypto take no internal rustfs-* dependency; io-metrics only rustfs-s3-ops (pure contract crate, backlog#1834); madmin only rustfs-signer (admin SDK SigV4 client, #6166); any new edge needs its own adjudication: $(paste -sd '; ' "$LEAF_CRATE_DEP_HITS_FILE")"
 fi
 
 # --- ecstore module-level lint blankets (backlog#1823 step 9) ---


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1834 (wrap-up finding). Follow-up to #6052 (PR3, the leaf-crate guard) and #6683 (PR2, the io-metrics adjudication).

## Summary of Changes

Wrap-up acceptance on backlog#1834 found the leaf-crate guard from #6052 blind to the dotted TOML dependency spelling: its pattern `^rustfs-[a-z0-9-]+ *=` requires ` =` immediately after the crate name, so `rustfs-signer.workspace = true` never matches. #6166 (HS-05, the SigV4-signed madmin `AdminClient`) added exactly that line to `crates/madmin/Cargo.toml` four days after the guard landed, so main has been carrying an internal dependency in a documented leaf crate while the guard reported clean.

Two changes, coupled because fixing the regex alone would turn the guard red on main:

- Guard: the dependency pattern and both allowlist patterns now accept an optional dotted key path (`(\.[a-zA-Z_-]+)*`) before the `=`, so both TOML spellings of a dependency are caught and both spellings of an allowed edge stay allowed. The failure message names the per-crate pins.
- Adjudication: `madmin` leaves the leaf set. `rustfs-signer` is not a pure contract crate (it depends on `rustfs-utils` with full features, `hyper`, `s3s`), so the edge cannot ride the #6683 criterion; instead the docs record that since #6166 madmin is the admin SDK client and the guard pins its internal dependency surface to exactly `rustfs-signer`. ARCHITECTURE.md invariant 2 and `docs/architecture/crate-boundaries.md` are updated to match; the pure-contract criterion for future leaf exceptions is unchanged.

## Verification

- `bash scripts/check_architecture_migration_rules.sh` — pass on the final tree
- Injection tests (all reverted afterwards, tree confirmed clean): dotted `rustfs-utils.workspace = true` appended to `crates/crypto/Cargo.toml` fails the guard; `rustfs-ecstore = { workspace = true }` appended to `crates/madmin/Cargo.toml` fails; `crates/io-metrics/Cargo.toml`'s allowed `rustfs-s3-ops` edge rewritten to the dotted spelling still passes; near-miss name `rustfs-s3-ops-extra` appended to io-metrics fails
- `bash scripts/check_layer_dependencies.sh` — pass
- `bash scripts/check_doc_paths.sh` — pass
- `bash -n scripts/check_architecture_migration_rules.sh` — pass; no Rust code touched

## Impact

Guard-and-docs only; no runtime behavior change. The documented leaf invariant, the actual dependency graph, and the guard that enforces them agree again. Any future `rustfs-*` dependency added to config/credentials/crypto/io-metrics/madmin in either TOML spelling fails `make pre-commit` with a pointer to the adjudication requirement.

## Additional Notes

Closes out the backlog#1834 series (PR1 #6051, PR3 #6052, PR6 #6053, PR4 #6061, PR5 #6154, PR2 #6683); this is the acceptance-pass fix.
