### PR TITLE
chore(deps): update s3s revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8514,16 +8514,6 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
@@ -9414,7 +9404,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "proptest",
- "quick-xml 0.42.0",
+ "quick-xml",
  "rand 0.10.2",
  "rcgen",
  "regex",
@@ -10157,7 +10147,7 @@ dependencies = [
  "jiff",
  "metrics",
  "percent-encoding",
- "quick-xml 0.42.0",
+ "quick-xml",
  "rayon",
  "rustc-hash",
  "rustfs-config",
@@ -10489,7 +10479,7 @@ dependencies = [
  "hyper-util",
  "lazy_static",
  "md-5 0.11.0",
- "quick-xml 0.42.0",
+ "quick-xml",
  "rand 0.10.2",
  "rustfs-checksums",
  "rustfs-config",
@@ -11043,7 +11033,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 [[package]]
 name = "s3s"
 version = "0.15.0"
-source = "git+https://github.com/rustfs/s3s.git?rev=0f6f83d98b37fd9edcaa3be573db4aa8f568e088#0f6f83d98b37fd9edcaa3be573db4aa8f568e088"
+source = "git+https://github.com/rustfs/s3s.git?rev=6e7b41252c7ba218a90886f58d297716ddf68acf#6e7b41252c7ba218a90886f58d297716ddf68acf"
 dependencies = [
  "arc-swap",
  "arrayvec",
@@ -11064,14 +11054,17 @@ dependencies = [
  "httparse",
  "hyper",
  "itoa",
+ "jiff",
  "md-5 0.11.0",
  "memchr",
  "mime",
  "nom 8.0.0",
  "numeric_cast",
  "pin-project-lite",
- "quick-xml 0.41.0",
+ "quick-xml",
  "regex",
+ "s3s-sigv2",
+ "s3s-sigv4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -11091,6 +11084,30 @@ dependencies = [
  "urlencoding",
  "xxhash-rust",
  "zeroize",
+]
+
+[[package]]
+name = "s3s-sigv2"
+version = "0.16.0-alpha.1"
+source = "git+https://github.com/rustfs/s3s.git?rev=6e7b41252c7ba218a90886f58d297716ddf68acf#6e7b41252c7ba218a90886f58d297716ddf68acf"
+dependencies = [
+ "jiff",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "s3s-sigv4"
+version = "0.16.0-alpha.1"
+source = "git+https://github.com/rustfs/s3s.git?rev=6e7b41252c7ba218a90886f58d297716ddf68acf#6e7b41252c7ba218a90886f58d297716ddf68acf"
+dependencies = [
+ "arrayvec",
+ "base64-simd",
+ "hex-simd",
+ "jiff",
+ "nom 8.0.0",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,7 +304,7 @@ rustify = { version = "0.7", default-features = false }
 rustix = { version = "1.1.4" }
 rust-embed = { version = "8.12.0" }
 rustc-hash = { version = "2.1.3" }
-s3s = { git = "https://github.com/rustfs/s3s.git", rev = "0f6f83d98b37fd9edcaa3be573db4aa8f568e088", version = "0.15.0", features = ["minio"] }
+s3s = { git = "https://github.com/rustfs/s3s.git", rev = "6e7b41252c7ba218a90886f58d297716ddf68acf", version = "0.15.0", features = ["minio"] }
 serial_test = "4.0.1"
 shadow-rs = { default-features = false, version = "2.0.0" }
 siphasher = "1.0.3"


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Update the workspace `s3s` git dependency to `6e7b41252c7ba218a90886f58d297716ddf68acf`.
- Pull in the upstream SelectRequest XML root alias compatibility fix from rustfs/s3s.
- Refresh `Cargo.lock` for the new s3s source revision, including the split `s3s-sigv2` and `s3s-sigv4` dependencies.

## Verification
- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs upload_stream -- --nocapture`
- `cargo test -p rustfs rustfs_s3_config_preserves_compatibility_over_s3s_defaults -- --nocapture`
- `cargo test -p rustfs-s3select-query -- --nocapture`

## Impact
This is a dependency-only update. It keeps RustFS on `s3s` 0.15.0 while advancing the pinned source revision for S3 Select XML compatibility. No RustFS runtime configuration, public API, or storage format changes are expected.

## Additional Notes
- Correctness: the RustFS upload stream error mapping and s3s config compatibility tests still pass with the new revision.
- Compatibility: the update preserves the RustFS compatibility boundary around s3s defaults and SigV2 behavior.
- Performance: no RustFS hot-path source changes were made; the lockfile changes are limited to the s3s revision and its expected dependency graph changes.
- Test coverage: local focused checks passed; full CI is expected to provide the broad workspace gate.
