### PR TITLE
refactor(s3-client): reuse rustfs-utils header classification instead of duplicating it

### DIFF
--- a/crates/s3-client/src/api_put_object.rs
+++ b/crates/s3-client/src/api_put_object.rs
@@ -24,6 +24,7 @@ use std::{collections::HashMap, sync::Arc};
 use time::{Duration, OffsetDateTime, macros::format_description};
 use tracing::{error, info, warn};
 
+use rustfs_utils::http::{is_amz_header, is_minio_header, is_rustfs_header, is_standard_header, is_storageclass_header};
 use s3s::dto::{ObjectLockLegalHoldStatus, ObjectLockRetentionMode, ReplicationStatus};
 use s3s::header::{
     X_AMZ_OBJECT_LOCK_LEGAL_HOLD, X_AMZ_OBJECT_LOCK_MODE, X_AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE, X_AMZ_REPLICATION_STATUS,
@@ -40,7 +41,6 @@ use crate::{
     constants::{ISO8601_DATEFORMAT, MAX_MULTIPART_PUT_OBJECT_SIZE, MIN_PART_SIZE},
     credentials::SignatureType,
     transition_api::{ReaderImpl, TransitionClient, UploadInfo},
-    utils::{is_amz_header, is_minio_header, is_rustfs_header, is_standard_header, is_storageclass_header},
 };
 
 #[derive(Debug, Clone)]

--- a/crates/s3-client/src/utils.rs
+++ b/crates/s3-client/src/utils.rs
@@ -12,67 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use lazy_static::lazy_static;
-use std::collections::HashMap;
-
-use s3s::header::X_AMZ_STORAGE_CLASS;
-
-lazy_static! {
-    static ref SUPPORTED_QUERY_VALUES: HashMap<String, bool> = {
-        let mut m = HashMap::new();
-        m.insert("attributes".to_string(), true);
-        m.insert("partNumber".to_string(), true);
-        m.insert("versionId".to_string(), true);
-        m.insert("response-cache-control".to_string(), true);
-        m.insert("response-content-disposition".to_string(), true);
-        m.insert("response-content-encoding".to_string(), true);
-        m.insert("response-content-language".to_string(), true);
-        m.insert("response-content-type".to_string(), true);
-        m.insert("response-expires".to_string(), true);
-        m
-    };
-    static ref SUPPORTED_HEADERS: HashMap<String, bool> = {
-        let mut m = HashMap::new();
-        m.insert("content-type".to_string(), true);
-        m.insert("cache-control".to_string(), true);
-        m.insert("content-encoding".to_string(), true);
-        m.insert("content-disposition".to_string(), true);
-        m.insert("content-language".to_string(), true);
-        m.insert("x-amz-website-redirect-location".to_string(), true);
-        m.insert("x-amz-object-lock-mode".to_string(), true);
-        m.insert("x-amz-metadata-directive".to_string(), true);
-        m.insert("x-amz-object-lock-retain-until-date".to_string(), true);
-        m.insert("expires".to_string(), true);
-        m.insert("x-amz-replication-status".to_string(), true);
-        m
-    };
-}
-
-pub fn is_storageclass_header(header_key: &str) -> bool {
-    header_key.to_lowercase() == X_AMZ_STORAGE_CLASS.as_str().to_lowercase()
-}
-
-pub fn is_standard_header(header_key: &str) -> bool {
-    *SUPPORTED_HEADERS.get(&header_key.to_lowercase()).unwrap_or(&false)
-}
-
-pub fn is_amz_header(header_key: &str) -> bool {
-    let key = header_key.to_lowercase();
-    key.starts_with("x-amz-meta-")
-        || key.starts_with("x-amz-grant-")
-        || key == "x-amz-acl"
-        || rustfs_utils::http::is_sse_header(header_key)
-        || key.starts_with("x-amz-checksum-")
-}
-
-pub fn is_rustfs_header(header_key: &str) -> bool {
-    header_key.to_lowercase().starts_with("x-rustfs-")
-}
-
-pub fn is_minio_header(header_key: &str) -> bool {
-    header_key.to_lowercase().starts_with("x-minio-")
-}
-
 /// Standard base64 (with `+`/`/` and `=` padding). Every base64 value this
 /// transition client emits or parses — `Content-MD5`, `x-amz-checksum-*`, and
 /// checksum digests in request/response bodies — is S3 wire format, which is


### PR DESCRIPTION
## What

`crates/s3-client/src/utils.rs` duplicated the entire header-classification table and helper functions (`SUPPORTED_HEADERS`, `SUPPORTED_QUERY_VALUES`, `is_standard_header`, `is_storageclass_header`, `is_amz_header`, `is_rustfs_header`, `is_minio_header`) from `crates/utils/src/http/headers.rs`, even though `crates/s3-client` already depends on `rustfs-utils` with the `full` feature — and one of the duplicated functions (`is_amz_header`) already called into `rustfs_utils::http` internally, i.e. half the file used the local copy and half used the canonical one.

This switches `crates/s3-client/src/api_put_object.rs` to import the five classification functions directly from `rustfs_utils::http` and deletes the local duplicates. `SUPPORTED_QUERY_VALUES` had no reader anywhere in `crates/s3-client` and is deleted outright (no forwarding shim added). `base64_encode`/`base64_decode` and their regression tests (rustfs#4811) are untouched.

## Verification

- `cargo fmt --all --check` — pass
- `cargo test -p rustfs-s3-client` — 45 passed, 0 failed
- `cargo clippy -p rustfs-s3-client --all-targets -- -D warnings` — 0 warnings
- Combined `cargo check --workspace --all-targets` together with the other 6 backlog#2039 wave-0 PRs — clean

## Adversarial self-check (correctness / simplicity / compatibility)

- Confirmed the five functions are actually `pub` and re-exported from `crates/utils/src/http/mod.rs`, and that `crates/s3-client/Cargo.toml` already enables the `full` feature — clippy compiling clean is constructive proof.
- Diffed the pre-switch `SUPPORTED_HEADERS` key set (11 keys) against `crates/utils`'s table sorted — identical, no key silently moved to a different table.
- Confirmed `s3s::header::X_AMZ_STORAGE_CLASS` and `rustfs_utils::http::AMZ_STORAGE_CLASS` are both `"x-amz-storage-class"` (both further lowercased before comparison, so no drift possible).
- Grepped the whole repo for any other consumer of `s3_client::utils::is_*` — none found outside `api_put_object.rs`.

Net effect: `api_put_object.rs:246`'s header-passthrough decision returns identical results for every header key before and after this change.

Refs rustfs/backlog#2050
