### PR TITLE
fix(e2e): add scanner publication lease RPCs to the minimal lock mock

### DIFF
--- a/crates/e2e_test/src/reliant/grpc_lock_server.rs
+++ b/crates/e2e_test/src/reliant/grpc_lock_server.rs
@@ -23,8 +23,9 @@ use rustfs_protos::{
     proto_gen::node_service::{
         BatchGenerallyLockRequest, BatchGenerallyLockResponse, BatchReadVersionRequest, BatchReadVersionResponse,
         GenerallyLockRequest, GenerallyLockResponse, GenerallyLockResult, PingRequest, PingResponse,
-        SnapshotLeaseMutationResponse, SnapshotLeaseReleaseRequest, SnapshotLeaseRenewRequest, SnapshotLeaseRequest,
-        SnapshotLeaseResponse, node_service_server::NodeService,
+        ScannerPublicationLeaseReleaseRequest, ScannerPublicationLeaseReleaseResponse, ScannerPublicationLeaseRequest,
+        ScannerPublicationLeaseResponse, SnapshotLeaseMutationResponse, SnapshotLeaseReleaseRequest, SnapshotLeaseRenewRequest,
+        SnapshotLeaseRequest, SnapshotLeaseResponse, node_service_server::NodeService,
     },
 };
 use std::pin::Pin;
@@ -102,6 +103,20 @@ impl NodeService for MinimalLockNodeService {
         &self,
         _request: Request<BatchReadVersionRequest>,
     ) -> Result<Response<BatchReadVersionResponse>, Status> {
+        Err(Status::unimplemented("MinimalLockNodeService only supports lock RPCs"))
+    }
+
+    async fn acquire_scanner_publication_lease(
+        &self,
+        _request: Request<ScannerPublicationLeaseRequest>,
+    ) -> Result<Response<ScannerPublicationLeaseResponse>, Status> {
+        Err(Status::unimplemented("MinimalLockNodeService only supports lock RPCs"))
+    }
+
+    async fn release_scanner_publication_lease(
+        &self,
+        _request: Request<ScannerPublicationLeaseReleaseRequest>,
+    ) -> Result<Response<ScannerPublicationLeaseReleaseResponse>, Status> {
         Err(Status::unimplemented("MinimalLockNodeService only supports lock RPCs"))
     }
 


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues
N/A (unblocks main CI; fallout from the proto regeneration that landed the scanner publication lease RPCs)

## Summary of Changes
Main CI has been red since 2026-08-26 (every `Test and Lint` run from 2ada8a5cf through 94a61d789): `crates/protos/src/generated/proto_gen/node_service.rs` gained `acquire_scanner_publication_lease` / `release_scanner_publication_lease` on the `NodeService` trait (#6461), but the e2e minimal lock mock `MinimalLockNodeService` was never given the two methods, so `e2e_test` (lib) fails with E0046 and `cargo clippy --all-targets` aborts before running any lints or tests. This adds the two missing methods to `crates/e2e_test/src/reliant/grpc_lock_server.rs` with the file's existing idiom for every non-lock RPC: `Status::unimplemented("MinimalLockNodeService only supports lock RPCs")`. No production code is touched.

## Verification
- `cargo clippy -p e2e_test --all-targets` — exit 0 (this exact target is what fails on main with E0046)
- `cargo fmt -p e2e_test` — clean

## Impact
Test-only change; restores workspace compilation so the `Test and Lint`, `Test and Lint (rio-v2)`, and `End-to-End Tests` jobs can run again. No user-facing, API, or wire impact.

## Additional Notes
The lease RPCs were added to `node.proto` and the committed generated code by #6461; the mock predates them (last touched by #5916). Any test that wants a real scanner-lease behaviour from this mock should implement it then — for the lock-only mock, `unimplemented` is the correct fail-closed answer, matching the neighbouring snapshot-lease stubs.
