### PR TITLE
fix(ecstore): document audit/notify KVS divergence and fix auth_token redaction

### DIFF
--- a/crates/ecstore/src/config/audit.rs
+++ b/crates/ecstore/src/config/audit.rs
@@ -26,6 +26,14 @@ use std::sync::LazyLock;
 
 #[allow(clippy::declare_interior_mutable_const)]
 /// Default KVS for audit webhook settings.
+///
+/// `WEBHOOK_BATCH_SIZE`/`WEBHOOK_MAX_RETRY`/`WEBHOOK_RETRY_INTERVAL`/`WEBHOOK_HTTP_TIMEOUT`
+/// exist here but not in [`crate::config::notify::DEFAULT_NOTIFY_WEBHOOK_KVS`]. This mirrors
+/// MinIO upstream: `internal/logger/config.go`'s `DefaultAuditWebhookKVS` carries the same
+/// four keys with the same defaults (`"1"`/`"0"`/`"3s"`/`"5s"`), while
+/// `internal/config/notify/parse.go`'s `DefaultWebhookKVS` (bucket event notifications) does
+/// not — the notify webhook delivery path never supported them. Not a copy/paste gap
+/// (backlog#2054).
 pub static DEFAULT_AUDIT_WEBHOOK_KVS: LazyLock<KVS> = LazyLock::new(|| {
     KVS(vec![
         KV {
@@ -41,7 +49,7 @@ pub static DEFAULT_AUDIT_WEBHOOK_KVS: LazyLock<KVS> = LazyLock::new(|| {
         KV {
             key: WEBHOOK_AUTH_TOKEN.to_owned(),
             value: "".to_owned(),
-            hidden_if_empty: false,
+            hidden_if_empty: true, // Sensitive field; matches notify's webhook auth_token (backlog#2054)
         },
         KV {
             key: WEBHOOK_CLIENT_CERT.to_owned(),
@@ -103,6 +111,15 @@ pub static DEFAULT_AUDIT_WEBHOOK_KVS: LazyLock<KVS> = LazyLock::new(|| {
 
 #[allow(clippy::declare_interior_mutable_const)]
 /// Default KVS for audit MQTT settings.
+///
+/// `MQTT_QOS`/`MQTT_KEEP_ALIVE_INTERVAL`/`MQTT_RECONNECT_INTERVAL` default to a stronger
+/// delivery posture here (`"1"`/`"60s"`/`"5s"`) than
+/// [`crate::config::notify::DEFAULT_NOTIFY_MQTT_KVS`] (`"0"`/`"0s"`/`"0s"`, which matches
+/// MinIO's own `DefaultMQTTKVS` in `internal/config/notify/parse.go` byte-for-byte). MinIO has
+/// no MQTT audit target to compare against — audit-over-MQTT is a RustFS-original addition —
+/// so this divergence cannot be checked against upstream; it is intentional (audit favors
+/// at-least-once delivery and faster reconnect over notify's opt-in defaults), not a
+/// copy/paste gap (backlog#2054).
 pub static DEFAULT_AUDIT_MQTT_KVS: LazyLock<KVS> = LazyLock::new(|| {
     KVS(vec![
         KV {

--- a/crates/ecstore/src/config/notify.rs
+++ b/crates/ecstore/src/config/notify.rs
@@ -26,6 +26,12 @@ use std::sync::LazyLock;
 
 /// The default configuration collection of webhooks，
 /// Initialized only once during the program life cycle, enabling high-performance lazy loading.
+///
+/// This table has no `batch_size`/`max_retry`/`retry_interval`/`http_timeout` keys, unlike
+/// [`crate::config::audit::DEFAULT_AUDIT_WEBHOOK_KVS`] — matching MinIO upstream, whose
+/// `internal/config/notify/parse.go` `DefaultWebhookKVS` (bucket event notifications) also
+/// omits them while `internal/logger/config.go`'s `DefaultAuditWebhookKVS` carries them.
+/// Intentional, not a copy/paste gap (backlog#2054).
 pub static DEFAULT_NOTIFY_WEBHOOK_KVS: LazyLock<KVS> = LazyLock::new(|| {
     KVS(vec![
         KV {
@@ -83,6 +89,12 @@ pub static DEFAULT_NOTIFY_WEBHOOK_KVS: LazyLock<KVS> = LazyLock::new(|| {
 });
 
 /// MQTT's default configuration collection
+///
+/// `MQTT_QOS`/`MQTT_KEEP_ALIVE_INTERVAL`/`MQTT_RECONNECT_INTERVAL` default to `"0"`/`"0s"`/`"0s"`
+/// here, matching MinIO's `DefaultMQTTKVS` in `internal/config/notify/parse.go`
+/// byte-for-byte — this table is a faithful port. [`crate::config::audit::DEFAULT_AUDIT_MQTT_KVS`]
+/// uses stronger, RustFS-original defaults instead (MinIO has no MQTT audit target to compare
+/// against); that divergence is intentional, not a copy/paste gap (backlog#2054).
 pub static DEFAULT_NOTIFY_MQTT_KVS: LazyLock<KVS> = LazyLock::new(|| {
     KVS(vec![
         KV {


### PR DESCRIPTION
## What

Triages the three divergences rustfs/backlog#2054 found between `crates/ecstore/src/config/audit.rs` and `notify.rs`'s default KVS tables, cross-checked against MinIO upstream (`internal/logger/config.go`, `internal/config/notify/parse.go`).

**1. webhook: audit has 4 extra keys (`batch_size`/`max_retry`/`retry_interval`/`http_timeout`) — intentional, matches MinIO exactly.**
MinIO's `internal/logger/config.go` `DefaultAuditWebhookKVS` carries the same four keys with the same defaults (`"1"`/`"0"`/`"3s"`/`"5s"`); `internal/config/notify/parse.go`'s `DefaultWebhookKVS` (bucket event notifications) does not. Not changed — documented with a doc comment on each table.

**2. mqtt: audit's QoS/keep-alive/reconnect defaults are stronger than notify's — no MinIO precedent either way, kept as-is.**
MinIO's audit logging has no MQTT target at all (`internal/logger/config.go` has zero MQTT references) — this is a RustFS-original addition with nothing upstream to compare against. Notify's `"0"`/`"0s"`/`"0s"` defaults match MinIO's `DefaultMQTTKVS` byte-for-byte, confirming notify is a faithful port and audit's stronger posture (`"1"`/`"60s"`/`"5s"`) is RustFS's own choice. Not changed — documented as intentional (audit favoring at-least-once delivery and faster reconnect), with a note that this couldn't be verified against upstream.

**3. webhook `auth_token`'s `hidden_if_empty`: audit had `false`, notify had `true` — fixed to `true`.**
No MinIO precedent either way (this KVS version has no per-key hidden flag upstream). Fixed audit to match notify and every other sensitive key in both files (`MQTT_PASSWORD`, `*_TLS_*`). A non-empty token was already redacted identically on both sides via `ends_with("_token")` pattern matching in `config_admin.rs` — this only changes how an *unset* audit webhook `auth_token` renders (omitted instead of shown as an empty value).

## Verification

- `cargo fmt --all --check` — pass
- `cargo test -p rustfs-ecstore --lib config::` — 125 passed, 0 failed
- `cargo clippy -p rustfs-ecstore --all-targets -- -D warnings` — clean

## Adversarial self-check

- Confirmed via `config_admin.rs`'s redaction logic that item 3's behavior change is scoped to the empty-value case only — a configured (non-empty) `auth_token` is unaffected on either side.
- Ran the full `config::` test suite (125 tests, including the `target_defaults` literal-expectation tests added by backlog#2044/#2045/#2046) to confirm no existing assertion depended on the old `false`.
- Items 1 and 2 are pure doc-comment additions — zero behavior change, verified via `git diff` showing only comment insertions on those tables.

Refs rustfs/backlog#2054
