### PR TITLE
ci: use dedicated RUSTFS_PERF_NODES for performance test

### DIFF
--- a/.github/workflows/rustfs-performance-test.yml
+++ b/.github/workflows/rustfs-performance-test.yml
@@ -69,7 +69,9 @@ defaults:
 env:
   RUSTFS_ACCESS_KEY: ${{ secrets.RUSTFS_ACCESS_KEY }}
   RUSTFS_SECRET_KEY: ${{ secrets.RUSTFS_SECRET_KEY }}
-  RUSTFS_NODES: ${{ secrets.RUSTFS_NODES || vars.RUSTFS_NODES }}
+  # Performance test uses its own node list (4 nodes); the shared
+  # RUSTFS_NODES secret is used by the 3-node pool-expansion / heal tests.
+  RUSTFS_NODES: ${{ secrets.RUSTFS_PERF_NODES || vars.RUSTFS_PERF_NODES || 'vm000 vm001 vm002 vm003' }}
   RUSTFS_SSH_USER: ${{ secrets.RUSTFS_SSH_USER || vars.RUSTFS_SSH_USER }}
   # Package used by the nightly run (workflow_dispatch inputs are empty for
   # workflow_run events), i.e. the latest nightly deb published by nightly-gnu.yml.


### PR DESCRIPTION
## Problem

The performance-test workflow reused the shared `RUSTFS_NODES` secret/variable that the 3-node pool-expansion and heal tests use. The performance test needs 4 nodes (`vm000 vm001 vm002 vm003`), so a single shared value cannot serve both.

## Fix

The performance workflow now reads a dedicated `RUSTFS_PERF_NODES` secret/variable and falls back to the 4-node default:

```yaml
RUSTFS_NODES: ${{ secrets.RUSTFS_PERF_NODES || vars.RUSTFS_PERF_NODES || 'vm000 vm001 vm002 vm003' }}
```

Pool-expansion / heal workflows are untouched and keep using the shared `RUSTFS_NODES`.

## Action needed

Optionally add `RUSTFS_PERF_NODES` (secret or repo variable) if the 4-node list differs from the default.