### PR TITLE
docs(agents): make branch naming identity-neutral

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,13 @@ This file contains repository-wide rules. Use the nearest subdirectory
 - An existing clean, isolated task worktree is sufficient. Create another
   worktree only when the current checkout is shared, dirty with unrelated work,
   or belongs to another task.
-- Never commit from a shared checkout. Use an `overtrue/` feature branch unless
-  the user requests another name.
+- Never commit from a shared checkout.
+- Use a task-specific branch named `<type>/<topic>`, such as `fix/...`,
+  `feat/...`, `test/...`, or `docs/...`, unless the user specifies a name.
+- Do not include agent, tool, contributor, account, or organization names in
+  branch names.
+- Push to the user-requested remote or the repository's configured push remote.
+  Do not hard-code or infer a remote from an account name.
 - Check free space before artifact-heavy builds, tests, coverage, or downloads.
   Re-check before a broad gate when space is tight.
 - Remove only task-owned temporary/build artifacts. Never delete another task's


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Replace the contributor-specific default branch prefix with the identity-neutral `<type>/<topic>` convention.
- Keep agent, tool, contributor, account, and organization names out of branch names.
- Direct pushes to a user-requested or repository-configured remote instead of hard-coding or inferring an account.

## Verification

- `git diff --check origin/main...HEAD`
- `./scripts/check_doc_paths.sh`
- `./scripts/check_no_planning_docs.sh`

## Impact

Agent workflow guidance only. There are no runtime, build, API, or deployment changes.

## Additional Notes

This mechanical instruction change was reviewed for correctness and simplicity. Rollback consists of reverting the single documentation commit.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
