### PR TITLE
docs: fix Getting Started links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <a href="https://docs.rustfs.com/installation/">Getting Started</a>
+  <a href="https://docs.rustfs.com/en/installation">Getting Started</a>
   · <a href="https://docs.rustfs.com/">Docs</a>
   · <a href="https://github.com/rustfs/rustfs/issues">Bug reports</a>
   · <a href="https://github.com/rustfs/rustfs/discussions">Discussions</a>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <a href="https://docs.rustfs.com/installation/">快速开始</a>
+  <a href="https://docs.rustfs.com/zh/installation">快速开始</a>
   · <a href="https://docs.rustfs.com/">文档</a>
   · <a href="https://github.com/rustfs/rustfs/issues">报告 Bug</a>
   · <a href="https://github.com/rustfs/rustfs/discussions">社区讨论</a>

--- a/rustfs/README.md
+++ b/rustfs/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://docs.rustfs.com/installation/">Getting Started</a>
+  <a href="https://docs.rustfs.com/en/installation">Getting Started</a>
   · <a href="https://docs.rustfs.com/">Docs</a>
   · <a href="https://github.com/rustfs/rustfs/issues">Bug reports</a>
   · <a href="https://github.com/rustfs/rustfs/discussions">Discussions</a>


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Correct the broken Getting Started documentation links in the English, Chinese, and rustfs README files.

## Verification

- `git diff --check`
- Confirmed the old URL no longer occurs in the repository.

## Impact

Documentation-only change. The Getting Started links now point to the appropriate localized installation pages.

## Additional Notes

Cargo, Clippy, and tests were not run because this is a documentation-only URL correction.