### PR TITLE
test: fall back to writable temp files for logs/status in /tmp

### DIFF
--- a/.github/workflows/rustfs-heal-test.yml
+++ b/.github/workflows/rustfs-heal-test.yml
@@ -109,7 +109,7 @@ jobs:
         with:
           name: rustfs-heal-test-${{ github.run_id }}
           path: |
-            /tmp/rustfs-heal-test.log
+            /tmp/rustfs-heal-test*.log
             /tmp/rustfs-warp.*.log
           if-no-files-found: warn
 

--- a/.github/workflows/rustfs-pool-expand-test.yml
+++ b/.github/workflows/rustfs-pool-expand-test.yml
@@ -154,7 +154,7 @@ jobs:
         with:
           name: rustfs-pool-test-${{ github.run_id }}
           path: |
-            /tmp/rustfs-pool-test.log
+            /tmp/rustfs-pool-test*.log
             /tmp/rustfs-warp.*.log
           if-no-files-found: warn
 

--- a/scripts/test/rustfs_heal_test.sh
+++ b/scripts/test/rustfs_heal_test.sh
@@ -900,7 +900,11 @@ step6_monitor_heal() {
     if printf '%s' "${summary}" | grep -qiE '^(finished|completed|success|done)$' \
       && [ "${vm002_used}" -ge "${HEAL_TARGET_GB}" ]; then
       log "heal done: summary=${summary} failed=0 ${NODES[${OUTAGE_NODE_INDEX}]}_used=${vm002_used}GB >= ${HEAL_TARGET_GB}GB"
-      printf '%s\n' "${body}" > "${TMPDIR:-/tmp}/rustfs-heal-final-status.json"
+      final_status_file="$(mktemp "${TMPDIR:-/tmp}/rustfs-heal-final-status.XXXXXX.json" 2>/dev/null \
+        || printf '%s' "${TMPDIR:-/tmp}/rustfs-heal-final-status.$$.json")"
+      printf '%s\n' "${body}" > "${final_status_file}" 2>/dev/null \
+        && log "final heal status saved: ${final_status_file}" \
+        || warn "could not save final heal status to ${final_status_file}"
       return 0
     fi
     sleep "${POLL_INTERVAL}"
@@ -1068,6 +1072,12 @@ main() {
   trap 'rm -f "${ADMIN_API_CODE_FILE}"' EXIT
   if [ -n "${LOG_FILE}" ]; then
     mkdir -p "$(dirname "${LOG_FILE}")"
+    if ! touch "${LOG_FILE}" 2>/dev/null; then
+      # A fixed /tmp path may be owned by another user (e.g. a previous root
+      # run); fall back to a unique, always-writable temp file.
+      LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/rustfs-heal-test.XXXXXX.log")"
+      warn "log file not writable; using ${LOG_FILE}"
+    fi
     exec > >(tee -a "${LOG_FILE}") 2>&1
   fi
   if [ "${RESET}" -eq 1 ]; then

--- a/scripts/test/rustfs_pool_expand.sh
+++ b/scripts/test/rustfs_pool_expand.sh
@@ -1128,6 +1128,12 @@ main() {
   trap 'rm -f "${ADMIN_API_CODE_FILE}"' EXIT
   if [ -n "${LOG_FILE}" ]; then
     mkdir -p "$(dirname "${LOG_FILE}")"
+    if ! touch "${LOG_FILE}" 2>/dev/null; then
+      # A fixed /tmp path may be owned by another user (e.g. a previous root
+      # run); fall back to a unique, always-writable temp file.
+      LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/rustfs-pool-test.XXXXXX.log")"
+      warn "log file not writable; using ${LOG_FILE}"
+    fi
     exec > >(tee -a "${LOG_FILE}") 2>&1
   fi
   if [ "${RESET}" -eq 1 ]; then


### PR DESCRIPTION
On the shared runner, fixed `/tmp` paths (test log, final heal status, warp log) can be owned by another user — e.g. files left by an earlier root-driven run — which breaks the `github-runner` user:

- `tee -a /tmp/rustfs-heal-test.log` → `Permission denied` (log artifact silently stale).
- Step 6's final status save `> /tmp/rustfs-heal-final-status.json` → `EACCES`, killed the step with exit 1 **after** the heal had actually passed (`summary=finished`, outage node at the target).
- `upload-artifact` failed with `EACCES` reading stale root-owned `/tmp/rustfs-warp.*.log`.

Fixes:

- Both scripts fall back to a unique `mktemp` log path when the configured `--log-file` is not writable.
- The final heal status JSON is written to a `mktemp` file, best effort.
- Workflow artifact uploads use globs (`/tmp/rustfs-heal-test*.log`, `/tmp/rustfs-pool-test*.log`, `/tmp/rustfs-warp.*.log`).