### PR TITLE
fix(ecstore): reject Azure tier storageClass/spAuth instead of silently ignoring them

### DIFF
--- a/crates/ecstore/src/services/tier/tier.rs
+++ b/crates/ecstore/src/services/tier/tier.rs
@@ -2545,6 +2545,24 @@ impl TierConfigMgr {
             })?;
         }
 
+        // The Azure warm backend goes through the same S3-compatible TransitionClient as every
+        // other provider (backlog#2055): it has no Azure Blob-native client and no Azure AD
+        // dependency, so `storage_class` and `sp_auth` cannot be honored today even though the
+        // config type carries them. Reject them explicitly here instead of silently accepting
+        // and then dropping them at the WarmBackendAzure construction boundary.
+        if matches!(&tier_config.tier_type, TierType::Azure)
+            && let Some(azure) = tier_config.azure.as_ref()
+        {
+            let sp_auth_set = !azure.sp_auth.tenant_id.is_empty()
+                || !azure.sp_auth.client_id.is_empty()
+                || !azure.sp_auth.client_secret.is_empty();
+            if !azure.storage_class.is_empty() || sp_auth_set {
+                let mut err = ERR_TIER_INVALID_CONFIG.clone();
+                err.message = "Azure remote tiers do not support storageClass or spAuth yet; leave both unset".to_string();
+                return Err(err);
+            }
+        }
+
         let d = new_warm_backend(&tier_config, true).await?;
 
         if !force {
@@ -6382,6 +6400,57 @@ mod tests {
         assert_eq!(err.code, ERR_TIER_INVALID_CONFIG.code);
         assert_eq!(err.message, "Wasabi endpoint must be https://s3.ap-northeast-1.wasabisys.com");
         assert!(mgr.tiers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_add_rejects_azure_storage_class_before_backend_setup() {
+        let mut mgr = empty_mgr();
+        let mut tier = build_azure_tier("account-a");
+        tier.azure.as_mut().expect("Azure payload should exist").storage_class = "HOT".to_string();
+
+        let err = mgr
+            .add(tier, true)
+            .await
+            .expect_err("a non-empty Azure storageClass must be rejected before backend setup");
+        assert_eq!(err.code, ERR_TIER_INVALID_CONFIG.code);
+        assert!(err.message.contains("storageClass"), "{}", err.message);
+        assert!(mgr.tiers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_add_rejects_azure_partial_sp_auth_before_backend_setup() {
+        // Only `tenant_id` is set: `TierAzure::is_sp_enabled()`-style "all three fields"
+        // logic would miss this, so the check must reject on *any* sp_auth sub-field
+        // being non-empty rather than requiring all three.
+        let mut mgr = empty_mgr();
+        let mut tier = build_azure_tier("account-a");
+        tier.azure.as_mut().expect("Azure payload should exist").sp_auth.tenant_id = "tenant".to_string();
+
+        let err = mgr
+            .add(tier, true)
+            .await
+            .expect_err("a partially-filled Azure spAuth must be rejected before backend setup");
+        assert_eq!(err.code, ERR_TIER_INVALID_CONFIG.code);
+        assert!(err.message.contains("spAuth"), "{}", err.message);
+        assert!(mgr.tiers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_add_does_not_reject_azure_config_without_storage_class_or_sp_auth() {
+        // A plain Azure config (the common case: static access/secret key, no
+        // storageClass, no spAuth) must sail past the new gate. `new_warm_backend`
+        // builds the S3-compatible client lazily (no eager DNS/connect), so with
+        // `force: true` (which also skips the `in_use` probe) this succeeds even
+        // against a fake endpoint — the point here is only that the gate itself
+        // does not fire.
+        let mut mgr = empty_mgr();
+        let tier = build_azure_tier("account-a");
+        let tier_name = tier.name.clone();
+
+        mgr.add(tier, true)
+            .await
+            .expect("a config with no storageClass/spAuth must not trip the new gate");
+        assert!(mgr.tiers.contains_key(&tier_name));
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/services/tier/tier_config.rs
+++ b/crates/ecstore/src/services/tier/tier_config.rs
@@ -646,12 +646,6 @@ pub struct TierAzure {
     pub sp_auth: ServicePrincipalAuth,
 }
 
-impl TierAzure {
-    pub fn is_sp_enabled(&self) -> bool {
-        !self.sp_auth.tenant_id.is_empty() && !self.sp_auth.client_id.is_empty() && !self.sp_auth.client_secret.is_empty()
-    }
-}
-
 /*
 fn AzureServicePrincipal(tenantID, clientID, clientSecret string) func(az *TierAzure) error {
   return func(az *TierAzure) error {


### PR DESCRIPTION
## What

`TierAzure.storage_class` and `.sp_auth` round-trip faithfully through the admin API and on-disk config (`ExternalTierAzure` encode/decode in `tier.rs`), so an operator can configure them, read them back via ListTier, and never learn they do nothing. They are dropped only at the `WarmBackendAzure` construction boundary: the Azure warm backend goes through the same S3-compatible `TransitionClient` as every other provider and has no Azure Blob-native client or Azure AD dependency (confirmed: no `azure_*` crate anywhere in the workspace `Cargo.toml`/`Cargo.lock`), so neither field can actually be honored today.

MinIO's reference implementation (`cmd/warm-backend-azure.go`) treats both as first-class: `storage_class` sets the blob access tier on every `PutWithMeta`/`Put`, and `sp_auth` is a full alternative to access/secret-key auth via `azidentity.NewClientSecretCredential`, mutually exclusive with it (`Validate()` rejects configs that set both or neither).

## Decision

The issue offered two options: implement real support (new Azure-native SDK dependency + a parallel non-S3-protocol client path — MinIO's own implementation needs `azure_core`/`azure_identity`/`azure_storage_blobs`, none of which this repo depends on today), or remove the fields entirely (a persisted-format break needing a compat migration, since `ExternalTierAzure` already ships these fields on the wire).

Both are substantially larger and riskier than the actual harm here (an operator silently misconfiguring a tier with no error). This PR takes the minimal safe middle ground: **reject** an Azure tier config with either field set, at `TierConfigMgr::add`, before backend construction — returning `ERR_TIER_INVALID_CONFIG` with an explicit message instead of silently accepting and ignoring. The fields stay in the config type (no format break); already-persisted tiers with these fields set are grandfathered in un-rejected (`edit` doesn't touch `sp_auth`/`storage_class` either, so there's no way to set them going forward except by editing the on-disk blob directly). Full native support remains a larger follow-up if ever prioritized.

Also removes `TierAzure::is_sp_enabled()`, which had zero callers repo-wide (the issue flagged this) and would have been misleading dead weight once this decision was made. Reusing it for the new gate would also have been wrong: it requires *all three* `sp_auth` sub-fields non-empty (`&&`), while the gate must reject on *any one* being set — a config with only `tenant_id` filled in would otherwise slip through undetected. Confirmed with a dedicated regression test.

## Verification

- `cargo fmt --all --check` — pass
- `cargo test -p rustfs-ecstore --lib services::tier::tier::tests::test_add_` — 9 passed, 0 failed
- `cargo clippy -p rustfs-ecstore --all-targets -- -D warnings` — clean

## Adversarial self-check (correctness / compatibility)

- Placed the new gate after the existing Wasabi `normalize_endpoint()` block and before `new_warm_backend(...).await?` — purely local, no network round trip, matching the existing pattern for pre-backend-construction rejection.
- Three new tests: non-empty `storage_class` rejected; a *partially*-filled `sp_auth` (only `tenant_id`) rejected — the case `is_sp_enabled()`'s `&&` semantics would have missed; and a plain config (no `storage_class`/`sp_auth`) is accepted (`Ok`), proving the gate doesn't false-positive on the common case.
- Confirmed `grep -rn "is_sp_enabled"` across `crates/` and `rustfs/` returns zero hits after removal.
- Confirmed `edit` (`TierConfigMgr::edit`, Azure arm) only touches `access_key`/`secret_key` and never `sp_auth`/`storage_class` — the grandfathering gap is real but narrow and pre-existing, not introduced by this change.
- The error message reaches the client verbatim: `ERR_TIER_INVALID_CONFIG`'s arm in `rustfs/src/admin/handlers/tier.rs` forwards `err.message` unmodified as an `S3ErrorCode::InvalidArgument`, unlike the other tier-error arms which hardcode a fixed string — no handler change needed.

Refs rustfs/backlog#2055
