### PR TITLE
refactor(ecstore): migrate minio/r2/rustfs warm backends to shared S3 constructor

### DIFF
--- a/crates/ecstore/src/services/tier/warm_backend.rs
+++ b/crates/ecstore/src/services/tier/warm_backend.rs
@@ -43,6 +43,7 @@ use rustfs_s3_client::{
     api_put_object::{AdvancedPutOptions, PutObjectOptions},
     transition_api::{ReadCloser, ReaderImpl},
 };
+use rustfs_utils::egress::validate_outbound_url;
 use rustfs_utils::http::headers::{
     CACHE_CONTROL, CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_LANGUAGE, CONTENT_TYPE, EXPIRES, HeaderExt as _,
 };
@@ -249,6 +250,13 @@ pub(crate) struct S3CompatibleWarmBackendParams<'a> {
     /// Tag handed to [`TransitionClient::new`] so per-provider client behavior
     /// and metrics stay attributable.
     pub provider_tag: &'a str,
+    /// SSRF guard run against the parsed endpoint once it's known to have a
+    /// host. Almost every provider passes [`rustfs_utils::egress::validate_outbound_url`]
+    /// unchanged; RustFS passes its own wrapper that adds a debug-only,
+    /// env-gated loopback exception for its e2e tier tests (see
+    /// rustfs/rustfs#6773) — the shared constructor stays the single call
+    /// site either way, so no provider can silently end up unvalidated.
+    pub validate_endpoint: fn(&url::Url) -> Result<(), rustfs_utils::egress::OutboundUrlError>,
 }
 
 /// Build the [`WarmBackendS3`] shared by the S3-compatible warm backend providers.
@@ -256,10 +264,6 @@ pub(crate) struct S3CompatibleWarmBackendParams<'a> {
 /// Credential, bucket, and endpoint validation run in this order because the
 /// existing provider constructors report the first failure they hit, and their
 /// error texts are user-visible through the tier admin API.
-#[allow(
-    dead_code,
-    reason = "expand step of the shared warm-backend extraction; the per-provider migrate step adds the production callers (backlog#2040)"
-)]
 pub(crate) async fn new_s3_compatible_warm_backend(
     params: S3CompatibleWarmBackendParams<'_>,
 ) -> Result<WarmBackendS3, std::io::Error> {
@@ -298,6 +302,10 @@ pub(crate) async fn new_s3_compatible_warm_backend(
     let host = u
         .host_str()
         .ok_or_else(|| std::io::Error::other("Invalid endpoint URL: missing host"))?;
+    // Runs after the host-presence check above (not immediately after Url::parse) so a
+    // host-less endpoint still reports this constructor's own "missing host" text instead of
+    // validate_endpoint's differently-worded rejection for the same input.
+    (params.validate_endpoint)(&u).map_err(|err| std::io::Error::other(format!("tier endpoint is not allowed: {err}")))?;
     let client =
         TransitionClient::new(&format!("{}:{}", host, u.port().unwrap_or(default_port)), opts, params.provider_tag).await?;
 
@@ -317,10 +325,6 @@ pub(crate) async fn new_s3_compatible_warm_backend(
 ///
 /// `object_size == -1` means "length unknown", so the caller is charged the
 /// worst case of a full [`MAX_MULTIPART_PUT_OBJECT_SIZE`] object.
-#[allow(
-    dead_code,
-    reason = "expand step of the shared warm-backend extraction; the per-provider migrate step adds the production callers (backlog#2040)"
-)]
 pub(crate) fn optimal_part_size(object_size: i64, min_part_size: i64) -> Result<i64, std::io::Error> {
     let mut object_size = object_size;
     if object_size == -1 {
@@ -936,6 +940,7 @@ mod tests {
             region: "us-east-1",
             bucket_lookup: BucketLookupType::BucketLookupDNS,
             provider_tag: "aliyun",
+            validate_endpoint: validate_outbound_url,
         }
     }
 
@@ -982,6 +987,18 @@ mod tests {
         let err = init_error(s3_compatible_params("rustfs://"), "an endpoint without a host must be rejected").await;
 
         assert_eq!(err.to_string(), "Invalid endpoint URL: missing host");
+    }
+
+    /// Every migrated provider that uses `validate_outbound_url` directly (all
+    /// but RustFS, which injects its own debug-only, env-gated wrapper — see
+    /// rustfs/rustfs#6773) goes through this one construction path, so the
+    /// SSRF guard only needs to be pinned here rather than once per provider
+    /// file (see backlog#2040's migrate steps and rustfs/rustfs#6764).
+    #[tokio::test]
+    async fn s3_compatible_backend_rejects_a_loopback_endpoint_before_any_network_setup() {
+        let err = init_error(s3_compatible_params("https://127.0.0.1:9000"), "a loopback endpoint must be rejected").await;
+
+        assert!(err.to_string().contains("not allowed"), "unexpected error: {err}");
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/services/tier/warm_backend_minio.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_minio.rs
@@ -19,24 +19,18 @@
 #![allow(clippy::all)]
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use crate::services::tier::{
     tier_config::TierMinIO,
-    warm_backend::{TransitionCandidateProbe, WarmBackend, WarmBackendGetOpts, build_transition_put_options},
+    warm_backend::{
+        S3CompatibleWarmBackendParams, TransitionCandidateProbe, WarmBackend, WarmBackendGetOpts, build_transition_put_options,
+        new_s3_compatible_warm_backend, optimal_part_size,
+    },
     warm_backend_s3::WarmBackendS3,
 };
-use rustfs_s3_client::{
-    admin_handler_utils::AdminError,
-    api_put_object::PutObjectOptions,
-    credentials::{Credentials, SignatureType, Static, Value},
-    transition_api::{Options, ReadCloser, ReaderImpl, TransitionClient, TransitionCore},
-};
+use rustfs_s3_client::transition_api::{BucketLookupType, ReadCloser, ReaderImpl};
 use rustfs_utils::egress::validate_outbound_url;
-use tracing::warn;
 
-const MAX_MULTIPART_PUT_OBJECT_SIZE: i64 = 1024 * 1024 * 1024 * 1024 * 5;
-const MAX_PARTS_COUNT: i64 = 10000;
 const _MAX_PART_SIZE: i64 = 1024 * 1024 * 1024 * 5;
 const MIN_PART_SIZE: i64 = 1024 * 1024 * 128;
 
@@ -44,51 +38,22 @@ pub struct WarmBackendMinIO(WarmBackendS3);
 
 impl WarmBackendMinIO {
     pub async fn new(conf: &TierMinIO, tier: &str) -> Result<Self, std::io::Error> {
-        if conf.access_key == "" || conf.secret_key == "" {
-            return Err(std::io::Error::other("both access and secret keys are required"));
-        }
-
-        if conf.bucket == "" {
-            return Err(std::io::Error::other("no bucket name was provided"));
-        }
-
-        let u = match url::Url::parse(&conf.endpoint) {
-            Ok(u) => u,
-            Err(e) => {
-                return Err(std::io::Error::other(e.to_string()));
-            }
-        };
-        validate_outbound_url(&u).map_err(|err| std::io::Error::other(format!("tier endpoint is not allowed: {err}")))?;
-
-        let creds = Credentials::new(Static(Value {
-            access_key_id: conf.access_key.clone(),
-            secret_access_key: conf.secret_key.clone(),
-            session_token: "".to_string(),
-            signer_type: SignatureType::SignatureV4,
-            ..Default::default()
-        }));
-        let opts = Options {
-            creds,
-            secure: u.scheme() == "https",
-            region: conf.region.clone(),
-            ..Default::default()
-        };
-        let scheme = u.scheme();
-        let default_port = if scheme == "https" { 443 } else { 80 };
-        let host = u
-            .host_str()
-            .ok_or_else(|| std::io::Error::other("Invalid endpoint URL: missing host"))?;
-        let client = TransitionClient::new(&format!("{}:{}", host, u.port().unwrap_or(default_port)), opts, "minio").await?;
-
-        let client = Arc::new(client);
-        let core = TransitionCore(Arc::clone(&client));
-        Ok(Self(WarmBackendS3 {
-            client,
-            core,
-            bucket: conf.bucket.clone(),
-            prefix: conf.prefix.strip_suffix("/").unwrap_or(&conf.prefix).to_owned(),
-            storage_class: "".to_string(),
-        }))
+        Ok(Self(
+            new_s3_compatible_warm_backend(S3CompatibleWarmBackendParams {
+                endpoint: &conf.endpoint,
+                access_key: &conf.access_key,
+                secret_key: &conf.secret_key,
+                bucket: &conf.bucket,
+                prefix: &conf.prefix,
+                region: &conf.region,
+                // MinIO tier endpoints are commonly path-style, so bucket addressing stays on
+                // `BucketLookupAuto`; pinning DNS here would break those deployments.
+                bucket_lookup: BucketLookupType::BucketLookupAuto,
+                provider_tag: "minio",
+                validate_endpoint: validate_outbound_url,
+            })
+            .await?,
+        ))
     }
 }
 
@@ -101,7 +66,7 @@ impl WarmBackend for WarmBackendMinIO {
         length: i64,
         meta: HashMap<String, String>,
     ) -> Result<String, std::io::Error> {
-        let part_size = optimal_part_size(length)?;
+        let part_size = optimal_part_size(length, MIN_PART_SIZE)?;
         let client = self.0.client.clone();
         let res = client
             .put_object(&self.0.bucket, &self.0.get_dest(object), r, length, &{
@@ -150,32 +115,15 @@ impl crate::services::tier::warm_backend::TransitionCandidateReconciler for Warm
     }
 }
 
-fn optimal_part_size(object_size: i64) -> Result<i64, std::io::Error> {
-    let mut object_size = object_size;
-    if object_size == -1 {
-        object_size = MAX_MULTIPART_PUT_OBJECT_SIZE;
-    }
-
-    if object_size > MAX_MULTIPART_PUT_OBJECT_SIZE {
-        return Err(std::io::Error::other("entity too large"));
-    }
-
-    let configured_part_size = MIN_PART_SIZE;
-    let mut part_size_flt = object_size as f64 / MAX_PARTS_COUNT as f64;
-    part_size_flt = (part_size_flt as f64 / configured_part_size as f64).ceil() * configured_part_size as f64;
-
-    let part_size = part_size_flt as i64;
-    if part_size == 0 {
-        return Ok(MIN_PART_SIZE);
-    }
-    Ok(part_size)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::services::tier::tier_config::TierMinIO;
 
+    /// The SSRF guard itself is exercised once, generically, in
+    /// `warm_backend::tests` (see backlog#2040/backlog#2043 and
+    /// rustfs/rustfs#6764) — this test only pins that this provider's
+    /// production constructor really is wired through that shared path.
     #[tokio::test]
     async fn new_rejects_loopback_endpoint_before_network_setup() {
         let conf = TierMinIO {

--- a/crates/ecstore/src/services/tier/warm_backend_r2.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_r2.rs
@@ -19,24 +19,18 @@
 #![allow(clippy::all)]
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use crate::services::tier::{
     tier_config::TierR2,
-    warm_backend::{TransitionCandidateProbe, WarmBackend, WarmBackendGetOpts, build_transition_put_options},
+    warm_backend::{
+        S3CompatibleWarmBackendParams, TransitionCandidateProbe, WarmBackend, WarmBackendGetOpts, build_transition_put_options,
+        new_s3_compatible_warm_backend, optimal_part_size,
+    },
     warm_backend_s3::WarmBackendS3,
 };
-use rustfs_s3_client::{
-    admin_handler_utils::AdminError,
-    api_put_object::PutObjectOptions,
-    credentials::{Credentials, SignatureType, Static, Value},
-    transition_api::{Options, ReadCloser, ReaderImpl, TransitionClient, TransitionCore},
-};
+use rustfs_s3_client::transition_api::{BucketLookupType, ReadCloser, ReaderImpl};
 use rustfs_utils::egress::validate_outbound_url;
-use tracing::warn;
 
-const MAX_MULTIPART_PUT_OBJECT_SIZE: i64 = 1024 * 1024 * 1024 * 1024 * 5;
-const MAX_PARTS_COUNT: i64 = 10000;
 const _MAX_PART_SIZE: i64 = 1024 * 1024 * 1024 * 5;
 const MIN_PART_SIZE: i64 = 1024 * 1024 * 128;
 
@@ -44,51 +38,22 @@ pub struct WarmBackendR2(WarmBackendS3);
 
 impl WarmBackendR2 {
     pub async fn new(conf: &TierR2, tier: &str) -> Result<Self, std::io::Error> {
-        if conf.access_key == "" || conf.secret_key == "" {
-            return Err(std::io::Error::other("both access and secret keys are required"));
-        }
-
-        if conf.bucket == "" {
-            return Err(std::io::Error::other("no bucket name was provided"));
-        }
-
-        let u = match url::Url::parse(&conf.endpoint) {
-            Ok(u) => u,
-            Err(e) => {
-                return Err(std::io::Error::other(e.to_string()));
-            }
-        };
-        validate_outbound_url(&u).map_err(|err| std::io::Error::other(format!("tier endpoint is not allowed: {err}")))?;
-
-        let creds = Credentials::new(Static(Value {
-            access_key_id: conf.access_key.clone(),
-            secret_access_key: conf.secret_key.clone(),
-            session_token: "".to_string(),
-            signer_type: SignatureType::SignatureV4,
-            ..Default::default()
-        }));
-        let opts = Options {
-            creds,
-            secure: u.scheme() == "https",
-            region: conf.region.clone(),
-            ..Default::default()
-        };
-        let scheme = u.scheme();
-        let default_port = if scheme == "https" { 443 } else { 80 };
-        let host = u
-            .host_str()
-            .ok_or_else(|| std::io::Error::other("Invalid endpoint URL: missing host"))?;
-        let client = TransitionClient::new(&format!("{}:{}", host, u.port().unwrap_or(default_port)), opts, "r2").await?;
-
-        let client = Arc::new(client);
-        let core = TransitionCore(Arc::clone(&client));
-        Ok(Self(WarmBackendS3 {
-            client,
-            core,
-            bucket: conf.bucket.clone(),
-            prefix: conf.prefix.strip_suffix("/").unwrap_or(&conf.prefix).to_owned(),
-            storage_class: "".to_string(),
-        }))
+        Ok(Self(
+            new_s3_compatible_warm_backend(S3CompatibleWarmBackendParams {
+                endpoint: &conf.endpoint,
+                access_key: &conf.access_key,
+                secret_key: &conf.secret_key,
+                bucket: &conf.bucket,
+                prefix: &conf.prefix,
+                region: &conf.region,
+                // R2 tier endpoints are commonly path-style, so bucket addressing stays on
+                // `BucketLookupAuto`; pinning DNS here would break those deployments.
+                bucket_lookup: BucketLookupType::BucketLookupAuto,
+                provider_tag: "r2",
+                validate_endpoint: validate_outbound_url,
+            })
+            .await?,
+        ))
     }
 }
 
@@ -101,7 +66,7 @@ impl WarmBackend for WarmBackendR2 {
         length: i64,
         meta: HashMap<String, String>,
     ) -> Result<String, std::io::Error> {
-        let part_size = optimal_part_size(length)?;
+        let part_size = optimal_part_size(length, MIN_PART_SIZE)?;
         let client = self.0.client.clone();
         let res = client
             .put_object(&self.0.bucket, &self.0.get_dest(object), r, length, &{
@@ -150,32 +115,15 @@ impl crate::services::tier::warm_backend::TransitionCandidateReconciler for Warm
     }
 }
 
-fn optimal_part_size(object_size: i64) -> Result<i64, std::io::Error> {
-    let mut object_size = object_size;
-    if object_size == -1 {
-        object_size = MAX_MULTIPART_PUT_OBJECT_SIZE;
-    }
-
-    if object_size > MAX_MULTIPART_PUT_OBJECT_SIZE {
-        return Err(std::io::Error::other("entity too large"));
-    }
-
-    let configured_part_size = MIN_PART_SIZE;
-    let mut part_size_flt = object_size as f64 / MAX_PARTS_COUNT as f64;
-    part_size_flt = (part_size_flt as f64 / configured_part_size as f64).ceil() * configured_part_size as f64;
-
-    let part_size = part_size_flt as i64;
-    if part_size == 0 {
-        return Ok(MIN_PART_SIZE);
-    }
-    Ok(part_size)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::services::tier::tier_config::TierR2;
 
+    /// The SSRF guard itself is exercised once, generically, in
+    /// `warm_backend::tests` (see backlog#2040/backlog#2043 and
+    /// rustfs/rustfs#6764) — this test only pins that this provider's
+    /// production constructor really is wired through that shared path.
     #[tokio::test]
     async fn new_rejects_loopback_endpoint_before_network_setup() {
         let conf = TierR2 {

--- a/crates/ecstore/src/services/tier/warm_backend_rustfs.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_rustfs.rs
@@ -19,23 +19,18 @@
 #![allow(clippy::all)]
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use crate::services::tier::{
     tier_config::TierRustFS,
-    warm_backend::{TransitionCandidateProbe, WarmBackend, WarmBackendGetOpts, build_transition_put_options},
+    warm_backend::{
+        S3CompatibleWarmBackendParams, TransitionCandidateProbe, WarmBackend, WarmBackendGetOpts, build_transition_put_options,
+        new_s3_compatible_warm_backend, optimal_part_size,
+    },
     warm_backend_s3::WarmBackendS3,
 };
-use rustfs_s3_client::{
-    admin_handler_utils::AdminError,
-    api_put_object::PutObjectOptions,
-    credentials::{Credentials, SignatureType, Static, Value},
-    transition_api::{Options, ReadCloser, ReaderImpl, TransitionClient, TransitionCore},
-};
+use rustfs_s3_client::transition_api::{BucketLookupType, ReadCloser, ReaderImpl};
 use rustfs_utils::egress::{OutboundUrlError, validate_outbound_url};
 
-const MAX_MULTIPART_PUT_OBJECT_SIZE: i64 = 1024 * 1024 * 1024 * 1024 * 5;
-const MAX_PARTS_COUNT: i64 = 10000;
 const _MAX_PART_SIZE: i64 = 1024 * 1024 * 1024 * 5;
 const MIN_PART_SIZE: i64 = 1024 * 1024 * 128;
 // Debug-only opt-in for single-host test/dev setups; release builds always reject loopback.
@@ -63,11 +58,16 @@ pub struct WarmBackendRustFS(WarmBackendS3);
 
 impl WarmBackendRustFS {
     pub async fn new(conf: &TierRustFS, tier: &str) -> Result<Self, std::io::Error> {
-        if conf.access_key == "" || conf.secret_key == "" {
+        // This provider reports endpoint problems with its own wording (and keeps the
+        // `url::ParseError` as the io::Error source) while the shared constructor carries the
+        // MinIO-derived texts. Unifying the two is a separate change, so the endpoint is
+        // pre-validated here, after the credential and bucket checks so the order in which the
+        // shared constructor would report the same failures is preserved.
+        if conf.access_key.is_empty() || conf.secret_key.is_empty() {
             return Err(std::io::Error::other("both access and secret keys are required"));
         }
 
-        if conf.bucket == "" {
+        if conf.bucket.is_empty() {
             return Err(std::io::Error::other("no bucket name was provided"));
         }
 
@@ -75,37 +75,30 @@ impl WarmBackendRustFS {
             Ok(u) => u,
             Err(e) => return Err(std::io::Error::other(e)),
         };
-        validate_rustfs_tier_endpoint(&u).map_err(|err| std::io::Error::other(format!("tier endpoint is not allowed: {err}")))?;
 
-        let creds = Credentials::new(Static(Value {
-            access_key_id: conf.access_key.clone(),
-            secret_access_key: conf.secret_key.clone(),
-            session_token: "".to_string(),
-            signer_type: SignatureType::SignatureV4,
-            ..Default::default()
-        }));
-        let opts = Options {
-            creds,
-            secure: u.scheme() == "https",
-            region: conf.region.clone(),
-            ..Default::default()
-        };
-        let scheme = u.scheme();
-        let default_port = if scheme == "https" { 443 } else { 80 };
-        let host = u
-            .host_str()
-            .ok_or_else(|| std::io::Error::other("endpoint URL must include a host"))?;
-        let client = TransitionClient::new(&format!("{host}:{}", u.port().unwrap_or(default_port)), opts, "rustfs").await?;
+        if u.host_str().is_none() {
+            return Err(std::io::Error::other("endpoint URL must include a host"));
+        }
 
-        let client = Arc::new(client);
-        let core = TransitionCore(Arc::clone(&client));
-        Ok(Self(WarmBackendS3 {
-            client,
-            core,
-            bucket: conf.bucket.clone(),
-            prefix: conf.prefix.strip_suffix("/").unwrap_or(&conf.prefix).to_owned(),
-            storage_class: "".to_string(),
-        }))
+        Ok(Self(
+            new_s3_compatible_warm_backend(S3CompatibleWarmBackendParams {
+                endpoint: &conf.endpoint,
+                access_key: &conf.access_key,
+                secret_key: &conf.secret_key,
+                bucket: &conf.bucket,
+                prefix: &conf.prefix,
+                region: &conf.region,
+                // RustFS tier endpoints are path-style, so bucket addressing stays on
+                // `BucketLookupAuto`; pinning DNS here would break those endpoints.
+                bucket_lookup: BucketLookupType::BucketLookupAuto,
+                provider_tag: "rustfs",
+                // Debug-only, env-gated loopback exception for this provider's own e2e tier
+                // tests (rustfs/rustfs#6773); every other provider passes plain
+                // `validate_outbound_url`.
+                validate_endpoint: validate_rustfs_tier_endpoint,
+            })
+            .await?,
+        ))
     }
 }
 
@@ -118,7 +111,7 @@ impl WarmBackend for WarmBackendRustFS {
         length: i64,
         meta: HashMap<String, String>,
     ) -> Result<String, std::io::Error> {
-        let part_size = optimal_part_size(length)?;
+        let part_size = optimal_part_size(length, MIN_PART_SIZE)?;
         let client = self.0.client.clone();
         let res = client
             .put_object(&self.0.bucket, &self.0.get_dest(object), r, length, &{
@@ -165,27 +158,6 @@ impl crate::services::tier::warm_backend::TransitionCandidateReconciler for Warm
         )
         .await
     }
-}
-
-fn optimal_part_size(object_size: i64) -> Result<i64, std::io::Error> {
-    let mut object_size = object_size;
-    if object_size == -1 {
-        object_size = MAX_MULTIPART_PUT_OBJECT_SIZE;
-    }
-
-    if object_size > MAX_MULTIPART_PUT_OBJECT_SIZE {
-        return Err(std::io::Error::other("entity too large"));
-    }
-
-    let configured_part_size = MIN_PART_SIZE;
-    let mut part_size_flt = object_size as f64 / MAX_PARTS_COUNT as f64;
-    part_size_flt = (part_size_flt as f64 / configured_part_size as f64).ceil() * configured_part_size as f64;
-
-    let part_size = part_size_flt as i64;
-    if part_size == 0 {
-        return Ok(MIN_PART_SIZE);
-    }
-    Ok(part_size)
 }
 
 #[cfg(test)]

--- a/scripts/error-other-format-baseline.txt
+++ b/scripts/error-other-format-baseline.txt
@@ -54,13 +54,11 @@
 19|crates/ecstore/src/services/rebalance/worker.rs
 33|crates/ecstore/src/services/tier/tier.rs
 1|crates/ecstore/src/services/tier/tier_config.rs
+1|crates/ecstore/src/services/tier/warm_backend.rs
 1|crates/ecstore/src/services/tier/warm_backend_aliyun.rs
 1|crates/ecstore/src/services/tier/warm_backend_azure.rs
 2|crates/ecstore/src/services/tier/warm_backend_gcs.rs
 1|crates/ecstore/src/services/tier/warm_backend_huaweicloud.rs
-1|crates/ecstore/src/services/tier/warm_backend_minio.rs
-1|crates/ecstore/src/services/tier/warm_backend_r2.rs
-1|crates/ecstore/src/services/tier/warm_backend_rustfs.rs
 1|crates/ecstore/src/services/tier/warm_backend_s3.rs
 1|crates/ecstore/src/services/tier/warm_backend_tencent.rs
 1|crates/ecstore/src/services/tier/warm_backend_wasabi.rs


### PR DESCRIPTION
## Update (reconciled with a second concurrent change)

This branch was updated after [PR#6773](https://github.com/rustfs/rustfs/pull/6773) landed on `main` while this migrate step was in flight. That PR added a RustFS-specific, debug-only, env-gated loopback exception (`validate_rustfs_tier_endpoint`, gated behind `RUSTFS_TIER_RUSTFS_ALLOW_LOOPBACK_ENDPOINT` and `cfg!(debug_assertions)`) to `warm_backend_rustfs.rs`'s SSRF check, needed to restore that provider's e2e coverage. My first version of this migration (and the sibling #2041/#2042 PRs) had already centralized `validate_outbound_url` directly into the shared constructor — which would have silently dropped RustFS's new loopback exception and re-broken its e2e test.

Fix: `S3CompatibleWarmBackendParams` now carries a `validate_endpoint: fn(&url::Url) -> Result<(), OutboundUrlError>` field instead of the shared constructor hardcoding one validator. MinIO and R2 (this PR) plus Aliyun/Azure/Huaweicloud/Tencent (the sibling PRs) pass plain `validate_outbound_url`; RustFS (this PR) passes `validate_rustfs_tier_endpoint`, its own wrapper. This identical `warm_backend.rs` change is bundled into all three K1 migrate PRs so none can land with a live SSRF-protection gap regardless of merge order — the content converges once any one of the three lands, so the others just need a rebase.

---

## What

Migrates the MinIO, R2, and RustFS tier warm backends onto the shared S3-compatible constructor added in rustfs/backlog#2040 ([PR#6755](https://github.com/rustfs/rustfs/pull/6755)), same pattern as the sibling PRs for #2041/#2042. Each provider's constructor and `optimal_part_size` are replaced with a call into `new_s3_compatible_warm_backend` / `optimal_part_size`, keeping the provider's own type name, `MIN_PART_SIZE`, and `provider_tag`.

This family passes `BucketLookupType::BucketLookupAuto`, **not** DNS — MinIO/R2/RustFS tier endpoints are commonly path-style, and pinning DNS lookup would break those deployments. `warm_backend_rustfs.rs` keeps its own local host-presence pre-check (producing its distinct `"endpoint URL must include a host"` wording, source-preserving via `std::io::Error::other(e)`) ahead of the shared constructor call, and now also keeps `validate_rustfs_tier_endpoint` — both provider-specific customizations the issue/later #6773 require, neither unified with the other providers.

## Verification

- `cargo fmt --all --check` — pass
- `cargo test -p rustfs-ecstore --lib services::tier` — 232 passed, 0 failed, including `warm_backend_rustfs::tests::new_returns_error_when_endpoint_has_no_host`, `new_rejects_loopback_endpoint_before_network_setup`, and `loopback_opt_in_does_not_allow_other_private_endpoints` (added by #6773, preserved here)
- `cargo clippy -p rustfs-ecstore --all-targets -- -D warnings` — clean
- Combined `cargo check -p rustfs-ecstore --lib --tests` on the final branch tip — clean
- `make pre-pr` fast guards — all pass; the workspace-wide `clippy-check`/`test` stage is left to CI (heavy parallel-session contention on the local machine during this work)

## Adversarial self-check (correctness / compatibility)

- **`bucket_lookup`** — confirmed all three providers pass `BucketLookupAuto` explicitly, never `DNS`.
- Byte-diffed `optimal_part_size` boundary behavior against the removed per-file implementations — numerically identical.
- Confirmed `warm_backend_minio.rs` / `warm_backend_r2.rs` pass plain `validate_outbound_url`, while `warm_backend_rustfs.rs` passes `validate_rustfs_tier_endpoint` and keeps its own host-presence pre-check and distinct error text — none of the three unified.
- Ran `loopback_opt_in_does_not_allow_other_private_endpoints` (asserts the env-gated exception covers only loopback, not other private ranges like `10.0.0.1`) — passes unmodified from #6773.

Refs rustfs/backlog#2043
