### PR TITLE
fix(e2e): implement scanner lease RPC stubs

### DIFF
--- a/crates/e2e_test/src/reliant/grpc_lock_server.rs
+++ b/crates/e2e_test/src/reliant/grpc_lock_server.rs
@@ -23,8 +23,9 @@ use rustfs_protos::{
     proto_gen::node_service::{
         BatchGenerallyLockRequest, BatchGenerallyLockResponse, BatchReadVersionRequest, BatchReadVersionResponse,
         GenerallyLockRequest, GenerallyLockResponse, GenerallyLockResult, PingRequest, PingResponse,
-        SnapshotLeaseMutationResponse, SnapshotLeaseReleaseRequest, SnapshotLeaseRenewRequest, SnapshotLeaseRequest,
-        SnapshotLeaseResponse, node_service_server::NodeService,
+        ScannerPublicationLeaseReleaseRequest, ScannerPublicationLeaseReleaseResponse, ScannerPublicationLeaseRequest,
+        ScannerPublicationLeaseResponse, SnapshotLeaseMutationResponse, SnapshotLeaseReleaseRequest, SnapshotLeaseRenewRequest,
+        SnapshotLeaseRequest, SnapshotLeaseResponse, node_service_server::NodeService,
     },
 };
 use std::pin::Pin;
@@ -123,6 +124,20 @@ impl NodeService for MinimalLockNodeService {
         &self,
         _request: Request<SnapshotLeaseReleaseRequest>,
     ) -> Result<Response<SnapshotLeaseMutationResponse>, Status> {
+        Err(Status::unimplemented("MinimalLockNodeService only supports lock RPCs"))
+    }
+
+    async fn acquire_scanner_publication_lease(
+        &self,
+        _request: Request<ScannerPublicationLeaseRequest>,
+    ) -> Result<Response<ScannerPublicationLeaseResponse>, Status> {
+        Err(Status::unimplemented("MinimalLockNodeService only supports lock RPCs"))
+    }
+
+    async fn release_scanner_publication_lease(
+        &self,
+        _request: Request<ScannerPublicationLeaseReleaseRequest>,
+    ) -> Result<Response<ScannerPublicationLeaseReleaseResponse>, Status> {
         Err(Status::unimplemented("MinimalLockNodeService only supports lock RPCs"))
     }
 


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Add explicit unimplemented scanner publication lease RPCs to the lock-only gRPC test service after those methods became required by `NodeService`.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p e2e_test`
- `cargo test -p e2e_test reliant::lock::test_distributed_lock_4_nodes_grpc -- --exact --nocapture`

## Impact

Test-only. The minimal lock service keeps rejecting non-lock RPCs and the `e2e_test` crate compiles again.

## Additional Notes

Fixes the `Test and Lint` compile failure from main run 33004398712.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
