### PR TITLE
fix(ecstore): move conditional PUT lock to commit-time recheck

### DIFF
--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -2592,29 +2592,19 @@ impl SetDisks {
 
         let mut object_lock_guard = None;
         let mut bucket_lifecycle_guard = None;
-        let deferred_data_movement_precondition = opts.data_movement && opts.http_preconditions.is_some();
 
-        if opts.http_preconditions.is_some() && !deferred_data_movement_precondition {
-            if !opts.no_lock {
-                if let Some(expected_incarnation_id) = opts.expected_bucket_incarnation_id
-                    && opts.bucket_lifecycle_lock_fence.is_none()
-                {
-                    bucket_lifecycle_guard = Some(
-                        metadata_sys::object_store_in(&self.ctx)
-                            .await?
-                            .acquire_bucket_incarnation_fence(bucket, expected_incarnation_id)
-                            .await?,
-                    );
-                }
-                object_lock_guard = Some(
-                    self.acquire_write_lock_diag("put_object_precondition", bucket, object)
-                        .await?,
-                );
-            }
-
-            if let Some(err) = self.check_write_precondition(bucket, object, opts).await {
-                return Err(err);
-            }
+        // This pre-body check is advisory fast-fail only: the authoritative
+        // precondition evaluation happens under the commit namespace lock
+        // below, so the namespace write lock must NOT be taken here — holding
+        // it across client-paced body ingestion starves concurrent reads of
+        // the same object into lock-timeout 503s (rustfs/backlog#2074).
+        // Data movement skips the advisory read: its staleness predicate is
+        // only meaningful at commit time.
+        if opts.http_preconditions.is_some()
+            && !opts.data_movement
+            && let Some(err) = self.check_write_precondition(bucket, object, opts).await
+        {
+            return Err(err);
         }
 
         let expected_restore_operation_id = restore_commit_operation_id_from_metadata(&opts.user_defined)?;
@@ -3084,7 +3074,9 @@ impl SetDisks {
             #[cfg(any(test, feature = "test-util"))]
             pause_put_object_commit(bucket, object, PutObjectCommitPause::AfterNamespace).await;
 
-            if deferred_data_movement_precondition && let Some(err) = self.check_write_precondition(bucket, object, opts).await {
+            if opts.http_preconditions.is_some()
+                && let Some(err) = self.check_write_precondition(bucket, object, opts).await
+            {
                 return Err(err);
             }
 
@@ -15841,6 +15833,161 @@ mod put_object_tmp_cleanup_tests {
             .await
             .expect("client object should drain");
         assert_eq!(body, b"new client body");
+    }
+
+    #[tokio::test]
+    async fn conditional_put_does_not_block_reads_during_body_ingestion() {
+        let (_temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
+        let bucket = "conditional-put-nonblocking-read";
+        let object = "object";
+        for disk in &disk_stores {
+            disk.make_volume(bucket).await.expect("bucket volume should be created");
+        }
+
+        let mut initial_reader = PutObjReader::from_vec(b"old body".to_vec());
+        let initial = set_disks
+            .put_object(bucket, object, &mut initial_reader, &ObjectOptions::default())
+            .await
+            .expect("initial object should be written");
+        let initial_etag = initial.etag.clone().expect("initial object should have an etag");
+
+        let body = vec![b'c'; 64 * 1024];
+        let split = body.len() / 2;
+        let (mut source, stream) = tokio::io::duplex(64);
+        let hash_reader = HashReader::from_stream(
+            stream,
+            i64::try_from(body.len()).expect("body length should fit i64"),
+            i64::try_from(body.len()).expect("body length should fit i64"),
+            None,
+            None,
+            false,
+        )
+        .expect("conditional hash reader should be created");
+        let writer_store = Arc::clone(&set_disks);
+        let etag_for_put = initial_etag.clone();
+        let put = tokio::spawn(async move {
+            let mut reader = PutObjReader::new(hash_reader);
+            writer_store
+                .put_object(
+                    bucket,
+                    object,
+                    &mut reader,
+                    &ObjectOptions {
+                        http_preconditions: Some(HTTPPreconditions {
+                            if_match: Some(etag_for_put),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                )
+                .await
+        });
+
+        source
+            .write_all(&body[..split])
+            .await
+            .expect("conditional PUT should consume the first half of the body");
+        let info = tokio::time::timeout(
+            Duration::from_secs(5),
+            set_disks.get_object_info(bucket, object, &ObjectOptions::default()),
+        )
+        .await
+        .expect("reads must not wait for the conditional PUT body")
+        .expect("the old version must stay readable during body ingestion");
+        assert_eq!(info.etag.as_deref(), Some(initial_etag.as_str()));
+
+        source
+            .write_all(&body[split..])
+            .await
+            .expect("conditional PUT should consume the remaining body");
+        drop(source);
+        put.await
+            .expect("conditional PUT task should join")
+            .expect("conditional PUT should commit after the body completes");
+    }
+
+    #[tokio::test]
+    async fn conditional_put_precondition_is_rechecked_at_commit() {
+        let (_temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
+        let bucket = "conditional-put-commit-recheck";
+        let object = "object";
+        for disk in &disk_stores {
+            disk.make_volume(bucket).await.expect("bucket volume should be created");
+        }
+
+        let mut initial_reader = PutObjReader::from_vec(b"old body".to_vec());
+        let initial = set_disks
+            .put_object(bucket, object, &mut initial_reader, &ObjectOptions::default())
+            .await
+            .expect("initial object should be written");
+        let initial_etag = initial.etag.clone().expect("initial object should have an etag");
+
+        let body = vec![b'c'; 64 * 1024];
+        let split = body.len() / 2;
+        let (mut source, stream) = tokio::io::duplex(64);
+        let hash_reader = HashReader::from_stream(
+            stream,
+            i64::try_from(body.len()).expect("body length should fit i64"),
+            i64::try_from(body.len()).expect("body length should fit i64"),
+            None,
+            None,
+            false,
+        )
+        .expect("conditional hash reader should be created");
+        let writer_store = Arc::clone(&set_disks);
+        let put = tokio::spawn(async move {
+            let mut reader = PutObjReader::new(hash_reader);
+            writer_store
+                .put_object(
+                    bucket,
+                    object,
+                    &mut reader,
+                    &ObjectOptions {
+                        http_preconditions: Some(HTTPPreconditions {
+                            if_match: Some(initial_etag),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                )
+                .await
+        });
+
+        source
+            .write_all(&body[..split])
+            .await
+            .expect("conditional PUT should consume the first half of the body");
+        let mut interloper_reader = PutObjReader::from_vec(b"interloper body".to_vec());
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            set_disks.put_object(bucket, object, &mut interloper_reader, &ObjectOptions::default()),
+        )
+        .await
+        .expect("the interloper write must not wait for the conditional PUT body")
+        .expect("the interloper write should commit while the conditional PUT streams");
+
+        source
+            .write_all(&body[split..])
+            .await
+            .expect("conditional PUT should consume the remaining body");
+        drop(source);
+        let err = put
+            .await
+            .expect("conditional PUT task should join")
+            .expect_err("the conditional PUT must recheck its precondition under the commit lock");
+        assert_eq!(err, StorageError::PreconditionFailed);
+
+        let mut reader = set_disks
+            .get_object_reader(bucket, object, None, HeaderMap::new(), &ObjectOptions::default())
+            .await
+            .expect("the interloper object should remain readable");
+        let mut body = Vec::new();
+        reader
+            .stream
+            .read_to_end(&mut body)
+            .await
+            .expect("the interloper object should drain");
+        assert_eq!(body, b"interloper body");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#2074 (the `S3 Implemented Tests` main regression; introduced-visible by the boundary change in #6770, while the underlying lock-holding defect predates it).

## Summary of Changes

A PUT with HTTP preconditions (`If-Match` / `If-None-Match`) used to acquire the per-object namespace write lock **before** ingesting the request body and hold it until commit. Body ingestion is client-paced, so any concurrent read of the same object (HeadObject/GetObject) queued behind that lock until the 5s acquire timeout and surfaced as 503 ServiceUnavailable. #6770 exposed this by lowering the small-eager PUT boundary to 512 KiB, which routed the 1 MB conditional writes of `test_atomic_conditional_write_1mb` onto the streaming path and made the gate fail deterministically on every branch; any real >512 KiB concurrent conditional write was equally affected.

This PR removes the pre-body lock and moves conditional writes onto the same commit-time shape that data-movement preconditions already use (`data_movement_precondition_is_rechecked_at_commit`):

- Before the body: an advisory, lock-free `check_write_precondition` keeps the fast 412/404 for requests that already fail.
- At commit: the authoritative re-check runs under the `put_object_commit` namespace write lock, before the metadata rename and inside the same continuous lock hold, so check-then-commit stays atomic and concurrent conditional writers still serialize to exactly one winner.

Reads during body ingestion now return the old (last committed) version instead of 503, matching AWS conditional-write semantics. A precondition invalidated mid-stream (e.g. an interloper write changed the etag) now fails closed with 412 at commit; the tmp shards are reclaimed by the existing inline failure-path cleanup.

Internal CAS writers (pool metadata, config) are unaffected: they run with `no_lock` under their own persistence fences, rebuild their payload readers per attempt, and now additionally get the commit-time re-check.

## Verification

- Red/green on the reported reproduction: `DEPLOY_MODE=binary TESTEXPR='test_atomic_conditional_write_1mb' scripts/s3-tests/run.sh` fails on unfixed main (HeadObject 503 after 5s, PUT idles 33s in the lock) and passes with this change in 0.48s.
- Two new regression tests in `put_object_tmp_cleanup_tests`, both verified to fail when the source hunks are reverted:
  - `conditional_put_does_not_block_reads_during_body_ingestion` — `get_object_info` must answer with the old etag while a conditional PUT is mid-body.
  - `conditional_put_precondition_is_rechecked_at_commit` — an interloper write during body ingestion must turn the conditional PUT into `PreconditionFailed` and keep the interloper's bytes.
- Full implemented s3tests suite (CI-equivalent, XDIST=4): 537 passed, 0 regressions.
- Conditional/if-match s3tests subset: 0 regressions (the failures reported by the raw run are all `excluded_tests.txt`/unimplemented entries pulled in by the TESTEXPR override).
- `make pre-pr`: every fast gate and clippy pass. The full workspace nextest run finished 15155/15161 passed; the 6 failures are load flakes on the local machine (disjoint failure sets across three reruns, every failed test passes in isolation — one of them needs 73s alone and dies on its internal 5s lock timeout under full parallel load — and none of them touches the precondition code paths this PR changes).

Adversarial validation (high risk: locking + S3-visible semantics), two sequential passes, one verdict per lens:

- Correctness: null — commit-time 412/404 returns before `tmp_cleanup_owned` is set, so the inline failure-path cleanup reclaims tmp shards; missing-object `If-Match` still 404s pre-body via the advisory check; delete-marker and versioned-lookup semantics reuse the unchanged `check_write_precondition`.
- Concurrency/durability: null — one-winner CAS preserved (re-check→rename under one continuous commit lock; `is_lock_lost` fencing still aborts a lost lock before rename); lock ordering now has a single acquisition site (bucket fence → object lock), removing the second ordering variant.
- Compatibility: null — evaluation point moves to commit, which is where AWS evaluates conditional writes; error surface (412/404/lock errors) unchanged; no metadata or wire format change.
- Test coverage: both new tests assert etag, exact bytes, and the specific error variant, and were run red against the unfixed source. Residual: the advisory fast-fail has no dedicated pin; losing it would only cost efficiency, not correctness.
- Performance: conditional PUTs pay one extra no-lock metadata read (advisory + commit re-check, the latter identical to the data-movement path); the unconditional PUT hot path is untouched.

## Impact

S3-visible behavior: HeadObject/GetObject concurrent with a streaming conditional PUT now return the last committed version instead of 503; a conditional PUT whose precondition is invalidated during body transfer receives 412 after upload instead of blocking the writer queue. No configuration, deployment, or on-disk format impact.

## Additional Notes

`copy_object` and `complete_multipart_upload` keep their early precondition checks: neither holds the namespace lock across client-paced input, so they do not exhibit the starvation. After this merges, the `S3 Implemented Tests` checks on #6790/#6791/#6793 need a rerun (they fail on this main regression, not on their own changes).
