### PR TITLE
ci(pool-test): fix scheduled runs and env source

### DIFF
--- a/.github/workflows/rustfs-pool-expand-test.yml
+++ b/.github/workflows/rustfs-pool-expand-test.yml
@@ -58,9 +58,12 @@ defaults:
 env:
   RUSTFS_ACCESS_KEY: ${{ secrets.RUSTFS_ACCESS_KEY }}
   RUSTFS_SECRET_KEY: ${{ secrets.RUSTFS_SECRET_KEY }}
-  RUSTFS_API_ENDPOINT: ${{ vars.RUSTFS_API_ENDPOINT || vars.RUSTFS_RC_ENDPOINT }}
-  RUSTFS_NODES: ${{ vars.RUSTFS_NODES }}
-  RUSTFS_SSH_USER: ${{ vars.RUSTFS_SSH_USER }}
+  RUSTFS_API_ENDPOINT: ${{ secrets.RUSTFS_API_ENDPOINT || vars.RUSTFS_API_ENDPOINT || vars.RUSTFS_RC_ENDPOINT }}
+  RUSTFS_NODES: ${{ secrets.RUSTFS_NODES || vars.RUSTFS_NODES }}
+  RUSTFS_SSH_USER: ${{ secrets.RUSTFS_SSH_USER || vars.RUSTFS_SSH_USER }}
+  # Package used by the scheduled run (workflow_dispatch inputs are empty for
+  # schedule events), i.e. the latest nightly deb published by nightly-gnu.yml.
+  RUSTFS_NIGHTLY_PACKAGE_URL: ${{ vars.RUSTFS_NIGHTLY_PACKAGE_URL || 'https://dl.rustfs.com/artifacts/rustfs/packages/nightly/rustfs-nightly-latest.deb' }}
 
 jobs:
   pool-expansion-test:
@@ -81,7 +84,7 @@ jobs:
           df -h /data | tail -1
 
       - name: Reset test environment (before)
-        if: ${{ inputs.cleanup_before }}
+        if: ${{ inputs.cleanup_before != 'false' }}
         run: |
           chmod +x scripts/test/rustfs_pool_expand.sh
           ./scripts/test/rustfs_pool_expand.sh --reset -y
@@ -91,8 +94,10 @@ jobs:
           ARGS=(--preflight --endpoint "${{ env.RUSTFS_API_ENDPOINT }}")
           if [ -n "${{ inputs.package_url }}" ]; then
             ARGS+=(--package-url "${{ inputs.package_url }}")
-          else
+          elif [ -n "${{ inputs.rustfs_version }}" ]; then
             ARGS+=(--version "${{ inputs.rustfs_version }}")
+          else
+            ARGS+=(--package-url "${{ env.RUSTFS_NIGHTLY_PACKAGE_URL }}")
           fi
           ./scripts/test/rustfs_pool_expand.sh "${ARGS[@]}"
 
@@ -101,21 +106,23 @@ jobs:
         run: |
           set -o pipefail
           STEPS="1,2,3,4,5,6"
-          if [ "${{ inputs.pools }}" = "3" ]; then
+          if [ "${{ inputs.pools || '3' }}" = "3" ]; then
             STEPS="$STEPS,7,8"
-            if [ "${{ inputs.run_decommission }}" = "true" ]; then
+            if [ "${{ inputs.run_decommission != 'false' }}" = "true" ]; then
               STEPS="$STEPS,9"
             fi
           fi
           ARGS=(--steps "$STEPS" --with-warp -y \
             --endpoint "${{ env.RUSTFS_API_ENDPOINT }}" \
-            --storage-threshold "${{ inputs.storage_threshold }}" \
-            --warp-duration "${{ inputs.warp_duration }}" \
+            --storage-threshold "${{ inputs.storage_threshold || '50' }}" \
+            --warp-duration "${{ inputs.warp_duration || '10m' }}" \
             --log-file /tmp/rustfs-pool-test.log)
           if [ -n "${{ inputs.package_url }}" ]; then
             ARGS+=(--package-url "${{ inputs.package_url }}")
-          else
+          elif [ -n "${{ inputs.rustfs_version }}" ]; then
             ARGS+=(--version "${{ inputs.rustfs_version }}")
+          else
+            ARGS+=(--package-url "${{ env.RUSTFS_NIGHTLY_PACKAGE_URL }}")
           fi
           ./scripts/test/rustfs_pool_expand.sh "${ARGS[@]}"
 
@@ -130,7 +137,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Reset test environment (after)
-        if: ${{ always() && inputs.cleanup_after }}
+        if: ${{ always() && inputs.cleanup_after != 'false' }}
         run: |
           ./scripts/test/rustfs_pool_expand.sh --reset -y
 
@@ -138,5 +145,5 @@ jobs:
         if: failure()
         run: |
           echo "RustFS pool expansion test failed"
-          echo "Package source: ${{ inputs.package_url || format('release {0}', inputs.rustfs_version) }}"
+          echo "Package source: ${{ inputs.package_url || inputs.rustfs_version || 'nightly (R2 latest)' }}"
           echo "See the uploaded log artifact for details."


### PR DESCRIPTION
## Problem

The scheduled pool expansion run (21:00 UTC) failed at preflight:

```
ARGS=(--preflight --endpoint "")
ARGS+=(--version "")
package URL not reachable: https://github.com/rustfs/rustfs/releases/download//rustfs__amd64.deb
```

`workflow_dispatch` inputs are **empty for `schedule` events**, so `inputs.rustfs_version` was `""`, `cleanup_before/after` evaluated empty (resets skipped), and the thresholds/duration fell through as blanks. `RUSTFS_API_ENDPOINT` / `RUSTFS_NODES` / `RUSTFS_SSH_USER` also came through empty because the workflow read `vars.*` while the repo has them configured as secrets.

## Fix

- Scheduled runs now fall back to the **latest nightly deb** (`https://dl.rustfs.com/artifacts/rustfs/packages/nightly/rustfs-nightly-latest.deb`, overridable via `RUSTFS_NIGHTLY_PACKAGE_URL` var) instead of an empty release tag.
- Manual dispatch still honors `package_url` / `rustfs_version`.
- Defaults: `pools=3`, `storage_threshold=50`, `warp_duration=10m`, `run_decommission=true`; cleanup defaults to enabled when the inputs are absent.
- `RUSTFS_API_ENDPOINT` / `RUSTFS_NODES` / `RUSTFS_SSH_USER` are read from secrets first, then variables — either configuration now works.