### PR TITLE
fix(ecstore): tighten decommission test-helper cfg gates to test-util

### DIFF
--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::bucket::replication::replication_state_from_filemeta;
-#[cfg(test)]
+#[cfg(all(test, feature = "test-util"))]
 use crate::bucket::utils::is_meta_bucketname;
 use crate::bucket::versioning_sys::BucketVersioningSys;
 use crate::bucket::{
@@ -8503,7 +8503,7 @@ impl ECStore {
         .await
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "test-util"))]
     pub(crate) async fn decommission_entry_for_test_with_bucket_incarnation(
         self: &Arc<Self>,
         idx: usize,
@@ -8671,7 +8671,7 @@ impl ECStore {
         Ok(())
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "test-util"))]
     pub(crate) async fn decommission_pool_for_test(
         self: &Arc<Self>,
         rx: CancellationToken,
@@ -9587,7 +9587,7 @@ impl ECStore {
         Ok(receipt_paths)
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "test-util"))]
     async fn persist_decommission_durable_ilm_manifest(&self, source_pool_idx: usize) -> Result<()> {
         let run_token = self.durable_ilm_receipt_run_token(source_pool_idx).await?;
         self.persist_decommission_durable_ilm_manifest_for_run(source_pool_idx, &run_token)
@@ -9705,7 +9705,7 @@ impl ECStore {
         Ok(receipts)
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "test-util"))]
     async fn persist_decommission_durable_ilm_receipt(
         &self,
         source_pool_idx: usize,
@@ -10309,7 +10309,7 @@ impl ECStore {
         Ok(())
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "test-util"))]
     async fn verify_and_cleanup_decommissioned_durable_ilm_record(
         &self,
         source_pool_idx: usize,
@@ -10381,7 +10381,7 @@ impl ECStore {
         resolve_decommission_entry_cleanup_delete_result(cleanup_result, RUSTFS_META_BUCKET, path)
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "test-util"))]
     pub(crate) async fn verify_and_cleanup_decommissioned_durable_ilm_record_for_test(
         &self,
         source_pool_idx: usize,
@@ -10392,12 +10392,12 @@ impl ECStore {
             .await
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "test-util"))]
     pub(crate) async fn decommission_durable_ilm_receipt_count_for_test(&self, source_pool_idx: usize) -> Result<usize> {
         Ok(self.list_decommission_durable_ilm_receipts(source_pool_idx).await?.len())
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "test-util"))]
     pub(crate) async fn decommission_durable_ilm_receipt_paths_for_test(
         &self,
         source_pool_idx: usize,
@@ -10405,7 +10405,7 @@ impl ECStore {
         self.list_decommission_durable_ilm_receipts(source_pool_idx).await
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "test-util"))]
     pub(crate) async fn persist_decommission_durable_ilm_receipt_for_test(
         &self,
         source_pool_idx: usize,
@@ -10424,12 +10424,12 @@ impl ECStore {
         Ok(decommission_durable_ilm_receipt_path(&run_token, source_path, record.id_kind, &record.id))
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "test-util"))]
     pub(crate) async fn persist_decommission_durable_ilm_manifest_for_test(&self, source_pool_idx: usize) -> Result<()> {
         self.persist_decommission_durable_ilm_manifest(source_pool_idx).await
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "test-util"))]
     pub(crate) async fn cleanup_decommission_durable_ilm_receipts_for_test(&self, source_pool_idx: usize) -> Result<()> {
         self.cleanup_decommission_durable_ilm_receipts(source_pool_idx).await
     }
@@ -10782,7 +10782,7 @@ impl ECStore {
         self.ensure_decommission_multipart_uploads_drained(idx, pool.as_ref(), &buckets)
             .await
     }
-    #[cfg(test)]
+    #[cfg(all(test, feature = "test-util"))]
     pub(crate) async fn check_after_decommission_for_test(self: &Arc<Self>, idx: usize) -> Result<()> {
         let generation = self.active_decommission_generation(idx).await?;
         self.check_after_decommission(idx, &CancellationToken::new(), generation)

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -490,7 +490,7 @@ fn decommission_mutation_fence_for_test(
         .map(|hook| hook.fence.clone())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-util"))]
 struct DecommissionFreeVersionSourceRaceState {
     bucket: String,
     object: String,
@@ -498,17 +498,17 @@ struct DecommissionFreeVersionSourceRaceState {
     release: tokio::sync::Notify,
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-util"))]
 pub(crate) struct DecommissionFreeVersionSourceRaceBarrier {
     state: Arc<DecommissionFreeVersionSourceRaceState>,
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-util"))]
 static DECOMMISSION_FREE_VERSION_SOURCE_RACE_BARRIER: std::sync::OnceLock<
     std::sync::Mutex<Option<Arc<DecommissionFreeVersionSourceRaceState>>>,
 > = std::sync::OnceLock::new();
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-util"))]
 impl DecommissionFreeVersionSourceRaceBarrier {
     pub(crate) fn install(bucket: &str, object: &str) -> Self {
         let state = Arc::new(DecommissionFreeVersionSourceRaceState {
@@ -537,7 +537,7 @@ impl DecommissionFreeVersionSourceRaceBarrier {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-util"))]
 impl Drop for DecommissionFreeVersionSourceRaceBarrier {
     fn drop(&mut self) {
         self.state.release.notify_one();
@@ -551,7 +551,7 @@ impl Drop for DecommissionFreeVersionSourceRaceBarrier {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-util"))]
 async fn pause_decommission_free_version_before_source_lock(bucket: &str, object: &str) {
     let state = DECOMMISSION_FREE_VERSION_SOURCE_RACE_BARRIER
         .get_or_init(|| std::sync::Mutex::new(None))
@@ -2385,7 +2385,7 @@ impl ECStore {
                 &object,
             )?
         };
-        #[cfg(test)]
+        #[cfg(all(test, feature = "test-util"))]
         if is_free_version {
             pause_decommission_free_version_before_source_lock(bucket, logical_object).await;
         }


### PR DESCRIPTION
## Related Issues

N/A (pre-existing warnings on main, surfaced during the set_disk lint-blanket retirement follow-up to #6697 via a pristine-main baseline comparison).

## Summary of Changes

The featureless tests lane (`cargo check -p rustfs-ecstore --tests`) carries 3 dead_code warnings on main: the decommission test helpers in `crates/ecstore/src/core/pools.rs` (12 methods, flagged as one "multiple methods are never used" warning) and the `DecommissionFreeVersionSourceRaceBarrier` ecosystem in `crates/ecstore/src/store/object.rs` (struct + associated items). All of their consumers are `#[cfg(feature = "test-util")]` tests inside the `store/init.rs` test module, so the existing `#[cfg(test)]` gates are one feature too wide. CI never sees the warnings because workspace feature unification pulls `test-util` in.

This PR tightens all 20 gates to `#[cfg(all(test, feature = "test-util"))]`: the 12 pools.rs helper methods, the `is_meta_bucketname` import only they use, and the 7-item barrier ecosystem in object.rs (state struct, barrier struct, static slot, impl, Drop impl, pause hook, and the production-path instrumentation block that calls it). `all(...)` rather than `any(...)` keeps the pure `--features test-util` lib lane free of newly dead items. This is a pure cfg-attribute change; no code was moved or edited, and non-test builds are byte-identical.

## Verification

- `cargo check -p rustfs-ecstore --message-format=short` — clean
- `cargo check -p rustfs-ecstore --tests --message-format=short` — clean (previously 3 dead_code warnings)
- `cargo check -p rustfs-ecstore --features rio-v2 --tests --message-format=short` — clean
- `cargo check -p rustfs-ecstore --features test-util --tests --message-format=short` — clean (confirms all gated items still compile and are consumed)
- `cargo nextest run -p rustfs-ecstore --no-fail-fast` — 4573 passed, 0 failed
- `make pre-commit` — all guard checks pass; the final `quick-check` step (`cargo check --workspace --exclude e2e_test`) passes when rerun with `-j2` (the in-gate run was killed by local memory pressure while compiling third-party dependencies, unrelated to this change)

## Impact

N/A. Test-only cfg gating; production code paths and the shipped binary are unchanged. The race-barrier pause hook in the decommission free-version path already compiled out of non-test builds and now also compiles out of non-`test-util` test builds, where it was unreachable anyway (no barrier could be installed without the feature).

## Additional Notes

The `#[cfg(test)]` import of `rmp_serde::Deserializer` in pools.rs is intentionally left untouched: its consumers are plain `#[cfg(test)]` code and it is not part of the warning set.
