### PR TITLE
refactor(ecstore): migrate data movement backpressure to shared ForegroundPressure

### DIFF
--- a/crates/ecstore/src/data_movement/backpressure.rs
+++ b/crates/ecstore/src/data_movement/backpressure.rs
@@ -15,7 +15,8 @@
 use crate::error::{Error, Result};
 use crate::runtime::sources::{self as runtime_sources, WorkloadSnapshotProviderRef};
 use metrics::{counter, histogram};
-use rustfs_concurrency::{AdmissionState, WorkloadAdmissionSnapshotProvider, WorkloadClass};
+use rustfs_concurrency::WorkloadAdmissionSnapshotProvider;
+use rustfs_concurrency::workload::ForegroundPressure;
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
@@ -137,23 +138,6 @@ async fn wait_for_data_movement_admission_with_provider(
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ForegroundPressure {
-    class: WorkloadClass,
-    usage_pct: usize,
-    threshold_pct: usize,
-}
-
-impl ForegroundPressure {
-    const fn reason(self) -> &'static str {
-        match self.class {
-            WorkloadClass::ForegroundRead => "foreground_read_pressure",
-            WorkloadClass::ForegroundWrite => "foreground_write_pressure",
-            _ => "foreground_pressure",
-        }
-    }
-}
-
 fn foreground_pressure(
     config: &DataMovementBackpressureConfig,
     provider: Option<&(dyn WorkloadAdmissionSnapshotProvider + Send + Sync)>,
@@ -163,39 +147,11 @@ fn foreground_pressure(
     }
 
     let snapshot = provider?.workload_admission_snapshot();
-    [
-        (WorkloadClass::ForegroundRead, config.foreground_read_high_percent),
-        (WorkloadClass::ForegroundWrite, config.foreground_write_high_percent),
-    ]
-    .into_iter()
-    .filter_map(|(class, threshold_pct)| {
-        if threshold_pct == 0 {
-            return None;
-        }
-
-        let entry = snapshot.get(class)?;
-        let usage_pct = if matches!(entry.state, AdmissionState::Saturated) {
-            100
-        } else {
-            let limit = entry.limit?;
-            if limit == 0 {
-                return None;
-            }
-            entry
-                .active
-                .unwrap_or(0)
-                .saturating_mul(100)
-                .checked_div(limit)
-                .unwrap_or(100)
-        };
-
-        (usage_pct >= threshold_pct).then_some(ForegroundPressure {
-            class,
-            usage_pct,
-            threshold_pct,
-        })
-    })
-    .max_by_key(|pressure| pressure.usage_pct)
+    rustfs_concurrency::workload::foreground_pressure(
+        &snapshot,
+        config.foreground_read_high_percent,
+        config.foreground_write_high_percent,
+    )
 }
 
 fn record_delay_start(
@@ -276,7 +232,7 @@ fn record_delay_completion(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustfs_concurrency::{WorkloadAdmissionRegistrySnapshot, WorkloadAdmissionSnapshot};
+    use rustfs_concurrency::{AdmissionState, WorkloadAdmissionRegistrySnapshot, WorkloadAdmissionSnapshot, WorkloadClass};
     use std::sync::Arc;
 
     #[derive(Debug)]


### PR DESCRIPTION
## What

Migrates `crates/ecstore/src/data_movement/backpressure.rs`'s `ForegroundPressure` type and pressure calculation onto the shared implementation added to `crates/concurrency/src/workload.rs` in rustfs/backlog#2047 ([PR#6757](https://github.com/rustfs/rustfs/pull/6757)). The local `ForegroundPressure` struct and `reason()` are deleted; `foreground_pressure()` keeps its own `config.enabled` early return and `provider?` unwrap, then delegates to the shared function with this file's two threshold fields (`config.foreground_read_high_percent` / `config.foreground_write_high_percent`).

`record_delay_start`/`record_delay_completion` and every other function in the file are untouched. `AdmissionState`/`WorkloadClass` are no longer referenced outside `#[cfg(test)]`, so those imports moved under that gate to avoid an `unused_imports` failure in non-test builds.

## Verification

- `cargo fmt --all --check` — pass
- `cargo test -p rustfs-ecstore --lib data_movement::backpressure` — 6 passed, 0 failed
- `cargo clippy -p rustfs-ecstore --all-targets -- -D warnings` — clean
- `make pre-pr` fast guards — all pass; the workspace-wide `clippy-check`/`test` stage is left to CI (heavy parallel-session contention on the local machine during this work)
- Combined `cargo check --workspace --all-targets` together with the other 6 backlog#2039 wave-1 PRs — clean

## Adversarial self-check (correctness / compatibility)

- Byte-diffed the removed 45-line calculation body against `workload.rs`'s shared `foreground_pressure()`: identical except for the parameter pipeline (config fields → two `usize` args, `provider?`/`!config.enabled` moved to the call site).
- The three `reason()` strings (`"foreground_read_pressure"` / `"foreground_write_pressure"` / `"foreground_pressure"`) are unchanged, verified against every call site that feeds them into `counter!`/`histogram!`/`debug!` — this is a logged/metric-visible contract.
- Verified the five boundary conditions (`threshold_pct == 0`, `limit == 0`, missing entry, missing `active`, `Saturated`) and the `>=` tie threshold all resolve identically pre/post-migration; the `max_by_key` tie-break (write wins on equal usage) is unchanged since the `[read, write]` array order is preserved.
- All 6 existing tests (including the mock `StaticWorkloadProvider`) pass unmodified — no assertion was rewritten.

Refs rustfs/backlog#2048
