### PR TITLE
fix(s3-client): rename-align CommonPrefix for tier in-use XML parsing

### DIFF
--- a/crates/s3-client/src/api_list.rs
+++ b/crates/s3-client/src/api_list.rs
@@ -471,4 +471,58 @@ mod tests {
         assert_eq!(parsed.delete_markers.len(), 1);
         assert_eq!(parsed.delete_markers[0].version_id, "marker-a");
     }
+
+    // Regression test for backlog#2076: a ListObjectsV2 response for a delimited
+    // listing over a bucket that holds nested-key objects (e.g. any warm-tier
+    // target that already stores more than one flat object) includes a
+    // <CommonPrefixes><Prefix>...</Prefix></CommonPrefixes> element. `CommonPrefix`
+    // previously had no `rename_all = "PascalCase"`, so quick_xml looked for a
+    // lowercase `<prefix>` child, never found one, and (with no `#[serde(default)]`
+    // either) failed the whole response with "missing field `prefix`" — surfacing to
+    // callers of `WarmBackendS3::in_use()` (tier add/remove) as `TierPermErr`.
+    #[test]
+    fn list_objects_v2_xml_parses_common_prefixes() {
+        let xml = br#"
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Name>warm-bucket</Name>
+                <Prefix></Prefix>
+                <Delimiter>/</Delimiter>
+                <MaxKeys>1</MaxKeys>
+                <IsTruncated>false</IsTruncated>
+                <CommonPrefixes>
+                    <Prefix>subdir/</Prefix>
+                </CommonPrefixes>
+            </ListBucketResult>
+        "#;
+
+        let parsed = quick_xml::de::from_reader::<_, ListBucketV2Result>(xml.as_slice()).expect("ListObjectsV2 XML should parse");
+
+        assert_eq!(parsed.common_prefixes.len(), 1);
+        assert_eq!(parsed.common_prefixes[0].prefix, "subdir/");
+    }
+
+    // Same fixture shape as list_object_versions_query hits (ListVersionsResult
+    // reuses the same CommonPrefix type).
+    #[test]
+    fn list_object_versions_xml_parses_common_prefixes() {
+        let xml = br#"
+            <ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Name>warm-bucket</Name>
+                <Prefix></Prefix>
+                <KeyMarker></KeyMarker>
+                <VersionIdMarker></VersionIdMarker>
+                <MaxKeys>1</MaxKeys>
+                <IsTruncated>false</IsTruncated>
+                <CommonPrefixes>
+                    <Prefix>subdir/</Prefix>
+                </CommonPrefixes>
+            </ListVersionsResult>
+        "#;
+
+        let parsed =
+            quick_xml::de::from_reader::<_, ListVersionsResult>(xml.as_slice()).expect("ListObjectVersions XML should parse");
+
+        assert_eq!(parsed.common_prefixes.len(), 1);
+        assert_eq!(parsed.common_prefixes[0].prefix, "subdir/");
+    }
 }

--- a/crates/s3-client/src/api_s3_datatypes.rs
+++ b/crates/s3-client/src/api_s3_datatypes.rs
@@ -30,6 +30,7 @@ use crate::utils::base64_decode;
 use super::transition_api;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(default, rename_all = "PascalCase")]
 pub struct CommonPrefix {
     pub prefix: String,
 }


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#2076.

## Summary of Changes

`CommonPrefix` in `crates/s3-client/src/api_s3_datatypes.rs` was missing the `#[serde(default, rename_all = "PascalCase")]` container attribute that every sibling struct in this file already carries. Its single field `prefix` was matched against a literal lowercase XML tag with no fallback, so any `ListObjectsV2`/`ListObjectVersions` response containing a `<CommonPrefixes><Prefix>...</Prefix></CommonPrefixes>` element (produced whenever a delimited listing finds nested-key objects under the queried prefix) failed to deserialize with `missing field 'prefix'`. `WarmBackendS3::in_use()` calls `list_objects_v2` with `delimiter="/"` to decide whether a remote tier backend still holds data, and `TierConfigMgr::add()`/`remove()` both call `in_use()` during validation unless `--force` is passed, so once a warm tier's remote bucket held any nested-key object (which is exactly what a completed ILM transition writes, e.g. `.../ilm/transition-transactions/<hash>/<a>/<b>/<c>`), every later attempt to add another tier at that backend, or to remove the existing one, failed with an HTTP 500 `TierPermErr` instead of running to completion. The fix is a one-line struct attribute; it does not touch RustFS's own server-side S3 API responses, which build `CommonPrefix` from the unrelated `s3s::dto::CommonPrefix` type — this struct is exclusively used by the outbound tier/transition client.

Fixing the rename also lets the pre-existing `ERR_TIER_BACKEND_IN_USE`/`ERR_TIER_BACKEND_NOT_EMPTY` guards in `TierConfigMgr::add()`/`remove()` do their job: verified locally against a build with this fix that once `in_use()` can parse the response, removing a tier that holds real transitioned data is correctly rejected (`tier backend is not empty`), and adding a second tier against an already-occupied backend is correctly rejected too (`tier backend is already in use`) — neither guard needed any code change once the XML bug was gone. A narrower, separate gap remains where a tier referenced only by a lifecycle rule's `StorageClass` (with zero objects transitioned yet) can still be removed; that is config-reference tracking unrelated to this XML bug and is tracked as a follow-up in rustfs/backlog#2077.

## Verification

- `cargo test -p rustfs-s3-client --lib` — 47 passed, including the two new regression tests (`list_objects_v2_xml_parses_common_prefixes`, `list_object_versions_xml_parses_common_prefixes`); both fail with `missing field 'prefix'` against the pre-fix struct and pass with the fix, confirmed by temporarily reverting the attribute and rerunning.
- `cargo clippy --all-targets -- -D warnings` — clean across the workspace.
- `cargo fmt --all -- --check` — clean.
- `make pre-commit` — all checks passed.
- End-to-end manual repro against a locally built `rustfs` binary with the fix: two live single-node instances (source + warm target), an empty-prefix RustFS tier, a real `--transition-days 0` ILM transition, then `rc ilm tier add` of a second tier at the same backend and `rc ilm tier remove` of the original tier — both now succeed/fail with the correct `TierNameBackendInUse` semantics instead of a 500.

## Impact

No API or config surface change. Fixes a regression that made ILM tier add/remove operations fail with a 500 once a warm-tier backend held any object with a nested key (which normal ILM transitions produce), and restores the existing in-use/not-empty removal guards to working order.

## Additional Notes

Filed rustfs/backlog#2077 to track the separate, lower-severity gap: `TierConfigMgr::remove()` doesn't check whether any bucket's lifecycle configuration still references a tier by name when the tier has zero physically transitioned objects.
