### PR TITLE
fix: provide cross-repo token for auto-testing checkout

### DIFF
--- a/.github/workflows/rustfs-heal-test.yml
+++ b/.github/workflows/rustfs-heal-test.yml
@@ -66,6 +66,7 @@ jobs:
           ref: main
           path: auto-testing
           persist-credentials: false
+          token: ${{ secrets.PF_TESTING_GH_TOKEN }}
 
       - name: Show environment
         run: |

--- a/.github/workflows/rustfs-performance-test.yml
+++ b/.github/workflows/rustfs-performance-test.yml
@@ -96,6 +96,7 @@ jobs:
           ref: main
           path: auto-testing
           persist-credentials: false
+          token: ${{ secrets.PF_TESTING_GH_TOKEN }}
 
       - name: Show environment
         run: |

--- a/.github/workflows/rustfs-pool-expand-test.yml
+++ b/.github/workflows/rustfs-pool-expand-test.yml
@@ -92,6 +92,7 @@ jobs:
           ref: main
           path: auto-testing
           persist-credentials: false
+          token: ${{ secrets.PF_TESTING_GH_TOKEN }}
 
       - name: Run S3 compatibility suite
         run: |
@@ -135,6 +136,7 @@ jobs:
           ref: main
           path: auto-testing
           persist-credentials: false
+          token: ${{ secrets.PF_TESTING_GH_TOKEN }}
 
       - name: Ensure docker (Vault container)
         run: |
@@ -187,6 +189,7 @@ jobs:
           ref: main
           path: auto-testing
           persist-credentials: false
+          token: ${{ secrets.PF_TESTING_GH_TOKEN }}
 
       - name: Ensure MQTT broker + clients (event notification tests)
         run: |
@@ -242,6 +245,7 @@ jobs:
           ref: main
           path: auto-testing
           persist-credentials: false
+          token: ${{ secrets.PF_TESTING_GH_TOKEN }}
 
       - name: Show environment
         run: |
@@ -337,6 +341,7 @@ jobs:
           ref: main
           path: auto-testing
           persist-credentials: false
+          token: ${{ secrets.PF_TESTING_GH_TOKEN }}
 
       - name: Reset test environment (before)
         if: ${{ inputs.cleanup_before != 'false' }}


### PR DESCRIPTION
The test workflows checkout the private rustfs/auto-testing repository, but the default GITHUB_TOKEN only has access to rustfs/rustfs, so every checkout failed with `fatal: repository 'https://github.com/rustfs/auto-testing/' not found` (all nightly test runs on 2026-08-28 failed at the checkout step).

Passes `secrets.PF_TESTING_GH_TOKEN` (the existing cross-repo PAT already used by the performance workflow) to the auto-testing checkout steps in all three workflows:

- rustfs-pool-expand-test.yml (5 jobs)
- rustfs-heal-test.yml (1 job)
- rustfs-performance-test.yml (1 job)

Note: if PF_TESTING_GH_TOKEN is a fine-grained token scoped only to rustfs/backlog, a dedicated PAT with read access to rustfs/auto-testing will be needed instead.