### PR TITLE
fix(s3): preserve atomic 1 MiB conditional writes

### DIFF
--- a/rustfs/src/app/object/put.rs
+++ b/rustfs/src/app/object/put.rs
@@ -35,6 +35,10 @@ const DEFAULT_ZERO_COPY_EAGER_PUT_MAX_SIZE_BYTES: usize = 16 * 1024 * 1024;
 
 const DEFAULT_SMALL_EAGER_PUT_MAX_SIZE_BYTES: usize = 512 * 1024;
 
+// Keep bounded conditional writes eager through the historical 1 MiB boundary
+// so the old object remains readable until the replacement body is complete.
+const CONDITIONAL_SMALL_EAGER_PUT_MAX_SIZE_BYTES: i64 = 1024 * 1024;
+
 const PUT_EAGER_STATUS_ELIGIBLE: &str = "eligible";
 
 const PUT_EAGER_STATUS_EXTRACT: &str = "extract";
@@ -516,6 +520,17 @@ fn should_use_small_eager_put_path_with_max_size(
     if is_extract || should_compress || server_side_encryption_requested {
         return false;
     }
+
+    let has_conditional_write = [http::header::IF_MATCH, http::header::IF_NONE_MATCH]
+        .into_iter()
+        .filter_map(|name| headers.get(name))
+        .filter_map(|value| value.to_str().ok())
+        .any(|value| !value.trim().is_empty());
+    let max_size = if has_conditional_write {
+        max_size.max(CONDITIONAL_SMALL_EAGER_PUT_MAX_SIZE_BYTES)
+    } else {
+        max_size
+    };
 
     if size <= 0 || size > max_size {
         return false;
@@ -2349,6 +2364,31 @@ mod tests {
             false,
             1024 * 1024,
         ));
+    }
+
+    #[test]
+    fn should_use_small_eager_put_path_keeps_conditional_1mb_writes_atomic() {
+        for header in [http::header::IF_MATCH, http::header::IF_NONE_MATCH] {
+            let mut headers = HeaderMap::new();
+            headers.insert(header, HeaderValue::from_static("*"));
+
+            assert!(should_use_small_eager_put_path_with_max_size(
+                1024 * 1024,
+                &headers,
+                false,
+                false,
+                false,
+                512 * 1024,
+            ));
+            assert!(!should_use_small_eager_put_path_with_max_size(
+                1024 * 1024 + 1,
+                &headers,
+                false,
+                false,
+                false,
+                512 * 1024,
+            ));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

rustfs/backlog#2063

## Summary of Changes

- Keep ordinary PUTs on the 512 KiB eager-body threshold.
- Keep non-empty `If-Match` and `If-None-Match` PUTs eager through 1 MiB so the previous object stays readable until the replacement body is complete.
- Add boundary coverage for both conditional headers.

## Verification

- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p rustfs --lib should_use_small_eager_put_path`
- `cargo build -p rustfs --bin rustfs`
- `TESTEXPR=test_atomic_conditional_write_1mb DEPLOY_MODE=binary RUSTFS_BINARY=target/debug/rustfs ./scripts/s3-tests/run.sh`
- `make pre-pr` passed formatting, guards, offline enrollment E2E, Clippy, script tests, and 8,485 nextest cases before two unrelated transition cache tests failed under parallel execution; both passed when rerun individually with `cargo test -p rustfs-ecstore --features test-util <test-name> -- --nocapture`.

## Impact

Conditional PUTs from 512 KiB through 1 MiB may buffer up to 1 MiB before storage commit. Ordinary PUT behavior and configuration remain unchanged.

## Additional Notes

- Correctness: PASS — the bounded conditional body is consumed before the storage lock can hide the committed object.
- Compatibility: PASS — conditional parsing and response behavior are unchanged.
- Security: PASS — no authentication or authorization path changes; only non-empty conditional headers select the restored path.
- Performance: PASS — the extra buffering is limited to conditional PUTs and capped at 1 MiB.
- Test coverage: PASS — both conditional headers and the exact S3 regression are covered.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
