### PR TITLE
fix(ci): pass --repo to gh release delete in preview cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1065,7 +1065,7 @@ jobs:
           while IFS= read -r preview_tag; do
             [[ -n "$preview_tag" ]] || continue
             echo "🧹 Deleting preview release $preview_tag (tag kept)"
-            gh release delete "$preview_tag" --yes
+            gh release delete "$preview_tag" --repo "${GITHUB_REPOSITORY}" --yes
             DELETED=$((DELETED + 1))
           done < <(
             jq -r --arg tag "$TAG" '


### PR DESCRIPTION
## Related Issues

N/A. Found and fixed while diagnosing why 1.0.0-rc.4's Docker/Helm publication never triggered.

## Summary of Changes

`cleanup-preview-releases` in `.github/workflows/build.yml` has no `actions/checkout` step — it only calls `gh api` and `gh release delete` directly against the API. `gh api` works fine without a checkout because it always receives the full `repos/{owner}/{repo}/...` path explicitly (see the job's own `gh api --paginate` call two lines above the fix). `gh release delete` has no such explicit target and falls back to auto-detecting the repository from the current git working directory, which does not exist in a checkout-less job, so every run of this job failed with `fatal: not a git repository (or any of the parent directories): .git`. That single job failure flips the whole `Build and Release` run's conclusion to `failure` even when every other job (all six platform builds, Create GitHub Release, Upload Release Assets, Publish Release, Update Latest Version) succeeds.

That failure has a second-order effect worth calling out: `docker.yml`'s `build-check` job and `helm-package.yml`'s `build-helm-package` job both gate on `github.event.workflow_run.conclusion == 'success'`, so a final tag's Docker images and Helm chart silently never build — there is no failed job to point at, the `workflow_run` event for them never reaches a running step at all. This is exactly what happened for `1.0.0-rc.4`: recovered by manually re-dispatching both workflows for that tag after the fact (`gh workflow run docker.yml -f version=1.0.0-rc.4`, `gh workflow run helm-package.yml -f version=1.0.0-rc.4`, both succeeded).

Add `--repo "${GITHUB_REPOSITORY}"` to the `gh release delete` call so the job no longer depends on git-context auto-detection. No other change to the cleanup logic.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"` — YAML parses.
- `actionlint .github/workflows/build.yml` — clean.
- `make pre-commit` — all checks passed.
- Not exercised end-to-end in CI (the failure only reproduces inside a real checkout-less Actions runner), but the fix mirrors the existing `--repository`/explicit-repo pattern already used by the sibling `gh api`, `gh release upload`, and `gh release edit`-adjacent calls in this same workflow file.

## Impact

CI-only change. Restores `cleanup-preview-releases` to actually succeeding, which in turn unblocks the downstream `docker.yml`/`helm-package.yml` `workflow_run` triggers for every future final tag. No RustFS binary, API, or config behavior changes.

## Additional Notes

`1.0.0-rc.4`'s own Docker images and Helm chart have already been published via manual `workflow_dispatch` while this fix was in flight, so this PR does not need to be treated as blocking for that release — it prevents the same silent gap on the next one.
