### PR TITLE
test(ci): point quarantine machinery at the legs it must protect

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -196,15 +196,23 @@ test-group = 'ecstore-serial-flaky'
 filter = 'package(rustfs-ecstore) & test(walk_dir_does_not_charge_consumer_backpressure_to_the_stall_budget)'
 retries = 2
 
-# QUARANTINE: OPEN rustfs#6703 — the relocated-pool GET resume test stages its
-# fixture by copying xl.meta from every source-pool disk, but an EC write only
-# guarantees quorum-many disks have materialized; a lagging disk under CI load
-# panics the staging copy with NotFound (failed on a zero-overlap s3-client PR).
-# Subsumes the previous serialization-only ci entry for this test: the
-# test-group is re-declared here per the header rule above.
+# Serialize the relocated-pool GET resume regression under the ci profile too
+# (see the matching default-profile override near the top). No longer a
+# quarantine: the fixture race (rustfs#6701/rustfs#6703) was fixed by #6707,
+# which made the staging tolerate quorum-tolerated disk gaps; only the 8-disk
+# cross-disk-IO serialization remains.
 [[profile.ci.overrides]]
 filter = 'package(rustfs) & test(execute_get_object_resumes_from_relocated_pool_without_splicing_body)'
 test-group = 'ecstore-serial-flaky'
+
+# QUARANTINE: OPEN rustfs#6711 — the multipart fencing test's epoch helper
+# reads xl.meta back from EVERY disk, but a multipart commit only guarantees
+# quorum-many disks have persisted; a lagging disk under CI load panics the
+# read-back with "file not found" (observed on the rio-v2 leg of a
+# nextest-config-only PR; same all-disk-materialization assumption as the
+# relocated-pool fixture fixed by #6707).
+[[profile.ci.overrides]]
+filter = 'package(rustfs-ecstore) & test(object_transaction_fencing_persists_epoch_on_multipart_commit)'
 retries = 2
 
 # Serialize the 4-disk reliability / degraded-read e2e tests under the ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,7 +497,10 @@ jobs:
           # job's 90-minute budget before any test starts.
           CARGO_BUILD_JOBS: "2"
         run: |
-          cargo nextest run -p rustfs -p rustfs-ecstore --features rio-v2
+          # --profile ci so the quarantine list (and its junit flaky markers)
+          # covers this leg too; the default profile is the local no-retry
+          # profile and silently ignored quarantined flakes here (rustfs#6703).
+          cargo nextest run --profile ci -p rustfs -p rustfs-ecstore --features rio-v2
           cargo test -p rustfs --doc --features rio-v2
 
   connect-short-credential-boundary:
@@ -607,7 +610,10 @@ jobs:
           # main nextest lane; Clippy is metadata-only and needs no such limit.
           CARGO_BUILD_JOBS: "2"
         run: |
-          cargo nextest run -p rustfs -p rustfs-protocols ${{ matrix.features.flags }}
+          # --profile ci so the quarantine list (and its junit flaky markers)
+          # covers this leg too; the default profile is the local no-retry
+          # profile and silently ignored quarantined flakes here (rustfs#6703).
+          cargo nextest run --profile ci -p rustfs -p rustfs-protocols ${{ matrix.features.flags }}
 
   build-rustfs-debug-binary:
     name: Build RustFS Debug Binary


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues
rustfs#6711 (new quarantine entry); retires the entry for rustfs#6701 / duplicate rustfs#6703, fixed by #6707

## Summary of Changes
Three related flake-policy repairs surfaced by #6704's first CI run:

- **The quarantine machinery never protected the legs where flakes strike.** The protocol (swift/sftp) and rio-v2 jobs invoked `cargo nextest run` without `--profile ci`, so they ran the **default** profile — by policy the local no-retry profile — and every `[[profile.ci.overrides]]` quarantine entry was silently ignored there. That is exactly why the relocated-pool flake reddened #6700 and #6704 on those legs while carrying a correct quarantine entry (verified with an isolated nextest 0.9.138 reproduction: the same config + entry retries as configured once `--profile ci` is passed). Both legs now pass `--profile ci`, which also extends the JUnit `flaky` markers — the observable the flake policy is built around — to these legs. The large-stack setup scripts exist identically in both profiles, so test environments do not change; the legs inherit `fail-fast = false` like the main lane.
- **Retire the relocated-pool quarantine.** #6707 fixed that fixture for real (staging now tolerates quorum-tolerated disk gaps), so per the policy the entry must not outlive the fix; it drops back to the serialization-only override it had before #6704 (the 8-disk cross-disk-IO `ecstore-serial-flaky` grouping is orthogonal to the flake and stays).
- **Quarantine the multipart fencing epoch read-back** (`set_disk::ops::multipart::tests::object_transaction_fencing_persists_epoch_on_multipart_commit`, rustfs#6711): its `object_transaction_epochs` helper reads `xl.meta` back from every disk and panics if any single disk has not persisted, but a multipart commit only guarantees write quorum — the same all-disk-materialization assumption class as the fixture #6707 just fixed. Observed failing on the rio-v2 leg of #6704's first run (a nextest-config-only diff that cannot affect it). `retries = 2` under the ci profile, linked to the OPEN issue.

## Verification
- Isolated reproduction workspace (stub packages mirroring the referenced package/binary names, this repo's exact `.config/nextest.toml`, cargo-nextest 0.9.138 — the CI version): with the previous config and no `--profile ci`, a forced failure of the relocated-pool test gets zero retries (the observed CI behaviour); with `--profile ci` it retries exactly as configured; with this PR's config the retired entry no longer retries and the file parses with exactly one override per test carrying the intended settings
- `actionlint .github/workflows/ci.yml` — clean
- `python3 tomllib` parse asserting the final override shapes

## Impact
CI-only. The swift/sftp and rio-v2 legs gain quarantine retries, JUnit flaky markers, and `fail-fast = false` (they now complete the suite on a failure instead of stopping early — same trade the main lane already makes). No test code or production code changes.

## Additional Notes
rustfs#6703 (duplicate of rustfs#6701) stays open until this PR lands so the currently-merged quarantine entry never references a closed issue; it will be closed as a duplicate referencing #6707 once this merges.
