### PR TITLE
test(pool): clean install via dpkg purge and split install/test phases

### DIFF
--- a/.github/workflows/rustfs-pool-expand-test.yml
+++ b/.github/workflows/rustfs-pool-expand-test.yml
@@ -89,6 +89,18 @@ jobs:
           chmod +x scripts/test/rustfs_pool_expand.sh
           ./scripts/test/rustfs_pool_expand.sh --reset -y
 
+      - name: Install RustFS package & start first pool
+        run: |
+          ARGS=(--steps 1,2,3 -y --endpoint "${{ env.RUSTFS_API_ENDPOINT }}")
+          if [ -n "${{ inputs.package_url }}" ]; then
+            ARGS+=(--package-url "${{ inputs.package_url }}")
+          elif [ -n "${{ inputs.rustfs_version }}" ]; then
+            ARGS+=(--version "${{ inputs.rustfs_version }}")
+          else
+            ARGS+=(--package-url "${{ env.RUSTFS_NIGHTLY_PACKAGE_URL }}")
+          fi
+          ./scripts/test/rustfs_pool_expand.sh "${ARGS[@]}"
+
       - name: Preflight checks
         run: |
           ARGS=(--preflight --endpoint "${{ env.RUSTFS_API_ENDPOINT }}")
@@ -105,26 +117,19 @@ jobs:
         id: pool_test
         run: |
           set -o pipefail
-          STEPS="1,2,3,4,5,6"
+          STEPS="4,5,6"
           if [ "${{ inputs.pools || '3' }}" = "3" ]; then
             STEPS="$STEPS,7,8"
             if [ "${{ inputs.run_decommission != 'false' }}" = "true" ]; then
               STEPS="$STEPS,9"
             fi
           fi
-          ARGS=(--steps "$STEPS" --with-warp -y \
+          ./scripts/test/rustfs_pool_expand.sh \
+            --steps "$STEPS" --with-warp -y \
             --endpoint "${{ env.RUSTFS_API_ENDPOINT }}" \
             --storage-threshold "${{ inputs.storage_threshold || '50' }}" \
             --warp-duration "${{ inputs.warp_duration || '10m' }}" \
-            --log-file /tmp/rustfs-pool-test.log)
-          if [ -n "${{ inputs.package_url }}" ]; then
-            ARGS+=(--package-url "${{ inputs.package_url }}")
-          elif [ -n "${{ inputs.rustfs_version }}" ]; then
-            ARGS+=(--version "${{ inputs.rustfs_version }}")
-          else
-            ARGS+=(--package-url "${{ env.RUSTFS_NIGHTLY_PACKAGE_URL }}")
-          fi
-          ./scripts/test/rustfs_pool_expand.sh "${ARGS[@]}"
+            --log-file /tmp/rustfs-pool-test.log
 
       - name: Upload test logs
         if: always()

--- a/scripts/test/rustfs_pool_expand.sh
+++ b/scripts/test/rustfs_pool_expand.sh
@@ -80,6 +80,7 @@ VOLUMES_AFTER_DECOMMISSION="http://rustfs-node2:9000/data/rustfs{1...4}/mnmd htt
 # RustFS service configuration (written to /etc/default/rustfs)
 RUSTFS_CONFIG_FILE="/etc/default/rustfs"
 RUSTFS_SERVICE="rustfs"
+RUSTFS_PACKAGE_NAME="rustfs"
 RUSTFS_USER="rustfs"
 RUSTFS_ADDRESS=":9000"
 RUSTFS_CONSOLE_ADDRESS=":9001"
@@ -701,24 +702,35 @@ preflight() {
   log "preflight OK"
 }
 
-# Reset the test environment: stop services, remove data dirs and config on all nodes.
-# Intended for CI so every run starts from a clean slate. Destructive!
+# Reset the test environment: purge the rustfs package (if installed) and
+# recreate the data directories on all nodes. Intended for CI so every run
+# starts from a clean slate. Destructive!
 step0_reset() {
-  log "reset: stop services and remove data dirs + config on all nodes"
-  confirm "This DESTROYS all RustFS data and config on ${NODES[*]} (irreversible). Continue?"
-  local -a dirs
-  dirs=()
-  while IFS= read -r d; do dirs+=("${d}"); done < <(volume_dirs "${VOLUMES_3}" | sort -u)
+  log "reset: purge rustfs package and recreate data dirs on all nodes"
+  confirm "This DESTROYS the RustFS install and ALL data on ${NODES[*]} (irreversible). Continue?"
   for node in "${NODES[@]}"; do
     {
       printf 'set -euo pipefail\n'
       printf 'SUDO=""; [ "$(id -u)" -ne 0 ] && SUDO="sudo -n"\n'
+      # Stop the service if it is still running, then purge the package
+      # (skipped when rustfs is not installed).
       printf '${SUDO} systemctl stop %s 2>/dev/null || true\n' "${RUSTFS_SERVICE}"
-      printf '${SUDO} systemctl reset-failed %s 2>/dev/null || true\n' "${RUSTFS_SERVICE}"
-      for d in "${dirs[@]}"; do
-        printf '${SUDO} rm -rf %s\n' "${d}"
-      done
-      printf '${SUDO} rm -f %s\n' "${RUSTFS_CONFIG_FILE}"
+      printf 'if ${SUDO} dpkg -l %s 2>/dev/null | grep -q "^ii"; then\n' "${RUSTFS_PACKAGE_NAME}"
+      printf '  ${SUDO} dpkg -P %s\n' "${RUSTFS_PACKAGE_NAME}"
+      printf '  echo "purged %s"\n' "${RUSTFS_PACKAGE_NAME}"
+      printf 'else\n'
+      printf '  echo "%s not installed, skip purge"\n' "${RUSTFS_PACKAGE_NAME}"
+      printf 'fi\n'
+      # Ensure the service user exists (created by the package postinst on
+      # install; a purge keeps it, but a never-installed node needs it for chown).
+      printf 'id -u %s >/dev/null 2>&1 || ${SUDO} useradd -r -s /bin/false -d /opt/%s %s\n' \
+        "${RUSTFS_USER}" "${RUSTFS_USER}" "${RUSTFS_USER}"
+      # Recreate the volume directories with the service user as owner.
+      printf 'for i in 1 2 3 4; do\n'
+      printf '  ${SUDO} rm -rf /data/rustfs${i}/mnmd\n'
+      printf '  ${SUDO} mkdir -p /data/rustfs${i}/mnmd\n'
+      printf '  ${SUDO} chown -R %s:%s /data/rustfs${i}/mnmd\n' "${RUSTFS_USER}" "${RUSTFS_USER}"
+      printf 'done\n'
     } | run_remote "${node}"
   done
   log "reset complete"


### PR DESCRIPTION
## Reset procedure (per the manual cleanup steps)

`--reset` now, on every node:

1. Purge the package when installed, skip when not: `dpkg -P rustfs`
   (with a `systemctl stop` guard first).
2. Recreate the volume dirs:
   ```
   for i in 1 2 3 4; do
     rm -rf /data/rustfs$i/mnmd
     mkdir -p /data/rustfs$i/mnmd
     chown -R rustfs:rustfs /data/rustfs$i/mnmd
   done
   ```

Verified on all three test nodes: installed → purged + dirs recreated; not installed → purge skipped + dirs recreated; the script `--reset` runs idempotently.

## Workflow phases

Split the pool-expansion workflow into explicit phases:

1. `Reset test environment (before)` — purge + recreate dirs.
2. **`Install RustFS package & start first pool`** (steps 1-3) — download the .deb, `dpkg -i`, start pool 0, verify via the admin API.
3. `Preflight checks` — now runs against a **running** cluster, so the admin API connectivity check is meaningful.
4. `Run pool expansion & decommission test` (steps 4-9) — warp writes, expand to 3 pools, rebalance twice, decommission.

The test phase no longer re-downloads/re-installs the package.