### PR TITLE
chore(tier): remove dead trailing_headers config from warm backends

### DIFF
--- a/crates/ecstore/src/services/tier/warm_backend_aliyun.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_aliyun.rs
@@ -68,7 +68,6 @@ impl WarmBackendAliyun {
         let opts = Options {
             creds,
             secure: u.scheme() == "https",
-            trailing_headers: true,
             region: conf.region.clone(),
             bucket_lookup: BucketLookupType::BucketLookupDNS,
             ..Default::default()

--- a/crates/ecstore/src/services/tier/warm_backend_azure.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_azure.rs
@@ -68,7 +68,6 @@ impl WarmBackendAzure {
         let opts = Options {
             creds,
             secure: u.scheme() == "https",
-            trailing_headers: true,
             region: conf.region.clone(),
             bucket_lookup: BucketLookupType::BucketLookupDNS,
             ..Default::default()

--- a/crates/ecstore/src/services/tier/warm_backend_huaweicloud.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_huaweicloud.rs
@@ -68,7 +68,6 @@ impl WarmBackendHuaweicloud {
         let opts = Options {
             creds,
             secure: u.scheme() == "https",
-            trailing_headers: true,
             region: conf.region.clone(),
             bucket_lookup: BucketLookupType::BucketLookupDNS,
             ..Default::default()

--- a/crates/ecstore/src/services/tier/warm_backend_minio.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_minio.rs
@@ -68,7 +68,6 @@ impl WarmBackendMinIO {
         let opts = Options {
             creds,
             secure: u.scheme() == "https",
-            trailing_headers: true,
             region: conf.region.clone(),
             ..Default::default()
         };

--- a/crates/ecstore/src/services/tier/warm_backend_r2.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_r2.rs
@@ -68,7 +68,6 @@ impl WarmBackendR2 {
         let opts = Options {
             creds,
             secure: u.scheme() == "https",
-            trailing_headers: true,
             region: conf.region.clone(),
             ..Default::default()
         };

--- a/crates/ecstore/src/services/tier/warm_backend_rustfs.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_rustfs.rs
@@ -65,7 +65,6 @@ impl WarmBackendRustFS {
         let opts = Options {
             creds,
             secure: u.scheme() == "https",
-            trailing_headers: true,
             region: conf.region.clone(),
             ..Default::default()
         };

--- a/crates/ecstore/src/services/tier/warm_backend_tencent.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_tencent.rs
@@ -68,7 +68,6 @@ impl WarmBackendTencent {
         let opts = Options {
             creds,
             secure: u.scheme() == "https",
-            trailing_headers: true,
             region: conf.region.clone(),
             bucket_lookup: BucketLookupType::BucketLookupDNS,
             ..Default::default()


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues
N/A. Found during adversarial self-check while implementing rustfs/backlog#2040 (out of that issue's scope); triaged and cleaned up directly per repo convention for benign dead code.

## Summary of Changes
`TransitionClient::private_new` in [crates/s3-client/src/transition_api.rs](crates/s3-client/src/transition_api.rs) computes `trailing_header_support = opts.trailing_headers && client.override_signer_type == SignatureType::SignatureV4`, but `override_signer_type` is hardcoded to `SignatureType::SignatureDefault` a few lines earlier and is never mutated afterwards anywhere in the codebase (no setter, no other assignment site), so this expression is always `false` regardless of what `opts.trailing_headers` is. The resulting `trailing_header_support` field also has no live reader: its only reference is inside `PutObjectOptions::validate()` in [crates/s3-client/src/api_put_object.rs](crates/s3-client/src/api_put_object.rs), which is itself annotated `#[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]`, and even there the reference to `trailing_header_support` is commented out. Actual chunked/streaming-signature behavior is gated separately by `metadata.stream_sha256 && !self.secure`, independent of this flag. So `trailing_headers: true` in the seven `warm_backend_*.rs` provider constructors (aliyun/azure/huaweicloud/tencent/minio/r2/rustfs) has never had any effect on request signing. This PR removes the misleading dead configuration from those seven call sites so it does not read as intentional, load-bearing behavior to future readers. No functional/behavioral change; `Options::trailing_headers` already defaults to `false` via `..Default::default()`.

## Verification
- `cargo fmt --all`
- `cargo check -p rustfs-ecstore`
- `make pre-commit` (fmt + arch guards + quick-check) — passed

## Impact
None. Purely removes dead configuration with no observable effect (see Summary); no signing, chunked-upload, or tiering behavior changes for any warm-tier provider.

## Additional Notes
N/A
