### PR TITLE
docs(rio): record the checksum hasher verdict and pin shared vectors

### DIFF
--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -49,10 +49,14 @@ pub const MD5_NAME: &str = "md5";
 /// (crates/s3-client/src/checksum.rs) delegates all per-algorithm dispatch
 /// here through its `algorithm()` bridge. The on-disk xl.meta bitset remains
 /// deliberately separate in `rustfs_rio::ChecksumType`
-/// (crates/rio/src/checksum.rs, varint bits are append-only). When adding an
-/// algorithm: add the variant here (the exhaustive matches force every
-/// metadata decision), bridge it in the client, and allocate an xl.meta bit
-/// in rio (or record why not).
+/// (crates/rio/src/checksum.rs, varint bits are append-only), and rio also
+/// keeps its own hot-path hasher shells — equivalence with this crate's
+/// hashers is enforced by both test suites pinning the same official
+/// known-answer vectors (backlog#1844 PR3 verdict, recorded on
+/// `rustfs_rio::ChecksumType`). When adding an algorithm: add the variant
+/// here (the exhaustive matches force every metadata decision), bridge it in
+/// the client, and allocate an xl.meta bit + hasher + shared vector in rio
+/// (or record why not).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum ChecksumAlgorithm {

--- a/crates/rio/src/checksum.rs
+++ b/crates/rio/src/checksum.rs
@@ -31,14 +31,28 @@ pub const RUSTFS_MULTIPART_CHECKSUM_TYPE: &str = "x-rustfs-multipart-checksum-ty
 
 /// Checksum type enumeration with flags
 ///
-/// One of three deliberately separate checksum registries (backlog#1833):
-/// this bitset owns the **on-disk xl.meta encoding** — the raw `u32` is
+/// This bitset owns the **on-disk xl.meta encoding** — the raw `u32` is
 /// varint-serialized into xl.meta (see `append_to`), so bits are append-only
-/// and must never be renumbered. `rustfs_checksums::ChecksumAlgorithm`
-/// (crates/checksums/src/lib.rs) owns the streaming-hash algorithm registry,
-/// and the MinIO-port client keeps its own `ChecksumMode`
-/// (crates/ecstore/src/client/checksum.rs). When adding an algorithm, extend
-/// all three (or record why not) — they do not derive from each other.
+/// and must never be renumbered. Canonical per-algorithm metadata (wire
+/// names, headers, digest lengths, checksum-type capabilities) lives in
+/// `rustfs_checksums::ChecksumAlgorithm` (crates/checksums/src/lib.rs), which
+/// the MinIO-port client's `ChecksumMode`
+/// (crates/s3-client/src/checksum.rs) consumes through its `algorithm()`
+/// bridge (backlog#1844).
+///
+/// The hasher implementations below stay rio-native rather than delegating
+/// to rustfs-checksums (backlog#1844 PR3 verdict): `ChecksumHasher` needs a
+/// non-consuming `finalize` plus `reset` on the server hot path, while the
+/// checksums `Checksum` trait finalizes by consuming the box; MD5 is a base
+/// type here (x-amz-checksum-md5, bit 14) but deliberately not a
+/// `ChecksumAlgorithm` variant; and both crates already drive the same
+/// backends (crc_fast, sha1/sha2, xxhash_rust, md5). Equivalence is enforced
+/// instead by pinning both sides to the same official known-answer vectors —
+/// see `hashers_match_rustfs_checksums_known_answer_vectors` below and the
+/// digest tests in crates/checksums. When adding an algorithm: extend
+/// `ChecksumAlgorithm` (exhaustive matches force the metadata), bridge it in
+/// the client, allocate a bit + hasher here, and pin the shared vector in
+/// both test suites (or record why a surface is skipped).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ChecksumType(pub u32);
 
@@ -1643,6 +1657,24 @@ mod tests {
                 ..Default::default()
             };
             assert!(acc.add_part(&c1, part1.len() as i64).is_err(), "{t:?} must not be full-object mergeable");
+        }
+    }
+
+    // Drift lock for the backlog#1844 PR3 verdict: rio keeps its own hasher
+    // shells instead of delegating to rustfs-checksums, so both sides pin the
+    // SAME input and official digests (crates/checksums/src/lib.rs pins these
+    // values for "test data" in its own tests). If either implementation ever
+    // changes backend, seed, or byte order, one of the two suites fails loudly.
+    #[test]
+    fn hashers_match_rustfs_checksums_known_answer_vectors() {
+        for (t, want_hex) in [
+            (ChecksumType::CRC32, "d308aeb2"),
+            (ChecksumType::CRC32C, "3379b4ca"),
+            (ChecksumType::CRC64_NVME, "aecaf3af9c98a855"),
+            (ChecksumType::SHA1, "f48dd853820860816c75d54d0f584dc863327a7c"),
+            (ChecksumType::SHA256, "916f0027a575074ce72a331777c3478d6513f786a591bd892da1a577bf2335f9"),
+        ] {
+            assert_eq!(raw_hex(t, b"test data"), want_hex, "{t:?} digest drifted from the shared vector");
         }
     }
 


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues
Closes the implementation plan of rustfs/backlog#1844 (PR3 of 3; PR1 #6696 built the bridge, PR2 removed the superseded plumbing)

## Summary of Changes
The backlog issue's PR3 asks for an evaluation of whether rio's hasher implementations should be provided by rustfs-checksums, with the conclusion recorded in the registry cross-reference comments either way. The evaluation concludes **against** delegating, and this PR records that verdict where the next maintainer will look:

- **Verdict (on `rustfs_rio::ChecksumType`)**: rio's `ChecksumHasher` contract needs a non-consuming `finalize` plus `reset` on the server hot path, while the checksums `Checksum` trait finalizes by consuming the box, so delegation means an adapter holding an `Option<Box<dyn Checksum>>` plus a factory, double indirection per write, and changed repeat-finalize semantics; MD5 is an xl.meta base type (`x-amz-checksum-md5`, bit 14) but deliberately not a `ChecksumAlgorithm` variant, so the adapter would be asymmetric anyway; and both crates already drive the same backends (crc_fast, sha1/sha2, xxhash_rust, md5), so the duplication is thin shells, not algorithm logic.
- **Enforcement instead of sharing**: rio previously pinned known-answer vectors only for the 2026-04 additions; the legacy five (CRC32, CRC32C, CRC64NVME, SHA1, SHA256) had no pinned digests on the rio side. A new `hashers_match_rustfs_checksums_known_answer_vectors` test pins the exact official digests that crates/checksums already pins for the same input, so if either implementation ever changes backend, seed, or byte order, one of the two suites fails loudly — drift is now impossible without a red test, which is the actual risk an adapter would have addressed.
- The three registry cross-reference comments (rio `ChecksumType`, `rustfs_checksums::ChecksumAlgorithm`, and the client `ChecksumMode` from PR1) now describe the post-#1844 layout — canonical metadata in `ChecksumAlgorithm`, client bridge, rio bitset + native hashers — including the add-an-algorithm recipe, and rio's stale pre-extraction path reference (`crates/ecstore/src/client/checksum.rs`) is gone.

Hard constraint respected: no xl.meta encoding or production rio code is touched — the diff is doc comments plus one test.

## Verification
- `cargo test -p rustfs-rio --lib checksum` — 15 passed (14 existing + the new drift-lock vectors)
- `cargo test -p rustfs-checksums` — 26 passed
- `cargo clippy -p rustfs-rio --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Impact
None at runtime: comments and a test only. The recorded verdict and the paired known-answer pins define the maintenance contract for future algorithm additions (metadata decisions forced in one place by `ChecksumAlgorithm`'s exhaustive matches; rio adds a bit + hasher + shared vector; the client adds one bridge arm).

## Additional Notes
With this PR the backlog#1844 acceptance criteria are met: the tier suite passed on PR1/PR2, the xl.meta round-trip tests are untouched and green, and the "next algorithm touches one registry" drill is documented on `ChecksumAlgorithm` itself — a missing metadata decision is now a compile error, a drifting hasher is a red test on whichever side drifted.
