### PR TITLE
fix(deps): move off the yanked chacha20 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,9 +1939,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cipher 0.5.2",
@@ -12174,7 +12174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",


### PR DESCRIPTION
## Related Issues

N/A — unblocks the Cargo Deny gate repo-wide.

## Summary of Changes

chacha20 0.10.1 was yanked on crates.io today, so the Cargo Deny job now fails with error[yanked] on every branch (first seen on #6767; main last passed 14:55 UTC before the yank). This is the fix cargo-deny itself suggests: `cargo update -p chacha20`, moving 0.10.1 -> 0.10.2. Lockfile-only, semver-compatible, no API change; chacha20 reaches us via chacha20poly1305 in rustfs-crypto.

## Verification

- `cargo check -p rustfs-crypto` — clean
- The Cargo Deny job on this PR is the authoritative gate for the yank error

## Impact

Dependency lockfile only. Every open PR keeps failing Cargo Deny until this merges and they rebase.

## Additional Notes

N/A
