### PR TITLE
chore(release): prepare 1.0.0-rc.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3858,7 +3858,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e_test"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -9300,7 +9300,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9441,7 +9441,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-audit"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "async-trait",
  "const-str",
@@ -9464,7 +9464,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-checksums"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9480,7 +9480,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-common"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "hotpath",
  "metrics",
@@ -9493,7 +9493,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-concurrency"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "hotpath",
  "insta",
@@ -9506,7 +9506,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-config"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "const-str",
  "hotpath",
@@ -9516,7 +9516,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-credentials"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "base64-simd",
  "hmac 0.13.0",
@@ -9530,7 +9530,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-crypto"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9551,7 +9551,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-data-usage"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "hotpath",
  "rmp-serde",
@@ -9561,7 +9561,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-ecstore"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -9697,7 +9697,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-extension-schema"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "hotpath",
  "serde",
@@ -9707,7 +9707,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-filemeta"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "arc-swap",
  "byteorder",
@@ -9734,7 +9734,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -9770,7 +9770,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal-contracts"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "serde",
  "tokio",
@@ -9779,7 +9779,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-iam"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9827,7 +9827,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-core"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "bytes",
  "hotpath",
@@ -9839,7 +9839,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-metrics"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "criterion",
  "hotpath",
@@ -9903,7 +9903,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-keystone"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "bytes",
  "futures",
@@ -9930,7 +9930,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-kms"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9980,7 +9980,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lifecycle"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "async-trait",
  "hotpath",
@@ -10003,7 +10003,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lock"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "async-trait",
  "compact_str",
@@ -10026,7 +10026,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-log-analyzer"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "chrono",
  "flate2",
@@ -10045,7 +10045,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-madmin"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "hotpath",
  "http 1.5.0",
@@ -10083,7 +10083,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-notify"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -10118,7 +10118,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-capacity"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "criterion",
  "futures",
@@ -10137,7 +10137,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-data-cache"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "bytes",
  "criterion",
@@ -10154,7 +10154,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-obs"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -10212,7 +10212,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-policy"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -10243,7 +10243,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protocols"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -10305,7 +10305,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protos"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "flatbuffers",
  "hotpath",
@@ -10330,7 +10330,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-replication"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "byteorder",
  "bytes",
@@ -10348,7 +10348,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -10388,7 +10388,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio-v2"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -10411,7 +10411,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-client"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -10456,7 +10456,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-ops"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "hotpath",
  "rustfs-s3-types",
@@ -10464,7 +10464,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-types"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "hotpath",
  "serde",
@@ -10473,7 +10473,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-api"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10503,7 +10503,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-query"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -10522,7 +10522,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10564,7 +10564,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner-contracts"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "chrono",
  "jiff",
@@ -10579,7 +10579,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-security-governance"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "hotpath",
  "thiserror 2.0.20",
@@ -10587,7 +10587,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-signer"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -10605,7 +10605,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-storage-api"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "async-trait",
  "hotpath",
@@ -10620,7 +10620,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-targets"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -10674,7 +10674,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-test-utils"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "hotpath",
  "rustfs-data-usage",
@@ -10690,7 +10690,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-tls-runtime"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "arc-swap",
  "hotpath",
@@ -10711,7 +10711,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-trusted-proxies"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "async-trait",
  "axum",
@@ -10748,7 +10748,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-utils"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "base64-simd",
  "blake2",
@@ -10790,7 +10790,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-zip"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "async-compression",
  "hotpath",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/rustfs/rustfs"
 rust-version = "1.97.1"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 homepage = "https://rustfs.com"
 description = "RustFS is a high-performance distributed object storage software built using Rust, one of the most popular languages worldwide. "
 keywords = ["RustFS", "Minio", "object-storage", "filesystem", "s3"]
@@ -89,55 +89,55 @@ redundant_clone = "warn"
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rustfs = { path = "./rustfs", version = "1.0.0-rc.3" }
-rustfs-heal = { path = "crates/heal", version = "1.0.0-rc.3" }
-rustfs-heal-contracts = { path = "crates/heal-contracts", version = "1.0.0-rc.3" }
-rustfs-scanner-contracts = { path = "crates/scanner-contracts", version = "1.0.0-rc.3" }
-rustfs-audit = { path = "crates/audit", version = "1.0.0-rc.3" }
-rustfs-checksums = { path = "crates/checksums", version = "1.0.0-rc.3" }
-rustfs-common = { path = "crates/common", version = "1.0.0-rc.3" }
-rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-rc.3" }
-rustfs-config = { path = "./crates/config", version = "1.0.0-rc.3" }
-rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-rc.3" }
-rustfs-credentials = { path = "crates/credentials", version = "1.0.0-rc.3" }
-rustfs-crypto = { path = "crates/crypto", version = "1.0.0-rc.3" }
-rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-rc.3" }
-rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-rc.3" }
-rustfs-iam = { path = "crates/iam", version = "1.0.0-rc.3" }
-rustfs-keystone = { path = "crates/keystone", version = "1.0.0-rc.3" }
-rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-rc.3" }
-rustfs-kms = { path = "crates/kms", version = "1.0.0-rc.3" }
-rustfs-lock = { path = "crates/lock", version = "1.0.0-rc.3" }
-rustfs-madmin = { path = "crates/madmin", version = "1.0.0-rc.3" }
-rustfs-notify = { path = "crates/notify", version = "1.0.0-rc.3" }
-rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-rc.3" }
-rustfs-io-core = { path = "crates/io-core", version = "1.0.0-rc.3" }
-rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-rc.3" }
-rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-rc.3", default-features = false }
-rustfs-log-analyzer = { path = "crates/log-analyzer", version = "1.0.0-rc.3" }
-rustfs-obs = { path = "crates/obs", version = "1.0.0-rc.3" }
-rustfs-policy = { path = "crates/policy", version = "1.0.0-rc.3" }
-rustfs-protos = { path = "crates/protos", version = "1.0.0-rc.3" }
-rustfs-protocols = { path = "crates/protocols", version = "1.0.0-rc.3" }
-rustfs-replication = { path = "crates/replication", version = "1.0.0-rc.3" }
-rustfs-rio = { path = "crates/rio", version = "1.0.0-rc.3" }
-rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-rc.3" }
-rustfs-s3-client = { path = "crates/s3-client", version = "1.0.0-rc.3" }
-rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-rc.3" }
-rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-rc.3" }
-rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-rc.3" }
-rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-rc.3" }
-rustfs-scanner = { path = "crates/scanner", version = "1.0.0-rc.3" }
-rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-rc.3" }
-rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-rc.3" }
-rustfs-signer = { path = "crates/signer", version = "1.0.0-rc.3" }
-rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-rc.3" }
-rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-rc.3" }
-rustfs-targets = { path = "crates/targets", version = "1.0.0-rc.3" }
-rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-rc.3" }
-rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-rc.3" }
-rustfs-utils = { path = "crates/utils", version = "1.0.0-rc.3" }
-rustfs-zip = { path = "./crates/zip", version = "1.0.0-rc.3" }
+rustfs = { path = "./rustfs", version = "1.0.0-rc.4" }
+rustfs-heal = { path = "crates/heal", version = "1.0.0-rc.4" }
+rustfs-heal-contracts = { path = "crates/heal-contracts", version = "1.0.0-rc.4" }
+rustfs-scanner-contracts = { path = "crates/scanner-contracts", version = "1.0.0-rc.4" }
+rustfs-audit = { path = "crates/audit", version = "1.0.0-rc.4" }
+rustfs-checksums = { path = "crates/checksums", version = "1.0.0-rc.4" }
+rustfs-common = { path = "crates/common", version = "1.0.0-rc.4" }
+rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-rc.4" }
+rustfs-config = { path = "./crates/config", version = "1.0.0-rc.4" }
+rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-rc.4" }
+rustfs-credentials = { path = "crates/credentials", version = "1.0.0-rc.4" }
+rustfs-crypto = { path = "crates/crypto", version = "1.0.0-rc.4" }
+rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-rc.4" }
+rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-rc.4" }
+rustfs-iam = { path = "crates/iam", version = "1.0.0-rc.4" }
+rustfs-keystone = { path = "crates/keystone", version = "1.0.0-rc.4" }
+rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-rc.4" }
+rustfs-kms = { path = "crates/kms", version = "1.0.0-rc.4" }
+rustfs-lock = { path = "crates/lock", version = "1.0.0-rc.4" }
+rustfs-madmin = { path = "crates/madmin", version = "1.0.0-rc.4" }
+rustfs-notify = { path = "crates/notify", version = "1.0.0-rc.4" }
+rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-rc.4" }
+rustfs-io-core = { path = "crates/io-core", version = "1.0.0-rc.4" }
+rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-rc.4" }
+rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-rc.4", default-features = false }
+rustfs-log-analyzer = { path = "crates/log-analyzer", version = "1.0.0-rc.4" }
+rustfs-obs = { path = "crates/obs", version = "1.0.0-rc.4" }
+rustfs-policy = { path = "crates/policy", version = "1.0.0-rc.4" }
+rustfs-protos = { path = "crates/protos", version = "1.0.0-rc.4" }
+rustfs-protocols = { path = "crates/protocols", version = "1.0.0-rc.4" }
+rustfs-replication = { path = "crates/replication", version = "1.0.0-rc.4" }
+rustfs-rio = { path = "crates/rio", version = "1.0.0-rc.4" }
+rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-rc.4" }
+rustfs-s3-client = { path = "crates/s3-client", version = "1.0.0-rc.4" }
+rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-rc.4" }
+rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-rc.4" }
+rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-rc.4" }
+rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-rc.4" }
+rustfs-scanner = { path = "crates/scanner", version = "1.0.0-rc.4" }
+rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-rc.4" }
+rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-rc.4" }
+rustfs-signer = { path = "crates/signer", version = "1.0.0-rc.4" }
+rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-rc.4" }
+rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-rc.4" }
+rustfs-targets = { path = "crates/targets", version = "1.0.0-rc.4" }
+rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-rc.4" }
+rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-rc.4" }
+rustfs-utils = { path = "crates/utils", version = "1.0.0-rc.4" }
+rustfs-zip = { path = "./crates/zip", version = "1.0.0-rc.4" }
 
 # Async Runtime and Networking
 async-channel = "2.5.0"

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # Using specific version
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.3
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.4
 ```
 
 If you use [podman](https://github.com/containers/podman) instead of docker, you can install the RustFS with the below command

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -112,7 +112,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # 使用指定版本运行
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.3
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.4
 ```
 
 如果您通过绑定挂载启用 TLS 证书目录，也请用同样方式准备该目录：

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
         {
           default = rustPlatform.buildRustPackage {
             pname = "rustfs";
-            version = "1.0.0-rc.3";
+            version = "1.0.0-rc.4";
 
             src = ./.;
 

--- a/helm/rustfs/Chart.yaml
+++ b/helm/rustfs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rustfs
 description: RustFS helm chart to deploy RustFS on kubernetes cluster.
 type: application
-version: "1.0.0-rc.3"
-appVersion: "1.0.0-rc.3"
+version: "1.0.0-rc.4"
+appVersion: "1.0.0-rc.4"
 home: https://rustfs.com
 icon: https://media.sys.truenas.net/apps/rustfs/icons/icon.svg
 maintainers:

--- a/rustfs.spec
+++ b/rustfs.spec
@@ -1,9 +1,9 @@
 %global _enable_debug_packages 0
 %global _empty_manifest_terminate_build 0
-%global prerelease rc.3
+%global prerelease rc.4
 Name:           rustfs
 Version:        1.0.0
-Release:        rc.3
+Release:        rc.4
 Summary:       High-performance distributed object storage for MinIO alternative
 
 License:        Apache-2.0
@@ -58,6 +58,9 @@ install %_builddir/%{name}-%{version}-%{prerelease}/target/%_arch/%_arch-unknown
 %_bindir/rustfs
 
 %changelog
+* Thu Aug 27 2026 overtrue <anzhengchao@gmail.com>
+- Update RPM package to RustFS 1.0.0-rc.4
+
 * Thu Aug 20 2026 overtrue <anzhengchao@gmail.com>
 - Update RPM package to RustFS 1.0.0-rc.3
 


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Bump the workspace and internal crate versions to `1.0.0-rc.4`.
- Align Docker examples, Nix, Helm, and RPM release metadata.

## Verification

- `make pre-commit`
- `git diff --check`

## Impact

Prepares the repository for the `1.0.0-rc.4` release. No runtime behavior changes.

## Additional Notes

The Console release gate passed with `v0.1.23` published from `ad64f5d2dfc4364e1fae5934df3d12e20e15cca9`.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
