### PR TITLE
fix(test): wait for EC materialization in relocated-pool resume fixture

### DIFF
--- a/rustfs/src/app/object/get.rs
+++ b/rustfs/src/app/object/get.rs
@@ -7023,6 +7023,29 @@ mod tests {
         body
     }
 
+    // An erasure-coded write returns once write-quorum disks commit, so a
+    // lagging disk can legally still be missing its xl.meta when the write
+    // call returns. Fixtures that iterate every disk of the owning pool must
+    // wait for full materialization first, or they race the trailing disk
+    // writes under CI load (issue #6703). Bounded so a genuinely failed disk
+    // write still surfaces as a test failure instead of a hang.
+    async fn wait_for_object_on_every_disk(disk_paths: &[std::path::PathBuf], bucket: &str, object: &str) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            if disk_paths
+                .iter()
+                .all(|path| path.join(bucket).join(object).join("xl.meta").is_file())
+            {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "object {bucket}/{object} must materialize xl.meta on every pool disk within the readiness window"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+    }
+
     // Deletes the given part files from every version data dir present on the
     // disks, simulating rebalance removing the object data while xl.meta stays
     // readable. Returns the number of version dirs visited and files removed.
@@ -7172,6 +7195,7 @@ mod tests {
                     .any(|path| path.join(&bucket).join(object).join("xl.meta").is_file())
             })
             .expect("multipart object must be placed in one source pool");
+        wait_for_object_on_every_disk(&pool_disk_paths[upload_pool], &bucket, object).await;
         if upload_pool != 0 {
             for (source_disk, target_disk) in pool_disk_paths[upload_pool].iter().zip(&pool_disk_paths[0]) {
                 let source_object = source_disk.join(&bucket).join(object);


### PR DESCRIPTION
## Related Issues

Fixes #6703.

## Summary of Changes

`app::object::get::tests::execute_get_object_resumes_from_relocated_pool_without_splicing_body` stages its relocated-object fixture by iterating every disk of the source pool and copying `xl.meta` plus the data directories. An erasure-coded write only guarantees write-quorum at return, so under CI load a lagging disk can legally still be missing its `xl.meta` when the staging loop reaches it, panicking the fixture with `NotFound` (observed on the `Test and Lint (sftp)` leg of run 33025470517).

This change adds a bounded readiness poll (`wait_for_object_on_every_disk`, 30 s deadline, 25 ms interval) that waits for `xl.meta` to exist on every disk of the owning pool before the pool-normalization rename and the staging loop run. The poll is bounded so a genuinely failed disk write still surfaces as a test failure instead of a hang. Production code is untouched; the diff is test-only.

Note for the open PR #6700: its `.config/nextest.toml` quarantine entry (`retries = 2`) for this test links this issue and can be dropped on rebase once this fix merges.

## Verification

- `cargo nextest run -p rustfs -E 'test(execute_get_object_resumes_from_relocated_pool_without_splicing_body)'` — 11 consecutive runs, all PASS.
- `cargo nextest run -p rustfs -E 'test(get_object_resume) + test(execute_get_object_resume)'` — all 8 resume-family tests PASS.
- `cargo clippy -p rustfs --lib --tests` — clean.
- `cargo fmt --all -- --check` — clean.
- `scripts/check_layer_dependencies.sh`, `scripts/check_architecture_migration_rules.sh`, `scripts/check_logging_guardrails.sh` — pass.

## Impact

N/A — test-only change; no production behavior, API, or configuration impact.

## Additional Notes

The fix keeps the fixture's all-disk staging semantics (the later shard-deletion and source-metadata-removal steps rely on every disk holding the object) rather than downgrading to quorum-many staging, which would weaken the relocation scenario the test exercises.
