### PR TITLE
test: deflake config snapshot, presigned tamper, and pool resume tests

### DIFF
--- a/crates/e2e_test/src/presigned_negative_test.rs
+++ b/crates/e2e_test/src/presigned_negative_test.rs
@@ -87,7 +87,9 @@ fn valid_config() -> PresigningConfig {
 }
 
 /// Flip bytes inside the `X-Amz-Signature=` query value without changing its
-/// length, producing a structurally valid but incorrect signature.
+/// length, producing a structurally valid but incorrect signature. Every hex
+/// digit is replaced by its complement (15 - v), which has no fixed point, so
+/// the tamper changes the value no matter which digits the signature contains.
 fn tamper_signature(uri: &str) -> String {
     let marker = "X-Amz-Signature=";
     let idx = uri.find(marker).expect("presigned uri must carry X-Amz-Signature") + marker.len();
@@ -96,10 +98,9 @@ fn tamper_signature(uri: &str) -> String {
     let (sig, tail) = rest.split_at(end);
     let tampered: String = sig
         .chars()
-        .map(|c| match c {
-            '0' => 'f',
-            'a' => '0',
-            other => other,
+        .map(|c| {
+            let v = c.to_digit(16).expect("X-Amz-Signature value must be hex");
+            char::from_digit(15 - v, 16).expect("complement of a hex digit is a hex digit")
         })
         .collect();
     assert_ne!(sig, tampered, "tamper must actually change the signature hex");

--- a/crates/ecstore/src/config/com.rs
+++ b/crates/ecstore/src/config/com.rs
@@ -5220,7 +5220,7 @@ mod tests {
     #[tokio::test]
     async fn server_config_snapshot_serializes_read_modify_write_transactions() {
         let baseline = encode_server_config_blob(&Config::new(), None).expect("baseline config should encode");
-        let store = Arc::new(RecoveryMockStore::new(RecoveryReadState::Blob(baseline), None));
+        let store = Arc::new(RecoveryMockStore::new(RecoveryReadState::Blob(baseline.clone()), None));
         let first = read_server_config_snapshot(store.clone())
             .await
             .expect("first config snapshot");
@@ -5234,7 +5234,11 @@ mod tests {
             .await
             .expect("second transaction should acquire after the first snapshot is dropped")
             .expect("second config snapshot");
-        assert!(configs_semantically_equal(&second.config, &Config::new()));
+        // Compare raw bytes against the baseline blob rather than a fresh
+        // Config::new(): the process-global DEFAULT_KVS can be registered by a
+        // sibling test mid-run, which would make a Config::new() evaluated here
+        // diverge from the baseline encoded above.
+        assert_eq!(second.raw.as_deref(), Some(baseline.as_slice()));
     }
 
     #[tokio::test]

--- a/rustfs/src/app/object/get.rs
+++ b/rustfs/src/app/object/get.rs
@@ -7218,6 +7218,12 @@ mod tests {
         let mut staged_targets = Vec::with_capacity(pool_disk_paths[target_pool].len());
         for (source_disk, target_disk) in pool_disk_paths[source_pool].iter().zip(&pool_disk_paths[target_pool]) {
             let source_dir = source_disk.join(&bucket).join(object);
+            // The same write-quorum minority gap tolerated above (#6701) can
+            // leave a lagging source-pool disk without the object; skip it and
+            // stage the replicas that exist — the reader tolerates the gap.
+            if !source_dir.join("xl.meta").is_file() {
+                continue;
+            }
             let target_dir = target_disk.join(&bucket).join(object);
             let staging_dir = temp_dir.path().join(format!("resume-relocate-{}", Uuid::new_v4()));
             std::fs::create_dir_all(&staging_dir).expect("create relocated target staging directory");
@@ -7234,15 +7240,18 @@ mod tests {
                 }
             }
             std::fs::copy(source_dir.join("xl.meta"), staging_dir.join("xl.meta")).expect("stage relocated object metadata");
-            staged_targets.push((staging_dir, target_dir));
+            staged_targets.push((staging_dir, target_dir, source_dir.join("xl.meta")));
         }
+        assert!(
+            staged_targets.len() > pool_disk_paths[source_pool].len() / 2,
+            "a write-quorum majority of the source pool's disks must hold the object to stage the relocation"
+        );
         let (version_dirs, deleted) = delete_object_part_shards(&pool_disk_paths[source_pool], &bucket, object, &[2, 3]);
         assert!(version_dirs > 0, "the source pool must have at least one version data directory");
         assert_eq!(deleted, version_dirs * 2);
 
-        for ((staging_dir, target_dir), source_disk) in staged_targets.into_iter().zip(&pool_disk_paths[source_pool]) {
+        for (staging_dir, target_dir, source_meta) in staged_targets {
             std::fs::rename(staging_dir, target_dir).expect("publish relocated target object");
-            let source_meta = source_disk.join(&bucket).join(object).join("xl.meta");
             std::fs::remove_file(source_meta).expect("remove relocated source object metadata");
         }
         store


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Three test-robustness fixes, no production code paths touched.

**1. Order-dependent server config snapshot test (`crates/ecstore/src/config/com.rs`).** `config::com::tests::server_config_snapshot_serializes_read_modify_write_transactions` compared the second snapshot against a fresh `Config::new()`, but `Config::new()` reads the process-global `DEFAULT_KVS` `OnceLock`, which a sibling test in the same process can register mid-run via `crate::config::init()`. Under `cargo test` (shared process, parallel threads) the baseline blob is encoded before registration while the closing `Config::new()` evaluates after it, so the semantic comparison failed deterministically; nextest's process-per-test isolation hid the coupling. The test now asserts the second snapshot's `raw` bytes equal the baseline blob, which is deterministic regardless of registration timing and matches the invariant under test: the second serialized transaction observes the store unchanged by the first. Pinning defaults with `crate::config::init()` at test start was tried and rejected because it flips `valid_heal_object_and_kvs_array_shapes_remain_accepted`, which latently depends on defaults being unregistered; that pre-existing coupling is tracked separately.

**2. Presigned tamper helper flake (`crates/e2e_test/src/presigned_negative_test.rs`).** `tamper_signature` only remapped `'0'` and `'a'`, so a signature containing neither character (~1 in 5000) left the URI unchanged and tripped the helper's own guard assert — this hit the E2E smoke lane on this PR's first CI run. Every hex digit is now replaced by its complement (`15 - v`), a map with no fixed point, so the tamper always changes the value while preserving length and hex shape.

**3. Relocated-pool resume staging flake (`rustfs/src/app/object/get.rs`).** `execute_get_object_resumes_from_relocated_pool_without_splicing_body` staged the relocation by reading `xl.meta` from every source-pool disk, but a write-quorum commit legitimately leaves a lagging minority disk without the object directory (#6701) — the test already tolerates that gap when normalizing the upload pool, and CI suite IO load hit the same gap in the staging loop on this PR's first run. The staging loop now skips sourceless disks, carries each staged metadata path explicitly instead of re-zipping positionally, and asserts a write-quorum majority was staged.

## Verification
- `cargo test -p rustfs-ecstore --lib config::` — 114 passed (previously failed deterministically on the snapshot test; re-run three times)
- `cargo nextest run -p rustfs-ecstore -E 'test(/config::/)'` — 114 passed
- `cargo nextest run -p rustfs --lib -E 'test(execute_get_object_resumes_from_relocated_pool_without_splicing_body)'` — 1 passed
- `cargo check -p e2e_test` — clean; the tamper complement is guarded by the helper's existing `assert_ne!`
- `cargo fmt --all -- --check` — clean
- `make pre-commit` — passes through all guards; the final `test-wiring-check` step aborts locally only because the host default Python lacks `tomllib` (<3.11); `scripts/check_test_wiring.py` run under Python 3.12 reports OK

## Impact
Test-only change; no production code paths affected.

## Additional Notes
Sibling tests in `com.rs` retain latent `DEFAULT_KVS` order-dependence (the heal decode test asserting `is_none`, and two other comparisons against fresh `Config::new()` around `com.rs:4749` and `com.rs:5367`); they currently pass by scheduling luck and are tracked as a separate follow-up task rather than bundled here.
