### PR TITLE
test(ci): quarantine the relocated-pool GET resume fixture flake

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -196,6 +196,17 @@ test-group = 'ecstore-serial-flaky'
 filter = 'package(rustfs-ecstore) & test(walk_dir_does_not_charge_consumer_backpressure_to_the_stall_budget)'
 retries = 2
 
+# QUARANTINE: OPEN rustfs#6703 — the relocated-pool GET resume test stages its
+# fixture by copying xl.meta from every source-pool disk, but an EC write only
+# guarantees quorum-many disks have materialized; a lagging disk under CI load
+# panics the staging copy with NotFound (failed on a zero-overlap s3-client PR).
+# Subsumes the previous serialization-only ci entry for this test: the
+# test-group is re-declared here per the header rule above.
+[[profile.ci.overrides]]
+filter = 'package(rustfs) & test(execute_get_object_resumes_from_relocated_pool_without_splicing_body)'
+test-group = 'ecstore-serial-flaky'
+retries = 2
+
 # Serialize the 4-disk reliability / degraded-read e2e tests under the ci
 # profile too (see the e2e-reliability test-group note near the top). Not a
 # quarantine: no retries, just single-threaded so several 4-disk servers never
@@ -209,10 +220,6 @@ test-group = 'e2e-reliability'
 # no retries, just serialized 4-disk cross-disk-commit IO.
 [[profile.ci.overrides]]
 filter = 'package(rustfs-ecstore) & test(/^set_disk::ops::multipart::tests::crash_consistency::/)'
-test-group = 'ecstore-serial-flaky'
-
-[[profile.ci.overrides]]
-filter = 'package(rustfs) & test(execute_get_object_resumes_from_relocated_pool_without_splicing_body)'
 test-group = 'ecstore-serial-flaky'
 
 # Match the default-profile embedded test isolation without quarantining or


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues
rustfs#6703 (tracking issue for the flake, filed per the docs/testing/README.md flake policy)

## Summary of Changes
`rustfs app::object::get::tests::execute_get_object_resumes_from_relocated_pool_without_splicing_body` failed on the `Test and Lint (sftp)` leg of #6700 (run 33025470517) with a `NotFound` panic in its own fixture staging (`stage relocated object metadata`, get.rs:7223), while the swift and rio-v2 legs of the same commit and the same leg of the parent PR #6696 passed — a non-deterministic failure with no corresponding code change. Suspected mechanism (detailed in rustfs#6703): the fixture copies `xl.meta` from every source-pool disk, but an EC write only guarantees quorum-many disks have materialized, so a lagging disk under CI load loses the race.

Per the flake policy this adds the test to the quarantine list in `.config/nextest.toml`: `retries = 2` under the ci profile only, linked to the OPEN issue. The entry subsumes the previous serialization-only ci override for this test (the `ecstore-serial-flaky` test-group is re-declared on the quarantine entry per the file's header rule), so the test keeps its serialization and the file keeps one entry per test.

## Verification
- `python3 -c "import tomllib; ..."` — config parses; exactly one ci override matches the test, carrying both `test-group = 'ecstore-serial-flaky'` and `retries = 2`
- The change is CI-profile configuration only; no production or test code is touched

## Impact
CI-only: the flake stops reddening unrelated PRs while staying visible through the JUnit `flaky` marker. The 30-day fix-or-delete window of the policy applies, tracked by rustfs#6703.

## Additional Notes
N/A
