### PR TITLE
ci: make MQTT broker setup deterministic in functional test suite

### DIFF
--- a/.github/workflows/rustfs-pool-expand-test.yml
+++ b/.github/workflows/rustfs-pool-expand-test.yml
@@ -197,11 +197,25 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y mosquitto mosquitto-clients
           fi
+          # Make restart deterministic on shared runners: stop any previous
+          # mosquitto instance/process and drop stale config first.
+          sudo systemctl stop mosquitto 2>/dev/null || true
+          sudo pkill -f mosquitto 2>/dev/null || true
+          sleep 1
+          sudo rm -f /etc/mosquitto/conf.d/rustfs-test.conf
           sudo mkdir -p /etc/mosquitto/conf.d
           printf 'listener 1883 0.0.0.0\nallow_anonymous true\n' | sudo tee /etc/mosquitto/conf.d/rustfs-test.conf >/dev/null
-          sudo systemctl restart mosquitto
+          sudo systemctl reset-failed mosquitto 2>/dev/null || true
+          sudo systemctl start mosquitto
           sleep 2
-          ss -tln 2>/dev/null | grep -q ':1883' || { echo "mosquitto not listening on 1883"; exit 1; }
+          if ! ss -tln 2>/dev/null | grep -q ':1883'; then
+            echo "=== mosquitto status ==="
+            sudo systemctl status mosquitto --no-pager | head -20 || true
+            echo "=== mosquitto journal ==="
+            sudo journalctl -u mosquitto -n 30 --no-pager || true
+            echo "mosquitto not listening on 1883"
+            exit 1
+          fi
 
       - name: Run tier / event / audit suite
         run: |

--- a/.github/workflows/rustfs-pool-expand-test.yml
+++ b/.github/workflows/rustfs-pool-expand-test.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       rustfs_version:
-        description: 'RustFS release tag to test (e.g. 1.0.0-rc.3)'
+        description: 'RustFS release tag to test (leave empty to use the latest nightly deb)'
         required: false
-        default: '1.0.0-rc.3'
       package_url:
         description: 'Direct .deb URL (nightly/R2/dev). Overrides rustfs_version.'
         required: false


### PR DESCRIPTION
## Problem

The "Ensure MQTT broker + clients" step in the functional test suite (rustfs-pool-expand-test.yml) failed with `Job for mosquitto.service failed` on the shared runner — a previous mosquitto instance/config can leave the service unable to restart.

## Fix

Make the setup deterministic:

- stop/pkill any previous mosquitto and drop the stale `rustfs-test.conf`
- `systemctl reset-failed` before start
- on failure, print `systemctl status` + `journalctl` so the root cause is visible in CI logs