### PR TITLE
ci: pass package selector to test run steps (fix rc.3 fallback)

### DIFF
--- a/.github/workflows/rustfs-pool-expand-test.yml
+++ b/.github/workflows/rustfs-pool-expand-test.yml
@@ -309,12 +309,19 @@ jobs:
               STEPS="$STEPS,9"
             fi
           fi
-          ./auto-testing/rustfs_pool_expand.sh \
-            --steps "$STEPS" --with-warp -y \
+          ARGS=(--steps "$STEPS" --with-warp -y \
             --endpoint "${{ env.RUSTFS_API_ENDPOINT }}" \
             --storage-threshold "${{ inputs.storage_threshold || '50' }}" \
             --warp-duration "${{ inputs.warp_duration || '10m' }}" \
-            --log-file /tmp/rustfs-pool-test.log
+            --log-file /tmp/rustfs-pool-test.log)
+          if [ -n "${{ inputs.package_url }}" ]; then
+            ARGS+=(--package-url "${{ inputs.package_url }}")
+          elif [ -n "${{ inputs.rustfs_version }}" ]; then
+            ARGS+=(--version "${{ inputs.rustfs_version }}")
+          else
+            ARGS+=(--package-url "${{ env.RUSTFS_NIGHTLY_PACKAGE_URL }}")
+          fi
+          ./auto-testing/rustfs_pool_expand.sh "${ARGS[@]}"
 
       - name: Upload test logs
         if: always()
@@ -384,12 +391,17 @@ jobs:
 
       - name: Run heal test (write -> outage -> heal -> verify)
         run: |
-          ./auto-testing/rustfs_heal_test.sh \
-            --steps 3,4,5,6,7 -y \
+          ARGS=(--steps 3,4,5,6,7 -y \
             --endpoint "${{ env.RUSTFS_API_ENDPOINT }}" \
             --stop-node-gb "${{ inputs.stop_node_gb || '15' }}" \
             --warp-stop-gb "${{ inputs.warp_stop_gb || '40' }}" \
-            --log-file /tmp/rustfs-heal-test.log
+            --log-file /tmp/rustfs-heal-test.log)
+          if [ -n "${{ inputs.package_url }}" ]; then
+            ARGS+=(--package-url "${{ inputs.package_url }}")
+          else
+            ARGS+=(--package-url "${{ env.RUSTFS_NIGHTLY_PACKAGE_URL }}")
+          fi
+          ./auto-testing/rustfs_heal_test.sh "${ARGS[@]}"
 
       - name: Upload test logs
         if: always()


### PR DESCRIPTION
## Problem

The install/preflight steps in the pool-expansion/heal workflow pass `--package-url` / `--version`, but the **run** steps did not. The pool-expand script's own default (`1.0.0-rc.3`) was therefore used for steps 4-9 even when the install used a different package (e.g. rc.4-preview.1 or nightly). Noted in rustfs/backlog#2063 as a harness inconsistency that misleads reproduction.

## Fix

Build the same package-selector args in the run steps:

- pool run: `package_url` -> `--package-url`; elif `rustfs_version` -> `--version`; else `--package-url` nightly latest
- heal run: `package_url` -> `--package-url`; else `--package-url` nightly latest