### PR TITLE
fix(s3): return BadDigest for Content-MD5 mismatch

### DIFF
--- a/crates/rio/src/etag_reader.rs
+++ b/crates/rio/src/etag_reader.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::compress_index::{Index, TryGetIndex};
-use crate::{EtagResolvable, HashReaderDetector, HashReaderMut};
+use crate::{BadDigest, EtagResolvable, HashReaderDetector, HashReaderMut};
 use md5::{Digest, Md5};
 use pin_project_lite::pin_project;
 use std::pin::Pin;
@@ -89,7 +89,13 @@ where
                     && *checksum != etag
                 {
                     error!("Checksum mismatch, expected={:?}, actual={:?}", checksum, etag);
-                    return Poll::Ready(Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "Checksum mismatch")));
+                    return Poll::Ready(Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        BadDigest {
+                            expected_md5: checksum.clone(),
+                            calculated_md5: etag,
+                        },
+                    )));
                 }
             }
         }
@@ -255,6 +261,7 @@ mod tests {
     async fn test_etag_reader_checksum_mismatch() {
         let data = b"checksum test data";
         let wrong_checksum = "deadbeefdeadbeefdeadbeefdeadbeef".to_string();
+        let calculated_md5 = hex_simd::encode_to_string(Md5::digest(data), hex_simd::AsciiCase::Lower);
         let reader = BufReader::new(&data[..]);
         let mut etag_reader = EtagReader::new(reader, Some(wrong_checksum.clone()));
 
@@ -262,5 +269,11 @@ mod tests {
         // Verification failed, should return InvalidData error
         let err = etag_reader.read_to_end(&mut buf).await.unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        let digest = err
+            .get_ref()
+            .and_then(|source| source.downcast_ref::<BadDigest>())
+            .expect("checksum mismatch should preserve the BadDigest type");
+        assert_eq!(digest.expected_md5, wrong_checksum);
+        assert_eq!(digest.calculated_md5, calculated_md5);
     }
 }

--- a/rustfs/src/error.rs
+++ b/rustfs/src/error.rs
@@ -622,6 +622,21 @@ mod tests {
     }
 
     #[test]
+    fn content_md5_mismatch_io_errors_map_to_bad_digest() {
+        let bad_digest = || rustfs_rio::BadDigest {
+            expected_md5: "expected".to_string(),
+            calculated_md5: "calculated".to_string(),
+        };
+        let api_error = ApiError::from(IoError::new(ErrorKind::InvalidData, bad_digest()));
+        assert_eq!(api_error.code, S3ErrorCode::BadDigest);
+        assert_eq!(api_error.message, ApiError::error_code_to_message(&S3ErrorCode::BadDigest));
+
+        let api_error = ApiError::from(StorageError::Io(IoError::new(ErrorKind::InvalidData, bad_digest())));
+        assert_eq!(api_error.code, S3ErrorCode::BadDigest);
+        assert_eq!(api_error.message, ApiError::error_code_to_message(&S3ErrorCode::BadDigest));
+    }
+
+    #[test]
     fn upload_stream_sha256_mismatch_maps_to_bad_digest() {
         let api_error = ApiError::from(IoError::other(MockUploadStreamError::Sha256Mismatch));
         assert_eq!(api_error.code, S3ErrorCode::BadDigest);


### PR DESCRIPTION
## Related Issues

Fixes #6829

## Summary of Changes

- Preserve the existing `BadDigest` type when `EtagReader` detects a `Content-MD5` mismatch.
- Cover direct I/O and storage-wrapped error mapping to the S3 `BadDigest` response.

## Verification

- `cargo fmt --all --check`
- `cargo test -p rustfs-rio etag_reader::tests`
- `cargo test -p rustfs content_md5_mismatch_io_errors_map_to_bad_digest --lib`
- `make pre-pr`

## Impact

A mismatched `Content-MD5` now returns the expected S3 `BadDigest` error instead of `InternalError`. Matching uploads are unchanged.

## Additional Notes

Adversarial review: the typed source survives both error paths and is covered at the API boundary; the public error remains fixed and non-secret; the change is limited to the mismatch path with one existing checksum clone.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
