### PR TITLE
fix(site-replication): send the reverse-reachability probe as POST

### DIFF
--- a/rustfs/src/admin/handlers/site_replication.rs
+++ b/rustfs/src/admin/handlers/site_replication.rs
@@ -4283,7 +4283,7 @@ async fn probe_reverse_peer_reachability(state: &SiteReplicationState, local_pee
                 continue;
             }
         };
-        if let Err(err) = PeerAdminRequest::put(&connection, SITE_REPLICATION_DEVNULL_PATH, &state.service_account_access_key)
+        if let Err(err) = devnull_probe_request(&connection, &state.service_account_access_key)
             .send(&secret_key, &serde_json::json!({}))
             .await
         {
@@ -4292,6 +4292,13 @@ async fn probe_reverse_peer_reachability(state: &SiteReplicationState, local_pee
     }
 
     errors
+}
+
+/// The probe must target devnull with a method the admin router actually
+/// registers for it — a mismatched method makes every probe fail and turns
+/// the "not reachable" warning into permanent noise.
+pub(crate) fn devnull_probe_request<'a>(connection: &'a PeerConnection, access_key: &'a str) -> PeerAdminRequest<'a> {
+    PeerAdminRequest::post(connection, SITE_REPLICATION_DEVNULL_PATH, access_key)
 }
 
 async fn backfill_existing_buckets_after_add(
@@ -11098,13 +11105,15 @@ mod tests {
             deployment_id: "remote".to_string(),
             ..peer("remote", "https://remote.example.com")
         };
-        let detail = "x".repeat(SITE_REPLICATION_PEER_ERROR_DETAIL_LIMIT + 32);
+        let detail = format!("HEAD{}TAIL", "x".repeat(SITE_REPLICATION_PEER_ERROR_DETAIL_LIMIT + 32));
 
         let error = status_peer_error(&remote, detail);
 
         assert_eq!(error.name, "remote");
         assert_eq!(error.endpoint, "https://remote.example.com");
-        assert!(error.error.ends_with("(truncated)"));
+        assert!(error.error.contains("(truncated)"));
+        assert!(error.error.starts_with("HEAD"));
+        assert!(error.error.ends_with("TAIL"));
         assert!(error.error.chars().count() <= SITE_REPLICATION_PEER_ERROR_DETAIL_LIMIT);
     }
 

--- a/rustfs/src/admin/route_registration_test.rs
+++ b/rustfs/src/admin/route_registration_test.rs
@@ -791,6 +791,19 @@ fn expected_admin_route_matrix() -> Vec<RouteMatrixEntry> {
 // production registration helper intentionally honors that environment switch.
 #[test]
 #[serial]
+fn test_reverse_probe_targets_a_registered_devnull_route() {
+    // The reverse-reachability probe used to send PUT while only POST is
+    // routed for devnull, so every probe failed with 501 and every add/join
+    // reported a false "not reachable" warning.
+    let router = registered_admin_router();
+    let connection = crate::site_replication::transport::PeerConnection::new("http://peer.example.com:9000", false, "")
+        .expect("peer connection");
+    let request = crate::admin::handlers::site_replication::devnull_probe_request(&connection, "site-replicator-0");
+    assert_route(&router, request.method().clone(), request.path());
+}
+
+#[test]
+#[serial]
 fn test_admin_route_matrix_matches_registered_routes() {
     let router = registered_admin_router();
 

--- a/rustfs/src/site_replication/transport.rs
+++ b/rustfs/src/site_replication/transport.rs
@@ -612,9 +612,26 @@ impl<'a> PeerAdminRequest<'a> {
         }
     }
 
+    pub(crate) fn post(connection: &'a PeerConnection, path: &'a str, access_key: &'a str) -> Self {
+        Self {
+            method: Method::POST,
+            ..Self::put(connection, path, access_key)
+        }
+    }
+
     pub(crate) fn with_client(mut self, client: &'a reqwest::Client) -> Self {
         self.client = Some(client);
         self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn method(&self) -> &Method {
+        &self.method
+    }
+
+    #[cfg(test)]
+    pub(crate) fn path(&self) -> &str {
+        self.path
     }
 
     async fn resolved_client(&self) -> S3Result<reqwest::Client> {
@@ -916,17 +933,36 @@ pub(crate) fn summarize_peer_error_detail(detail: &str) -> String {
         return detail.to_string();
     }
 
-    let suffix = "... (truncated)";
-    let take_chars = SITE_REPLICATION_PEER_ERROR_DETAIL_LIMIT.saturating_sub(suffix.chars().count());
-    let mut summary: String = detail.chars().take(take_chars).collect();
-    summary.push_str(suffix);
-    summary
+    // Keep both ends: nested peer errors append the decisive status/code at
+    // the tail, so a prefix-only cut drops exactly the part an operator needs.
+    let ellipsis = " ... (truncated) ... ";
+    let budget = SITE_REPLICATION_PEER_ERROR_DETAIL_LIMIT.saturating_sub(ellipsis.chars().count());
+    let head_chars = budget / 2;
+    let tail_chars = budget - head_chars;
+    let head: String = detail.chars().take(head_chars).collect();
+    let tail: String = detail.chars().skip(detail_chars.saturating_sub(tail_chars)).collect();
+    format!("{head}{ellipsis}{tail}")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    #[test]
+    fn test_summarize_peer_error_detail_keeps_head_and_tail() {
+        let detail = format!("HEAD{}TAIL", "x".repeat(SITE_REPLICATION_PEER_ERROR_DETAIL_LIMIT * 2));
+        let summary = summarize_peer_error_detail(&detail);
+        assert!(summary.starts_with("HEAD"));
+        assert!(summary.ends_with("TAIL"));
+        assert!(summary.contains("(truncated)"));
+        assert!(summary.chars().count() <= SITE_REPLICATION_PEER_ERROR_DETAIL_LIMIT);
+    }
+
+    #[test]
+    fn test_summarize_peer_error_detail_passes_short_details_through() {
+        assert_eq!(summarize_peer_error_detail("  short error  "), "short error");
+    }
 
     #[tokio::test]
     #[serial]


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#2072. Also addresses the error-detail truncation part of rustfs/backlog#2073 (F5).

## Summary of Changes

The reverse-reachability probe that runs on the joining site during `site-replication add`/`join` sent `PUT` to the devnull endpoint, while the admin router only registers `POST /rustfs/admin/v3/site-replication/devnull`. Every probe therefore failed with 501, and every add/join response carried a false `initialSyncErrorMessage: "... is not reachable from this site"`, drowning out the real network-asymmetry warnings the probe exists to surface. Verified on a real two-VM deployment: the message appears on 100% of add calls while replication is fully healthy.

- Add a `POST` constructor to `PeerAdminRequest` (it only had `PUT`/`GET`) and send the probe through a named `devnull_probe_request` helper.
- A new route-registration test builds the actual probe request and asserts its method/path pair is a registered admin route, so a probe/router method drift fails CI instead of shipping as permanent warning noise.
- `summarize_peer_error_detail` now keeps both the head and the tail of oversized details. Nested peer errors append the decisive status/code at the tail, and the previous prefix-only cut dropped exactly that part (the same truncation hid the 501 root cause during diagnosis).

## Verification

- `cargo test -p rustfs --lib site_replication` (255 passed)
- `cargo test -p rustfs --lib route_registration_test` (8 passed, including the new probe-route assertion)
- `cargo test -p rustfs --lib test_status_peer_error_summarizes` (updated for head+tail truncation)
- `cargo clippy -p rustfs --lib --tests` (clean)
- `make pre-commit` equivalent: fmt-check through quick-check all pass (test-wiring-check run via uv because the local system python lacks `tomllib`; the script itself passes)

## Impact

Operator-facing only: add/join responses stop reporting healthy peers as unreachable, and truncated peer errors retain their final status/code. No wire-format or API changes; the devnull endpoint itself is unchanged.

## Additional Notes

Found during full site-replication testing on real hardware (report and root-cause analysis in rustfs/backlog#2073).
