### PR TITLE
test(get): tolerate quorum-tolerated disk gaps in relocated-pool test

### DIFF
--- a/rustfs/src/app/object/get.rs
+++ b/rustfs/src/app/object/get.rs
@@ -7173,12 +7173,25 @@ mod tests {
             })
             .expect("multipart object must be placed in one source pool");
         if upload_pool != 0 {
+            let mut normalized_disks = 0;
             for (source_disk, target_disk) in pool_disk_paths[upload_pool].iter().zip(&pool_disk_paths[0]) {
                 let source_object = source_disk.join(&bucket).join(object);
+                // The multipart commit succeeds on write quorum, so under suite
+                // IO load a lagging disk of the erasure set can legitimately
+                // hold no object directory (#6701). Normalize the disks that
+                // do hold it; the reader tolerates the same minority gap.
+                if !source_object.exists() {
+                    continue;
+                }
                 let target_bucket = target_disk.join(&bucket);
                 std::fs::create_dir_all(&target_bucket).expect("create normalized target bucket directory");
                 std::fs::rename(source_object, target_bucket.join(object)).expect("normalize the test object into the old pool");
+                normalized_disks += 1;
             }
+            assert!(
+                normalized_disks > pool_disk_paths[upload_pool].len() / 2,
+                "a write-quorum majority of the upload pool's disks must hold the multipart object to normalize"
+            );
         }
         let source_pool = 0;
         let target_pool = 1;


### PR DESCRIPTION
## Related Issues

Fixes #6701. Unblocks the CI lane that failed twice on #6699.

## Summary of Changes

`app::object::get::tests::execute_get_object_resumes_from_relocated_pool_without_splicing_body` normalizes its freshly-written multipart object into pool 0 by renaming `<disk>/<bucket>/<object>` for every disk pair of the upload pool, panicking with `NotFound` when any disk lacks the object directory. That assumption is wrong under load: the multipart commit succeeds on write quorum, so a lagging disk of the erasure set can legitimately hold no object directory. Reproduced on pristine main `64739778c` with zero local changes (`cargo nextest run -p rustfs --lib --no-fail-fast`, failed round 1 of 3 with exactly this panic) while 8/8 isolated runs pass; the same panic hit CI twice on #6699's branch.

The normalization loop now skips disks that do not hold the object and asserts that a write-quorum majority of the upload pool's disks were normalized — the reader tolerates the same minority gap, which is what the test exercises.

## Verification

- Reproduction evidence and analysis in #6701 (pristine-main full-suite failure, isolated-run passes, two CI hits).
- The single test passes in isolation with the fix; the full `-p rustfs --lib` suite run for this change is delegated to this PR's own CI lane (the local machine is currently saturated by concurrent builds — the failing condition needs suite-level IO load, which the CI runner supplies).

## Impact

Test-only change; no production code touched.

## Additional Notes

If the flake persists in some other shape, #6701 stays the quarantine anchor required by docs/testing/README.md for the `ci` profile's retry list.
