### PR TITLE
fix(startup): never panic when the system CA bundle is absent

### DIFF
--- a/crates/ecstore/src/bucket/bucket_target_sys.rs
+++ b/crates/ecstore/src/bucket/bucket_target_sys.rs
@@ -352,6 +352,28 @@ pub struct BucketTargetSys {
     heartbeat_started: OnceLock<()>,
 }
 
+/// Build the bucket-target health-check HTTP client without panicking when
+/// the host has no system CA bundle (issue #6734).
+///
+/// `BucketTargetSys::get()` initializes lazily on the startup path (bucket
+/// metadata install calls it on the main thread), and `reqwest::Client::new()`
+/// panics when the TLS backend cannot load any system trust root — the state
+/// of a minimal container image. Fall back to a client with an explicit empty
+/// trust store: HTTP health checks keep working, and HTTPS targets fail closed
+/// at the TLS handshake with a clear certificate error instead of aborting
+/// the whole process at startup.
+fn build_health_check_client() -> HttpClient {
+    HttpClient::builder().build().unwrap_or_else(|error| {
+        warn!(
+            "bucket target health-check HTTP client could not load system TLS roots ({error}); continuing with an empty trust store — HTTPS target health checks will fail until a CA bundle is installed"
+        );
+        HttpClient::builder()
+            .tls_certs_only(std::iter::empty::<reqwest::Certificate>())
+            .build()
+            .expect("HTTP client construction must succeed with an explicit empty trust store")
+    })
+}
+
 impl BucketTargetSys {
     pub fn get() -> &'static Self {
         GLOBAL_BUCKET_TARGET_SYS.get_or_init(Self::new)
@@ -364,7 +386,7 @@ impl BucketTargetSys {
             targets_map: Arc::new(RwLock::new(HashMap::new())),
             h_mutex: Arc::new(RwLock::new(HashMap::new())),
             target_h_mutex: Arc::new(RwLock::new(HashMap::new())),
-            hc_client: Arc::new(HttpClient::new()),
+            hc_client: Arc::new(build_health_check_client()),
             a_mutex: Arc::new(Mutex::new(HashMap::new())),
             arn_errs_map: Arc::new(RwLock::new(HashMap::new())),
             target_update_mutexes: Arc::new(Mutex::new(HashMap::new())),
@@ -2489,6 +2511,18 @@ impl Error for BucketTargetError {}
 mod tests {
     use super::*;
     use rcgen::generate_simple_self_signed;
+
+    // The startup panic fix for hosts without a CA bundle (issue #6734) rests
+    // on two properties: the health-check client constructor never panics, and
+    // its degraded fallback — an explicit empty trust store — always builds.
+    #[test]
+    fn health_check_client_construction_never_panics() {
+        let _ = build_health_check_client();
+        HttpClient::builder()
+            .tls_certs_only(std::iter::empty::<reqwest::Certificate>())
+            .build()
+            .expect("empty-trust-store client build must succeed without touching system roots");
+    }
 
     #[derive(Clone, Debug)]
     struct RecordingHttpConnector {

--- a/crates/policy/src/policy/opa.rs
+++ b/crates/policy/src/policy/opa.rs
@@ -173,20 +173,28 @@ pub async fn lookup_config() -> Result<Args, OpaConfigError> {
 
 impl AuthZPlugin {
     pub fn new(config: Args) -> Self {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(5))
-            .connect_timeout(Duration::from_secs(1))
-            .pool_max_idle_per_host(10)
-            .pool_idle_timeout(Some(Duration::from_secs(60)))
-            .tcp_keepalive(Some(Duration::from_secs(30)))
-            .tcp_nodelay(true)
-            .http2_keep_alive_interval(Some(Duration::from_secs(30)))
-            .http2_keep_alive_timeout(Duration::from_secs(15))
-            .build()
-            .unwrap_or_else(|err| {
-                error!("failed to build OPA HTTP client, falling back to default reqwest client: {err}");
-                reqwest::Client::new()
-            });
+        let builder = || {
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(5))
+                .connect_timeout(Duration::from_secs(1))
+                .pool_max_idle_per_host(10)
+                .pool_idle_timeout(Some(Duration::from_secs(60)))
+                .tcp_keepalive(Some(Duration::from_secs(30)))
+                .tcp_nodelay(true)
+                .http2_keep_alive_interval(Some(Duration::from_secs(30)))
+                .http2_keep_alive_timeout(Duration::from_secs(15))
+        };
+        // Never fall back to `reqwest::Client::new()`: it panics for the same
+        // reason the first build failed (e.g. no system CA bundle, issue
+        // #6734). Retry with an explicit empty trust store instead — an HTTP
+        // OPA endpoint keeps working, an HTTPS one fails closed per request.
+        let client = builder().build().unwrap_or_else(|err| {
+            error!("failed to build OPA HTTP client ({err}); continuing with an empty trust store");
+            builder()
+                .tls_certs_only(std::iter::empty::<reqwest::Certificate>())
+                .build()
+                .expect("HTTP client construction must succeed with an explicit empty trust store")
+        });
 
         Self { client, args: config }
     }

--- a/crates/trusted-proxies/src/cloud/metadata/aws.rs
+++ b/crates/trusted-proxies/src/cloud/metadata/aws.rs
@@ -43,7 +43,7 @@ impl AwsMetadataFetcher {
     ///
     /// Returns a new instance of `AwsMetadataFetcher`.
     pub fn new(timeout: Duration) -> Self {
-        let client = Client::builder().timeout(timeout).build().unwrap_or_else(|_| Client::new());
+        let client = super::metadata_http_client(timeout);
 
         Self {
             client,

--- a/crates/trusted-proxies/src/cloud/metadata/azure.rs
+++ b/crates/trusted-proxies/src/cloud/metadata/azure.rs
@@ -34,7 +34,7 @@ pub struct AzureMetadataFetcher {
 impl AzureMetadataFetcher {
     /// Creates a new `AzureMetadataFetcher`.
     pub fn new(timeout: Duration) -> Self {
-        let client = Client::builder().timeout(timeout).build().unwrap_or_else(|_| Client::new());
+        let client = super::metadata_http_client(timeout);
 
         Self {
             client,

--- a/crates/trusted-proxies/src/cloud/metadata/gcp.rs
+++ b/crates/trusted-proxies/src/cloud/metadata/gcp.rs
@@ -34,7 +34,7 @@ pub struct GcpMetadataFetcher {
 impl GcpMetadataFetcher {
     /// Creates a new `GcpMetadataFetcher`.
     pub fn new(timeout: Duration) -> Self {
-        let client = Client::builder().timeout(timeout).build().unwrap_or_else(|_| Client::new());
+        let client = super::metadata_http_client(timeout);
 
         Self {
             client,

--- a/crates/trusted-proxies/src/cloud/metadata/mod.rs
+++ b/crates/trusted-proxies/src/cloud/metadata/mod.rs
@@ -24,3 +24,40 @@ mod gcp;
 pub use aws::*;
 pub use azure::*;
 pub use gcp::*;
+
+/// Build the metadata HTTP client without panicking when the host has no
+/// system CA bundle (issue #6734).
+///
+/// `reqwest::Client::new()` panics when the TLS backend cannot load any
+/// system trust root, which is exactly the state of a minimal container
+/// image. Cloud metadata endpoints are plain HTTP link-local addresses, so a
+/// client with an explicit empty trust store is fully functional here; TLS
+/// requests through it fail closed at the handshake.
+pub(crate) fn metadata_http_client(timeout: std::time::Duration) -> reqwest::Client {
+    reqwest::Client::builder().timeout(timeout).build().unwrap_or_else(|error| {
+        tracing::warn!(
+            "cloud metadata HTTP client could not load system TLS roots ({error}); continuing with an empty trust store"
+        );
+        reqwest::Client::builder()
+            .timeout(timeout)
+            .tls_certs_only(std::iter::empty::<reqwest::Certificate>())
+            .build()
+            .expect("HTTP client construction must succeed with an explicit empty trust store")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    // The startup panic fix for hosts without a CA bundle (issue #6734) rests
+    // on the constructor never panicking and its degraded fallback — an
+    // explicit empty trust store — always building.
+    #[test]
+    fn metadata_http_client_construction_never_panics() {
+        let _ = super::metadata_http_client(std::time::Duration::from_secs(1));
+        reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(1))
+            .tls_certs_only(std::iter::empty::<reqwest::Certificate>())
+            .build()
+            .expect("empty-trust-store client build must succeed without touching system roots");
+    }
+}

--- a/rustfs/src/update.rs
+++ b/rustfs/src/update.rs
@@ -16,7 +16,7 @@ use crate::version;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use thiserror::Error;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 /// Update check related errors
 #[derive(Error, Debug)]
@@ -73,17 +73,31 @@ impl Default for VersionChecker {
     }
 }
 
+/// Build the update-check HTTP client without panicking when the host has no
+/// system CA bundle (issue #6734): `reqwest::Client::new()` panics for the
+/// same reason a builder `build()` fails, so falling back to it turned a
+/// degraded environment into a process abort. With an explicit empty trust
+/// store the HTTPS version check fails closed per request instead.
+fn version_check_client(timeout: Duration) -> reqwest::Client {
+    let builder = || {
+        reqwest::Client::builder()
+            .timeout(timeout)
+            .user_agent(format!("RustFS/{}", get_current_version()))
+    };
+    builder().build().unwrap_or_else(|error| {
+        warn!("update-check HTTP client could not load system TLS roots ({error}); continuing with an empty trust store");
+        builder()
+            .tls_certs_only(std::iter::empty::<reqwest::Certificate>())
+            .build()
+            .expect("HTTP client construction must succeed with an explicit empty trust store")
+    })
+}
+
 impl VersionChecker {
     /// Create a new version checker
     pub fn new() -> Self {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
-            .user_agent(format!("RustFS/{}", get_current_version()))
-            .build()
-            .unwrap_or_else(|_| reqwest::Client::new());
-
         Self {
-            client,
+            client: version_check_client(Duration::from_secs(10)),
             version_url: "https://version.rustfs.com/latest.json".to_string(),
             timeout: Duration::from_secs(10),
         }
@@ -91,14 +105,8 @@ impl VersionChecker {
 
     /// Create version checker with custom configuration
     pub fn with_config(url: String, timeout: Duration) -> Self {
-        let client = reqwest::Client::builder()
-            .timeout(timeout)
-            .user_agent(format!("RustFS/{}", get_current_version()))
-            .build()
-            .unwrap_or_else(|_| reqwest::Client::new());
-
         Self {
-            client,
+            client: version_check_client(timeout),
             version_url: url,
             timeout,
         }
@@ -181,6 +189,18 @@ pub async fn check_updates_with_url(url: String) -> Result<UpdateCheckResult, Up
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // The startup panic fix for hosts without a CA bundle (issue #6734) rests
+    // on the constructor never panicking and its degraded fallback — an
+    // explicit empty trust store — always building.
+    #[test]
+    fn version_check_client_construction_never_panics() {
+        let _ = version_check_client(Duration::from_secs(1));
+        reqwest::Client::builder()
+            .tls_certs_only(std::iter::empty::<reqwest::Certificate>())
+            .build()
+            .expect("empty-trust-store client build must succeed without touching system roots");
+    }
 
     #[tokio::test]
     async fn test_get_current_version() {


### PR DESCRIPTION
## Related Issues

Fixes #6734

## Summary of Changes

RustFS exits with code 101 at startup in a minimal container without a system CA bundle: `reqwest`'s TLS backend fails to load any trust root, and every code path that either calls `reqwest::Client::new()` directly or uses it as the `unwrap_or_else` fallback of a failed builder panics with `No CA certificates were loaded from the system`. The reproducing panic (rustfs/connect offline e2e, state-only inventory) fires on the main thread in `BucketTargetSys::get()`, which lazily constructs its health-check client while bucket metadata is installed during startup — long before any HTTPS request is needed.

All panic-on-missing-CA construction sites now follow the same non-panicking pattern: try the normal builder, and on failure log a warning and rebuild with an explicit empty trust store (`tls_certs_only` with no certificates), which never touches system roots. Plain-HTTP consumers keep working unchanged; HTTPS requests through a degraded client fail closed per request at the TLS handshake with a clear certificate error instead of aborting the process at startup.

- `crates/ecstore/src/bucket/bucket_target_sys.rs` — the reported startup panic site: the bucket-target health-check client.
- `crates/trusted-proxies/src/cloud/metadata/{aws,azure,gcp}.rs` — cloud metadata fetchers (they talk to plain-HTTP link-local endpoints, so the degraded client is fully functional there); the three previous `unwrap_or_else(|_| Client::new())` fallbacks re-panicked with the same root cause they were meant to absorb.
- `crates/policy/src/policy/opa.rs` — same fallback pattern in the OPA authz client.
- `rustfs/src/update.rs` — same fallback pattern in the version checker (both constructors).

TLS certificate verification is never weakened: the degraded client has an empty trust store, so it trusts nothing rather than everything.

## Verification

- `cargo test -p rustfs-ecstore --lib health_check_client` — passed (constructor never panics; the empty-trust-store fallback build is pinned to succeed)
- `cargo test -p rustfs-trusted-proxies metadata_http_client` — passed
- `cargo test -p rustfs-policy --lib` — 609 passed
- `cargo nextest run -p rustfs --lib -E 'test(version_check_client_construction_never_panics)'` — passed
- `cargo clippy -p rustfs-ecstore -p rustfs-policy -p rustfs-trusted-proxies -p rustfs --all-targets` — clean
- `make pre-commit` — passed
- The missing-CA condition itself cannot be simulated in-process on a developer host (the platform verifier reads the system stores); the original reproduction is rustfs/connect's offline end-to-end job, which exercises exactly this startup path in a CA-less Ubuntu 24.04 container.

## Impact

Startup no longer aborts on hosts without a CA bundle; state-only Connect inventory and all plain-HTTP functionality work there. Outbound HTTPS (bucket-target health checks, HTTPS OPA endpoints, the version check) on such hosts now fails per request with a certificate error and a startup-time warning naming the missing CA bundle, which is the bounded behavior the issue asks for. Hosts with a CA bundle see no behavior change.

## Additional Notes

`crates/iam/src/oidc.rs` and `rustfs/src/connect` already build their clients through fallible constructors and were not affected.
