### PR TITLE
fix(scanner): retain completed candidates during proof retries

### DIFF
--- a/crates/ecstore/src/api/mod.rs
+++ b/crates/ecstore/src/api/mod.rs
@@ -405,7 +405,7 @@ pub mod notification {
     pub use crate::services::notification_sys::{
         CrossPoolFenceFleetProofToken, NotificationPeerErr, NotificationSys, ScannerPublicationLeaseGrant,
         acquire_cross_pool_fence_fleet_proof, cross_pool_fence_fleet_proof_matches, get_global_notification_sys,
-        new_global_notification_sys, start_remote_version_state_fleet_probe,
+        new_global_notification_sys, scanner_peer_transport_error_message_is_retryable, start_remote_version_state_fleet_probe,
     };
 }
 

--- a/crates/ecstore/src/cluster/rpc/peer_rest_client.rs
+++ b/crates/ecstore/src/cluster/rpc/peer_rest_client.rs
@@ -725,7 +725,7 @@ impl PeerRestClient {
     /// never take it offline no matter what its message says. The substring
     /// fallback only covers failures that exist purely as text, such as the
     /// dial errors `get_client` wraps.
-    fn is_network_like_error(err: &Error) -> bool {
+    pub(crate) fn is_network_like_error(err: &Error) -> bool {
         if let Error::Io(io_err) = err
             && let Some(status) = embedded_tonic_status(io_err)
         {

--- a/crates/ecstore/src/services/notification_sys.rs
+++ b/crates/ecstore/src/services/notification_sys.rs
@@ -1970,7 +1970,11 @@ where
 {
     timeout(timeout_duration, activity)
         .await
-        .map_err(|_| Error::other(format!("scanner activity peer {host} timed out after {timeout_duration:?}")))?
+        .map_err(|_| scanner_activity_timeout_error(host, timeout_duration))?
+}
+
+fn scanner_activity_timeout_error(host: &str, timeout_duration: Duration) -> Error {
+    Error::RemoteClientUnavailable(format!("scanner activity peer {host} timed out after {timeout_duration:?}"))
 }
 
 async fn scanner_activity_with_reconnect_retry<Activity, ActivityFuture, Retry, RetryFuture, Retryable>(
@@ -2010,7 +2014,7 @@ where
     })
     .await;
 
-    result.map_err(|_| Error::other(format!("scanner activity peer {host} timed out after {timeout_duration:?}")))?
+    result.map_err(|_| scanner_activity_timeout_error(host, timeout_duration))?
 }
 
 pub fn scanner_peer_transport_error_message_is_retryable(error: &str) -> bool {
@@ -2934,6 +2938,7 @@ mod tests {
         .await
         .expect_err("a stalled peer must not block scanner scheduling");
 
+        assert!(matches!(err, Error::RemoteClientUnavailable(_)));
         assert!(err.to_string().contains("timed out"));
         assert!(err.to_string().contains("peer-1"));
     }
@@ -2967,6 +2972,7 @@ mod tests {
         .await
         .expect_err("a stalled retry must remain inside the first attempt's deadline");
 
+        assert!(matches!(err, Error::RemoteClientUnavailable(_)));
         assert!(err.to_string().contains("timed out"));
         assert!(err.to_string().contains("peer-1"));
         assert_eq!(attempts.load(Ordering::SeqCst), 2);

--- a/crates/ecstore/src/services/notification_sys.rs
+++ b/crates/ecstore/src/services/notification_sys.rs
@@ -1483,9 +1483,20 @@ impl NotificationSys {
             futures.push(async move {
                 let client = client.ok_or_else(|| Error::other(format!("scanner activity peer[{idx}] is unreachable")))?;
                 let host = client.grid_host.clone();
-                scanner_activity_with_timeout(SCANNER_ACTIVITY_PROBE_TIMEOUT, &host, client.scanner_activity())
-                    .await
-                    .map(|activity| (host, activity))
+                let activity_client = client.clone();
+                let retry_client = client.clone();
+                scanner_activity_with_reconnect_retry(
+                    SCANNER_ACTIVITY_PROBE_TIMEOUT,
+                    &host,
+                    move || {
+                        let client = activity_client.clone();
+                        async move { client.scanner_activity().await }
+                    },
+                    move || async move { retry_client.prepare_retry().await },
+                    PeerRestClient::is_network_like_error,
+                )
+                .await
+                .map(|activity| (host, activity))
             });
         }
 
@@ -1962,6 +1973,50 @@ where
         .map_err(|_| Error::other(format!("scanner activity peer {host} timed out after {timeout_duration:?}")))?
 }
 
+async fn scanner_activity_with_reconnect_retry<Activity, ActivityFuture, Retry, RetryFuture, Retryable>(
+    timeout_duration: Duration,
+    host: &str,
+    mut activity: Activity,
+    retry: Retry,
+    retryable: Retryable,
+) -> Result<ScannerPeerActivity>
+where
+    Activity: FnMut() -> ActivityFuture,
+    ActivityFuture: Future<Output = Result<ScannerPeerActivity>>,
+    Retry: FnOnce() -> RetryFuture,
+    RetryFuture: Future<Output = ()>,
+    Retryable: FnOnce(&Error) -> bool,
+{
+    let result = timeout(timeout_duration, async {
+        match activity().await {
+            Ok(snapshot) => Ok(snapshot),
+            Err(first_error) => {
+                if !retryable(&first_error) {
+                    return Err(first_error);
+                }
+                debug!(
+                    event = EVENT_NOTIFICATION_CAPABILITY_PROBE,
+                    component = LOG_COMPONENT_ECSTORE,
+                    subsystem = LOG_SUBSYSTEM_NOTIFICATION,
+                    state = "scanner_activity_reconnect",
+                    peer = host,
+                    error = %first_error,
+                    "notification capability probe reconnect"
+                );
+                retry().await;
+                activity().await
+            }
+        }
+    })
+    .await;
+
+    result.map_err(|_| Error::other(format!("scanner activity peer {host} timed out after {timeout_duration:?}")))?
+}
+
+pub fn scanner_peer_transport_error_message_is_retryable(error: &str) -> bool {
+    crate::cluster::rpc::client::message_has_network_needle(error)
+}
+
 #[allow(dead_code, reason = "asserted by this file's tests (backlog#1823)")]
 async fn call_peer_with_timeout<F, Fut>(
     timeout_dur: Duration,
@@ -2422,6 +2477,7 @@ fn aggregate_scanner_dirty_usage_acknowledgement_results(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn remote_version_state_fleet_proof_rejects_stale_or_mismatched_membership() {
@@ -2880,6 +2936,115 @@ mod tests {
 
         assert!(err.to_string().contains("timed out"));
         assert!(err.to_string().contains("peer-1"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn scanner_activity_reconnect_stays_within_the_original_probe_deadline() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let reconnects = Arc::new(AtomicUsize::new(0));
+        let activity_attempts = attempts.clone();
+        let retry_reconnects = reconnects.clone();
+        let started_at = tokio::time::Instant::now();
+
+        let err = scanner_activity_with_reconnect_retry(
+            Duration::from_millis(5),
+            "peer-1",
+            move || {
+                let attempt = activity_attempts.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    if attempt == 0 {
+                        Err(Error::RemoteClientUnavailable("peer peer-1 is temporarily offline".to_string()))
+                    } else {
+                        std::future::pending::<Result<ScannerPeerActivity>>().await
+                    }
+                }
+            },
+            move || async move {
+                retry_reconnects.fetch_add(1, Ordering::SeqCst);
+            },
+            PeerRestClient::is_network_like_error,
+        )
+        .await
+        .expect_err("a stalled retry must remain inside the first attempt's deadline");
+
+        assert!(err.to_string().contains("timed out"));
+        assert!(err.to_string().contains("peer-1"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(reconnects.load(Ordering::SeqCst), 1);
+        assert_eq!(started_at.elapsed(), Duration::from_millis(5));
+    }
+
+    #[tokio::test]
+    async fn scanner_activity_probe_reconnects_once_within_the_probe_deadline() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let reconnects = Arc::new(AtomicUsize::new(0));
+        let activity_attempts = attempts.clone();
+        let retry_reconnects = reconnects.clone();
+        let expected = ScannerPeerActivity {
+            instance_id: "0123456789abcdef0123456789abcdef".to_string(),
+            namespace_generation: 1,
+            maintenance_generation: 2,
+            protocol_version: 7,
+            topology_digest: Some([3; 32]),
+            data_movement_active: Some(false),
+            dirty_usage_generation: Some(4),
+            dirty_usage_pending: Some(false),
+            movement_generation: Some(5),
+            publication_blocked: Some(false),
+        };
+        let activity_snapshot = expected.clone();
+
+        let snapshot = scanner_activity_with_reconnect_retry(
+            Duration::from_secs(1),
+            "peer-1",
+            move || {
+                let attempt = activity_attempts.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    if attempt == 0 {
+                        Err(Error::RemoteClientUnavailable("peer peer-1 is temporarily offline".to_string()))
+                    } else {
+                        Ok(activity_snapshot.clone())
+                    }
+                }
+            },
+            move || async move {
+                retry_reconnects.fetch_add(1, Ordering::SeqCst);
+            },
+            PeerRestClient::is_network_like_error,
+        )
+        .await
+        .expect("a quick offline failure should reconnect and retry once");
+
+        assert_eq!(snapshot, expected);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(reconnects.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn scanner_activity_probe_does_not_reconnect_for_application_errors() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let reconnects = Arc::new(AtomicUsize::new(0));
+        let activity_attempts = attempts.clone();
+        let retry_reconnects = reconnects.clone();
+
+        let err = scanner_activity_with_reconnect_retry(
+            Duration::from_secs(1),
+            "peer-1",
+            move || {
+                activity_attempts.fetch_add(1, Ordering::SeqCst);
+                async { Err(Error::NotImplemented) }
+            },
+            move || async move {
+                retry_reconnects.fetch_add(1, Ordering::SeqCst);
+            },
+            PeerRestClient::is_network_like_error,
+        )
+        .await
+        .expect_err("an application error must remain visible without reconnecting");
+
+        assert!(matches!(err, Error::NotImplemented));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(reconnects.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/services/notification_sys.rs
+++ b/crates/ecstore/src/services/notification_sys.rs
@@ -3005,11 +3005,12 @@ mod tests {
             "peer-1",
             move || {
                 let attempt = activity_attempts.fetch_add(1, Ordering::SeqCst);
+                let activity_snapshot = activity_snapshot.clone();
                 async move {
                     if attempt == 0 {
                         Err(Error::RemoteClientUnavailable("peer peer-1 is temporarily offline".to_string()))
                     } else {
-                        Ok(activity_snapshot.clone())
+                        Ok(activity_snapshot)
                     }
                 }
             },

--- a/crates/scanner/src/scanner.rs
+++ b/crates/scanner/src/scanner.rs
@@ -2937,8 +2937,9 @@ use usage_store::*;
 
 pub use activity::scanner_topology_digest;
 pub(crate) use activity::{
-    ScannerActivitySnapshot, ScannerDirtyUsageAcknowledgement, probe_scanner_activity, scanner_activity_allows_usage_publication,
-    scanner_activity_publication_lease_targets, scanner_activity_snapshot_digest, scanner_dirty_usage_acknowledgements,
+    ScannerActivitySnapshot, ScannerDirtyUsageAcknowledgement, await_scanner_publication_activity, probe_scanner_activity,
+    scanner_activity_allows_usage_publication, scanner_activity_publication_lease_targets, scanner_activity_snapshot_digest,
+    scanner_dirty_usage_acknowledgements,
 };
 pub(crate) use activity::{ScannerCycleOutcome, scanner_cycle_outcome_with_pending_maintenance};
 #[cfg(test)]

--- a/crates/scanner/src/scanner.rs
+++ b/crates/scanner/src/scanner.rs
@@ -108,6 +108,10 @@ const CLEAN_IDLE_BACKOFF_FACTOR: u32 = 2;
 /// unavailable peer cannot drive a tight retry loop.
 const SCANNER_RETRY_BASE_INTERVAL: Duration = Duration::from_secs(5);
 const SCANNER_RETRY_MAX_INTERVAL: Duration = Duration::from_secs(30 * 60);
+/// Keep a structurally complete scan in memory while its cluster publication
+/// proof is temporarily unavailable. The short cap makes recovery prompt
+/// without turning an unavailable peer into another namespace scan loop.
+const SCANNER_PUBLICATION_PROOF_RETRY_MAX_INTERVAL: Duration = Duration::from_secs(30);
 /// A transient backend outage remains self-healing after the short retry
 /// budget is exhausted, but the probe is intentionally sparse until storage
 /// recovers or an operator reset wakes the scanner.
@@ -142,6 +146,13 @@ static SCANNER_CYCLE_RECOVERY_WAKE: LazyLock<Notify> = LazyLock::new(Notify::new
 
 fn remote_publication_lease_fence_targets_are_required(target_count: usize, grants_present: bool, fence_present: bool) -> bool {
     target_count > 0 && (!grants_present || !fence_present)
+}
+
+fn data_usage_persist_outcome_after_lease_failure(outcome: DataUsagePersistOutcome) -> DataUsagePersistOutcome {
+    match outcome {
+        DataUsagePersistOutcome::Failed | DataUsagePersistOutcome::NoUpdate => outcome,
+        _ => DataUsagePersistOutcome::Deferred(ScannerCycleDeferReason::ActivityBaselineUnavailable),
+    }
 }
 
 pub(super) fn notify_scanner_cycle_recovery_wake() {
@@ -1462,7 +1473,16 @@ async fn run_data_scanner_cycle_with_budget(
         {
             Some(ScannerCycleDeferReason::DataMovement)
         }
-        Ok(result) => final_data_usage_publication_defer_reason(storeapi.as_ref(), result.status).await,
+        Ok(result) => {
+            let publication_proof_ctx = cycle_budget.token();
+            final_data_usage_publication_defer_reason(
+                &publication_proof_ctx,
+                cycle_info.current,
+                storeapi.as_ref(),
+                result.status,
+            )
+            .await
+        }
         Err(_) => Some(ScannerCycleDeferReason::ActivityBaselineUnavailable),
     };
     let publication_deferred = publication_defer_reason.is_some();
@@ -1485,15 +1505,23 @@ async fn run_data_scanner_cycle_with_budget(
         // allowing the peer to admit movement while a local PUT is in flight.
         Some(ScannerCycleDeferReason::ActivityBaselineUnavailable)
     } else if let Some(notification_system) = storeapi.notification_system() {
-        match notification_system
-            .acquire_scanner_publication_leases(remote_publication_lease_targets.clone())
-            .await
-        {
-            Ok(grants) => {
+        let publication_proof_ctx = cycle_budget.token();
+        let lease_result = await_scanner_publication_proof(
+            &publication_proof_ctx,
+            cycle_info.current,
+            "lease_acquire",
+            || notification_system.acquire_scanner_publication_leases(remote_publication_lease_targets.clone()),
+            |err| scanner_publication_lease_error_is_retryable(&err.to_string()),
+        )
+        .await;
+        match lease_result {
+            ScannerPublicationProofWait::Ready(grants) => {
                 remote_publication_leases = Some((notification_system, grants));
                 None
             }
-            Err(_) => Some(ScannerCycleDeferReason::ActivityBaselineUnavailable),
+            ScannerPublicationProofWait::Rejected(_) | ScannerPublicationProofWait::Cancelled => {
+                Some(ScannerCycleDeferReason::ActivityBaselineUnavailable)
+            }
         }
     } else {
         Some(ScannerCycleDeferReason::ActivityBaselineUnavailable)
@@ -1546,24 +1574,33 @@ async fn run_data_scanner_cycle_with_budget(
         .then_some(ScannerCycleDeferReason::ActivityBaselineUnavailable)
         .or(publication_defer_reason);
     let budget_elapsed = cycle_budget.budget_elapsed() && !ctx.is_cancelled();
+    let cycle_stopped_before_persist = cycle_budget.token().is_cancelled();
     let remote_lease_probe = remote_publication_leases
         .as_ref()
         .map(|(notification_system, grants)| (Arc::clone(notification_system), grants.clone()));
-    let mut usage_persist_outcome = match publication_defer_reason {
-        Some(reason) => {
-            drop(receiver);
-            DataUsagePersistOutcome::Deferred(reason)
-        }
-        None => {
-            // ScannerIO emits its complete or observational update only after
-            // all set workers finish. Persist after the final activity fence;
-            // this also avoids blocking the scanner on a denied publication.
-            let storeapi_clone = storeapi.clone();
-            let ctx_clone = ctx.clone();
-            let route_probe_store = storeapi.clone();
-            let remote_lease_fence = remote_lease_fence.clone();
-            let mut usage_persist_task = AbortOnDropHandle::new(tokio::spawn(async move {
-                store_data_usage_in_backend_with_outcome_for_epoch_and_baseline_and_route_probe_for_publication_epoch_and_lease_fence(
+    let mut usage_persist_outcome = if cycle_stopped_before_persist {
+        // The retained candidate belongs to this cycle budget and leader
+        // context. Drop it without turning an intentional stop into another
+        // activity deferral; the existing cancellation/budget paths below
+        // decide whether to stop or persist a partial cursor.
+        drop(receiver);
+        DataUsagePersistOutcome::NoUpdate
+    } else {
+        match publication_defer_reason {
+            Some(reason) => {
+                drop(receiver);
+                DataUsagePersistOutcome::Deferred(reason)
+            }
+            None => {
+                // ScannerIO emits its complete or observational update only after
+                // all set workers finish. Persist after the final activity fence;
+                // this also avoids blocking the scanner on a denied publication.
+                let storeapi_clone = storeapi.clone();
+                let ctx_clone = ctx.clone();
+                let route_probe_store = storeapi.clone();
+                let remote_lease_fence = remote_lease_fence.clone();
+                let mut usage_persist_task = AbortOnDropHandle::new(tokio::spawn(async move {
+                    store_data_usage_in_backend_with_outcome_for_epoch_and_baseline_and_route_probe_for_publication_epoch_and_lease_fence(
                     ctx_clone,
                     storeapi_clone,
                     receiver,
@@ -1591,46 +1628,47 @@ async fn run_data_scanner_cycle_with_budget(
                     },
                 )
                 .await
-            }));
-            match wait_for_data_usage_persist_task(ctx, &mut usage_persist_task, usage_persist_timeout).await {
-                DataUsagePersistTaskResult::Completed(outcome) => outcome,
-                DataUsagePersistTaskResult::JoinFailed(err) => {
-                    error!(
-                        target: "rustfs::scanner",
-                        event = EVENT_SCANNER_PERSIST_STATE,
-                        component = LOG_COMPONENT_SCANNER,
-                        subsystem = LOG_SUBSYSTEM_RUNTIME,
-                        cycle = cycle_info.current,
-                        state = "usage_persist_task_failed",
-                        error = %err,
-                        "Scanner data usage persistence task failed"
-                    );
-                    DataUsagePersistOutcome::Failed
-                }
-                DataUsagePersistTaskResult::Cancelled => {
-                    debug!(
-                        target: "rustfs::scanner",
-                        event = EVENT_SCANNER_PERSIST_STATE,
-                        component = LOG_COMPONENT_SCANNER,
-                        subsystem = LOG_SUBSYSTEM_RUNTIME,
-                        cycle = cycle_info.current,
-                        state = "usage_persist_task_cancelled",
-                        "Scanner data usage persistence task cancelled"
-                    );
-                    DataUsagePersistOutcome::Failed
-                }
-                DataUsagePersistTaskResult::TimedOut => {
-                    error!(
-                        target: "rustfs::scanner",
-                        event = EVENT_SCANNER_PERSIST_STATE,
-                        component = LOG_COMPONENT_SCANNER,
-                        subsystem = LOG_SUBSYSTEM_RUNTIME,
-                        cycle = cycle_info.current,
-                        timeout = ?usage_persist_timeout,
-                        state = "usage_persist_task_timed_out",
-                        "Scanner data usage persistence task timed out"
-                    );
-                    DataUsagePersistOutcome::Failed
+                }));
+                match wait_for_data_usage_persist_task(ctx, &mut usage_persist_task, usage_persist_timeout).await {
+                    DataUsagePersistTaskResult::Completed(outcome) => outcome,
+                    DataUsagePersistTaskResult::JoinFailed(err) => {
+                        error!(
+                            target: "rustfs::scanner",
+                            event = EVENT_SCANNER_PERSIST_STATE,
+                            component = LOG_COMPONENT_SCANNER,
+                            subsystem = LOG_SUBSYSTEM_RUNTIME,
+                            cycle = cycle_info.current,
+                            state = "usage_persist_task_failed",
+                            error = %err,
+                            "Scanner data usage persistence task failed"
+                        );
+                        DataUsagePersistOutcome::Failed
+                    }
+                    DataUsagePersistTaskResult::Cancelled => {
+                        debug!(
+                            target: "rustfs::scanner",
+                            event = EVENT_SCANNER_PERSIST_STATE,
+                            component = LOG_COMPONENT_SCANNER,
+                            subsystem = LOG_SUBSYSTEM_RUNTIME,
+                            cycle = cycle_info.current,
+                            state = "usage_persist_task_cancelled",
+                            "Scanner data usage persistence task cancelled"
+                        );
+                        DataUsagePersistOutcome::Failed
+                    }
+                    DataUsagePersistTaskResult::TimedOut => {
+                        error!(
+                            target: "rustfs::scanner",
+                            event = EVENT_SCANNER_PERSIST_STATE,
+                            component = LOG_COMPONENT_SCANNER,
+                            subsystem = LOG_SUBSYSTEM_RUNTIME,
+                            cycle = cycle_info.current,
+                            timeout = ?usage_persist_timeout,
+                            state = "usage_persist_task_timed_out",
+                            "Scanner data usage persistence task timed out"
+                        );
+                        DataUsagePersistOutcome::Failed
+                    }
                 }
             }
         }
@@ -1644,11 +1682,10 @@ async fn run_data_scanner_cycle_with_budget(
             // A lease that expired or could not be released is never treated
             // as a successful authoritative publication. The peer may have
             // admitted movement immediately after the lease ended.
-            usage_persist_outcome = if usage_persist_outcome == DataUsagePersistOutcome::Failed {
-                DataUsagePersistOutcome::Failed
-            } else {
-                DataUsagePersistOutcome::Deferred(ScannerCycleDeferReason::ActivityBaselineUnavailable)
-            };
+            // No metadata write was attempted after the cycle budget or
+            // shutdown token stopped the retained candidate. A release
+            // failure cannot invalidate a publication that never began.
+            usage_persist_outcome = data_usage_persist_outcome_after_lease_failure(usage_persist_outcome);
         }
     }
     let unresolved_heal_work = global_metrics().current_scan_cycle_has_unresolved_heal_work();
@@ -2720,6 +2757,8 @@ impl Drop for ScannerScanModeGuard {
 }
 
 async fn final_data_usage_publication_defer_reason(
+    ctx: &CancellationToken,
+    cycle: u64,
     storeapi: &ECStore,
     status: ScannerCycleStatus,
 ) -> Option<ScannerCycleDeferReason> {
@@ -2730,7 +2769,11 @@ async fn final_data_usage_publication_defer_reason(
             }
             if status == ScannerCycleStatus::Complete {
                 let distributed = storeapi.setup_is_dist_erasure().await;
-                match probe_scanner_activity(storeapi, distributed).await {
+                match await_scanner_publication_activity(ctx, cycle, "pre_persist", || {
+                    probe_scanner_activity(storeapi, distributed)
+                })
+                .await
+                {
                     Ok(snapshot) if scanner_activity_allows_usage_publication(&snapshot) => None,
                     Ok(_) => Some(ScannerCycleDeferReason::DataMovement),
                     Err(_) => Some(ScannerCycleDeferReason::ActivityBaselineUnavailable),

--- a/crates/scanner/src/scanner/activity.rs
+++ b/crates/scanner/src/scanner/activity.rs
@@ -108,6 +108,146 @@ impl ScannerRetryBackoff {
     }
 }
 
+pub(crate) fn scanner_publication_proof_retry_delay(consecutive_failures: u32) -> Duration {
+    let exponent = consecutive_failures.saturating_sub(1).min(31);
+    let multiplier = 1u32.checked_shl(exponent).unwrap_or(u32::MAX);
+    SCANNER_RETRY_BASE_INTERVAL
+        .saturating_mul(multiplier)
+        .min(SCANNER_PUBLICATION_PROOF_RETRY_MAX_INTERVAL)
+}
+
+pub(crate) fn scanner_publication_activity_error_is_retryable(error: &str) -> bool {
+    crate::storage_api::scanner_peer_transport_error_message_is_retryable(error)
+}
+
+pub(crate) fn scanner_publication_lease_error_is_retryable(error: &str) -> bool {
+    scanner_publication_activity_error_is_retryable(error)
+        || error.ends_with("scanner publication lease capacity is exhausted")
+        || error.ends_with("scanner publication lease response arrived after its safety window")
+}
+
+pub(crate) enum ScannerPublicationProofWait<T, E> {
+    Ready(T),
+    Rejected(E),
+    Cancelled,
+}
+
+pub(crate) async fn await_scanner_publication_proof<T, E, F, Fut, Retryable>(
+    ctx: &CancellationToken,
+    cycle: u64,
+    stage: &'static str,
+    mut proof: F,
+    retryable: Retryable,
+) -> ScannerPublicationProofWait<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    E: std::fmt::Display,
+    Retryable: Fn(&E) -> bool,
+{
+    let started_at = Instant::now();
+    let mut consecutive_failures = 0u32;
+
+    loop {
+        if ctx.is_cancelled() {
+            return ScannerPublicationProofWait::Cancelled;
+        }
+
+        match proof().await {
+            Ok(value) => {
+                if consecutive_failures > 0 {
+                    info!(
+                        target: "rustfs::scanner",
+                        event = EVENT_SCANNER_CYCLE_STATE,
+                        component = LOG_COMPONENT_SCANNER,
+                        subsystem = LOG_SUBSYSTEM_RUNTIME,
+                        state = "publication_proof_recovered",
+                        cycle,
+                        stage,
+                        attempts = consecutive_failures.saturating_add(1),
+                        pending_duration = ?started_at.elapsed(),
+                        "Scanner publication proof recovered"
+                    );
+                }
+                return ScannerPublicationProofWait::Ready(value);
+            }
+            Err(err) if !retryable(&err) => {
+                warn!(
+                    target: "rustfs::scanner",
+                    event = EVENT_SCANNER_CYCLE_STATE,
+                    component = LOG_COMPONENT_SCANNER,
+                    subsystem = LOG_SUBSYSTEM_RUNTIME,
+                    state = "publication_proof_rejected",
+                    cycle,
+                    stage,
+                    error = %err,
+                    "Scanner publication proof failed with a non-retryable cluster state"
+                );
+                return ScannerPublicationProofWait::Rejected(err);
+            }
+            Err(err) => {
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                let retry_delay = scanner_publication_proof_retry_delay(consecutive_failures);
+                if consecutive_failures == 1 || consecutive_failures.is_multiple_of(20) {
+                    warn!(
+                        target: "rustfs::scanner",
+                        event = EVENT_SCANNER_CYCLE_STATE,
+                        component = LOG_COMPONENT_SCANNER,
+                        subsystem = LOG_SUBSYSTEM_RUNTIME,
+                        state = "publication_proof_pending",
+                        cycle,
+                        stage,
+                        attempt = consecutive_failures,
+                        retry_delay = ?retry_delay,
+                        error = %err,
+                        "Scanner retained a completed scan while publication proof is unavailable"
+                    );
+                } else {
+                    debug!(
+                        target: "rustfs::scanner",
+                        event = EVENT_SCANNER_CYCLE_STATE,
+                        component = LOG_COMPONENT_SCANNER,
+                        subsystem = LOG_SUBSYSTEM_RUNTIME,
+                        state = "publication_proof_retry",
+                        cycle,
+                        stage,
+                        attempt = consecutive_failures,
+                        retry_delay = ?retry_delay,
+                        error = %err,
+                        "Scanner publication activity proof retry scheduled"
+                    );
+                }
+
+                tokio::select! {
+                    _ = ctx.cancelled() => return ScannerPublicationProofWait::Cancelled,
+                    _ = tokio::time::sleep(retry_delay) => {}
+                }
+            }
+        }
+    }
+}
+
+pub(crate) async fn await_scanner_publication_activity<F, Fut>(
+    ctx: &CancellationToken,
+    cycle: u64,
+    stage: &'static str,
+    probe: F,
+) -> Result<ScannerActivitySnapshot, String>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<ScannerActivitySnapshot, String>>,
+{
+    match await_scanner_publication_proof(ctx, cycle, stage, probe, |err: &String| {
+        scanner_publication_activity_error_is_retryable(err)
+    })
+    .await
+    {
+        ScannerPublicationProofWait::Ready(snapshot) => Ok(snapshot),
+        ScannerPublicationProofWait::Rejected(err) => Err(err),
+        ScannerPublicationProofWait::Cancelled => Err(format!("scanner publication activity proof was cancelled during {stage}")),
+    }
+}
+
 impl Default for ScannerCleanIdleBackoff {
     fn default() -> Self {
         Self { interval_multiplier: 1 }

--- a/crates/scanner/src/scanner/tests.rs
+++ b/crates/scanner/src/scanner/tests.rs
@@ -4705,6 +4705,156 @@ fn superseded_retry_backoff_grows_from_the_default_cycle() {
     }
 }
 
+#[test]
+fn publication_proof_retry_backoff_reaches_its_short_cap() {
+    for (failures, expected) in [(1, 5), (2, 10), (3, 20), (4, 30), (20, 30)] {
+        assert_eq!(scanner_publication_proof_retry_delay(failures), Duration::from_secs(expected));
+    }
+}
+
+#[test]
+fn publication_proof_retry_classifies_availability_without_masking_protocol_errors() {
+    for error in [
+        "peer node3 is temporarily offline",
+        "scanner activity peer node3 timed out after 5s",
+        "transport error: connection refused",
+    ] {
+        assert!(scanner_publication_activity_error_is_retryable(error), "{error}");
+    }
+
+    for error in [
+        "scanner activity peer node3 uses protocol 6, expected 7",
+        "scanner activity peer node3 has a different storage topology",
+        "scanner activity peer node3 omitted its movement generation",
+        "duplicate scanner activity peer: node3",
+        "scanner activity peer[2] is unreachable",
+        "scanner publication lease peer node3 is unavailable",
+    ] {
+        assert!(!scanner_publication_activity_error_is_retryable(error), "{error}");
+    }
+}
+
+#[test]
+fn publication_lease_retry_preserves_only_recoverable_candidates() {
+    for error in [
+        "scanner publication lease acquisition failed: scanner publication lease capacity is exhausted",
+        "scanner publication lease acquisition failed: scanner publication lease response arrived after its safety window",
+        "scanner publication lease acquisition failed: peer node3 is temporarily offline",
+    ] {
+        assert!(scanner_publication_lease_error_is_retryable(error), "{error}");
+    }
+
+    for error in [
+        "scanner publication lease acquisition failed: scanner publication lease generation is stale",
+        "scanner publication lease acquisition failed: peer returned a different scanner publication lease session",
+        "scanner publication lease acquisition failed: scanner publication lease is blocked by data movement",
+        "scanner publication lease acquisition failed: peer returned an invalid scanner publication lease proof",
+    ] {
+        assert!(!scanner_publication_lease_error_is_retryable(error), "{error}");
+    }
+}
+
+#[test]
+fn lease_failure_preserves_unattempted_and_failed_persistence_outcomes() {
+    assert_eq!(
+        data_usage_persist_outcome_after_lease_failure(DataUsagePersistOutcome::NoUpdate),
+        DataUsagePersistOutcome::NoUpdate
+    );
+    assert_eq!(
+        data_usage_persist_outcome_after_lease_failure(DataUsagePersistOutcome::Failed),
+        DataUsagePersistOutcome::Failed
+    );
+    assert_eq!(
+        data_usage_persist_outcome_after_lease_failure(DataUsagePersistOutcome::Saved),
+        DataUsagePersistOutcome::Deferred(ScannerCycleDeferReason::ActivityBaselineUnavailable)
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn publication_proof_retains_candidate_until_activity_recovers() {
+    let ctx = CancellationToken::new();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let probe_attempts = attempts.clone();
+    let started_at = Instant::now();
+
+    let snapshot = await_scanner_publication_activity(&ctx, 17, "postscan", move || {
+        let attempt = probe_attempts.fetch_add(1, Ordering::SeqCst);
+        async move {
+            if attempt == 0 {
+                Err("peer temporarily offline".to_string())
+            } else {
+                Ok(ScannerActivitySnapshot::new())
+            }
+        }
+    })
+    .await
+    .expect("a retained publication candidate should survive one transient probe failure");
+
+    assert!(snapshot.is_empty());
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    assert_eq!(started_at.elapsed(), Duration::from_secs(5));
+}
+
+#[tokio::test(start_paused = true)]
+async fn publication_proof_does_not_retry_a_protocol_mismatch() {
+    let ctx = CancellationToken::new();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let probe_attempts = attempts.clone();
+
+    let err = await_scanner_publication_activity(&ctx, 17, "postscan", move || {
+        probe_attempts.fetch_add(1, Ordering::SeqCst);
+        async { Err("scanner activity peer node3 uses protocol 6, expected 7".to_string()) }
+    })
+    .await
+    .expect_err("a protocol mismatch must not be hidden behind availability retries");
+
+    assert!(err.contains("uses protocol"));
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn publication_proof_stops_waiting_when_the_cycle_is_cancelled() {
+    let ctx = CancellationToken::new();
+    ctx.cancel();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let probe_attempts = attempts.clone();
+
+    let err = await_scanner_publication_activity(&ctx, 17, "postscan", move || {
+        probe_attempts.fetch_add(1, Ordering::SeqCst);
+        async { Ok(ScannerActivitySnapshot::new()) }
+    })
+    .await
+    .expect_err("a cancelled cycle must release its retained publication candidate");
+
+    assert!(err.contains("cancelled"));
+    assert_eq!(attempts.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn publication_proof_releases_candidate_when_cancelled_during_backoff() {
+    let ctx = CancellationToken::new();
+    let cancel_ctx = ctx.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let probe_attempts = attempts.clone();
+    let started_at = Instant::now();
+
+    let cancel = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        cancel_ctx.cancel();
+    });
+    let err = await_scanner_publication_activity(&ctx, 17, "postscan", move || {
+        probe_attempts.fetch_add(1, Ordering::SeqCst);
+        async { Err("peer temporarily offline".to_string()) }
+    })
+    .await
+    .expect_err("cycle cancellation must release a candidate waiting to retry publication proof");
+    cancel.await.expect("cancellation task should complete");
+
+    assert!(err.contains("cancelled"));
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    assert_eq!(started_at.elapsed(), Duration::from_secs(1));
+}
+
 #[tokio::test(start_paused = true)]
 async fn corrupt_cycle_state_backoff_uses_virtual_clock() {
     let mut backoff = ScannerRetryBackoff::default();

--- a/crates/scanner/src/scanner_io.rs
+++ b/crates/scanner/src/scanner_io.rs
@@ -241,16 +241,21 @@ fn classify_nsscanner_cycle(
     dirty_usage_status: DirtyUsageSnapshotStatus,
     activity_status: ScannerCycleActivityStatus,
 ) -> ScannerCycleStatus {
-    // The post-scan activity proof is required regardless of why the scan was
-    // incomplete.  Returning Incomplete first would apply the long ordinary
-    // retry/backoff path to an unverifiable publication and could acknowledge
-    // a cycle without a movement-generation proof.
+    // Cancellation and the cycle budget are authoritative stop conditions.
+    // Incomplete cycles publish no usage and acknowledge no dirty state, so
+    // preserving that outcome cannot bypass the activity proof. It also keeps
+    // a publication-proof wait that reaches its deadline from being mistaken
+    // for a fresh availability deferral and immediately re-walking the tree.
+    if budget_elapsed || cancelled {
+        return ScannerCycleStatus::Incomplete;
+    }
+    // Outside an explicit stop condition, an unavailable post-scan proof must
+    // remain deferred even when other work was partial. Otherwise the ordinary
+    // incomplete path could hide the cluster-fencing failure.
     if activity_status == ScannerCycleActivityStatus::Unverified {
         return ScannerCycleStatus::Deferred(ScannerCycleDeferReason::ActivityBaselineUnavailable);
     }
-    if budget_elapsed
-        || cancelled
-        || !matches!(bucket_scan_status, ScannerBucketScanStatus::Complete)
+    if !matches!(bucket_scan_status, ScannerBucketScanStatus::Complete)
         || dirty_usage_status == DirtyUsageSnapshotStatus::Unverified
     {
         return ScannerCycleStatus::Incomplete;
@@ -315,26 +320,42 @@ async fn scanner_cycle_activity_status(
     store: &ECStore,
     distributed: bool,
     before: &crate::scanner::ScannerActivitySnapshot,
+    ctx: &CancellationToken,
+    cycle: u64,
+    retain_completed_candidate: bool,
 ) -> (ScannerCycleActivityStatus, Vec<(String, String, u64)>) {
-    match crate::scanner::probe_scanner_activity(store, distributed).await {
+    let activity = if retain_completed_candidate {
+        crate::scanner::await_scanner_publication_activity(ctx, cycle, "postscan", || {
+            crate::scanner::probe_scanner_activity(store, distributed)
+        })
+        .await
+    } else {
+        crate::scanner::probe_scanner_activity(store, distributed).await
+    };
+
+    match activity {
         Ok(after) => {
             let status = if after == *before {
                 ScannerCycleActivityStatus::Unchanged
             } else {
                 ScannerCycleActivityStatus::Changed
             };
-            (status, crate::scanner::scanner_activity_publication_lease_targets(&after))
+            let lease_targets = crate::scanner::scanner_activity_publication_lease_targets(&after);
+            (status, lease_targets)
         }
         Err(err) => {
-            warn!(
-                target: "rustfs::scanner::io",
-                event = EVENT_SCANNER_SET_STATE,
-                component = LOG_COMPONENT_SCANNER,
-                subsystem = LOG_SUBSYSTEM_IO,
-                state = "cycle_activity_probe_failed",
-                error = %err,
-                "Scanner cycle activity verification failed"
-            );
+            if !retain_completed_candidate {
+                warn!(
+                    target: "rustfs::scanner::io",
+                    event = EVENT_SCANNER_SET_STATE,
+                    component = LOG_COMPONENT_SCANNER,
+                    subsystem = LOG_SUBSYSTEM_IO,
+                    state = "cycle_activity_probe_failed",
+                    cycle,
+                    error = %err,
+                    "Scanner cycle activity verification failed"
+                );
+            }
             (ScannerCycleActivityStatus::Unverified, Vec::new())
         }
     }

--- a/crates/scanner/src/scanner_io/io_cycle.rs
+++ b/crates/scanner/src/scanner_io/io_cycle.rs
@@ -151,12 +151,18 @@ impl ScannerIOCycle for ECStore {
                     ScannerCycleResult::new(ScannerCycleStatus::Incomplete, None).with_publication_epoch(publication_epoch)
                 );
             }
-            let (activity_status, remote_publication_lease_targets) =
-                scanner_cycle_activity_status(self, distributed, &activity_before).await;
             let dirty_usage_status = dirty_usage_snapshot_status(&dirty_usage_snapshot);
+            let retain_completed_candidate = bucket_plan_complete
+                && !budget.budget_elapsed()
+                && !ctx.is_cancelled()
+                && dirty_usage_status == DirtyUsageSnapshotStatus::Current;
+            let (activity_status, remote_publication_lease_targets) =
+                scanner_cycle_activity_status(self, distributed, &activity_before, &ctx, want_cycle, retain_completed_candidate)
+                    .await;
+            let budget_elapsed = budget.budget_elapsed();
             let status = classify_nsscanner_cycle(
                 true,
-                false,
+                budget_elapsed,
                 ctx.is_cancelled(),
                 ScannerBucketScanStatus::Complete,
                 dirty_usage_status,
@@ -402,8 +408,6 @@ impl ScannerIOCycle for ECStore {
         let budget_elapsed = budget.budget_elapsed();
         let dirty_usage_status = dirty_usage_snapshot_status(&dirty_usage_snapshot);
         let dirty_usage_current = dirty_usage_status == DirtyUsageSnapshotStatus::Current;
-        let (activity_status, remote_publication_lease_targets) =
-            scanner_cycle_activity_status(self, distributed, &activity_before).await;
         let all_bucket_names = all_buckets.iter().map(|bucket| bucket.name.clone()).collect::<Vec<_>>();
         let completed_usage = completed_data_usage_info(
             &results,
@@ -429,6 +433,15 @@ impl ScannerIOCycle for ECStore {
             })
             .flatten();
         let structurally_complete_snapshot = result.is_ok() && completed_all_sets && completed_usage.is_some();
+        let retain_completed_candidate = structurally_complete_snapshot
+            && !budget_elapsed
+            && !ctx.is_cancelled()
+            && bucket_scan_status == ScannerBucketScanStatus::Complete
+            && dirty_usage_status == DirtyUsageSnapshotStatus::Current;
+        let (activity_status, remote_publication_lease_targets) =
+            scanner_cycle_activity_status(self, distributed, &activity_before, &ctx, want_cycle, retain_completed_candidate)
+                .await;
+        let budget_elapsed = budget.budget_elapsed();
         let cycle_status = classify_nsscanner_cycle(
             structurally_complete_snapshot,
             budget_elapsed,

--- a/crates/scanner/src/scanner_io/tests.rs
+++ b/crates/scanner/src/scanner_io/tests.rs
@@ -862,6 +862,23 @@ fn unverified_activity_defers_partial_and_floor_cycles() {
     );
 }
 
+#[test]
+fn cancelled_publication_proof_preserves_budget_and_cancel_outcomes() {
+    for (budget_elapsed, cancelled) in [(true, false), (false, true)] {
+        assert_eq!(
+            classify_nsscanner_cycle(
+                true,
+                budget_elapsed,
+                cancelled,
+                ScannerBucketScanStatus::Complete,
+                DirtyUsageSnapshotStatus::Current,
+                ScannerCycleActivityStatus::Unverified,
+            ),
+            ScannerCycleStatus::Incomplete
+        );
+    }
+}
+
 #[tokio::test]
 async fn structurally_complete_superseded_cycles_publish_without_claiming_convergence() {
     let (updates, mut receiver) = mpsc::channel(2);

--- a/crates/scanner/src/storage_api.rs
+++ b/crates/scanner/src/storage_api.rs
@@ -92,6 +92,7 @@ pub(crate) use rustfs_ecstore::api::event::{EventArgs as EcstoreEventArgs, send_
 pub(crate) use rustfs_ecstore::api::layout::{
     EndpointServerPools as EcstoreEndpointServerPools, Endpoints as EcstoreEndpoints, PoolEndpoints as EcstorePoolEndpoints,
 };
+pub(crate) use rustfs_ecstore::api::notification::scanner_peer_transport_error_message_is_retryable;
 pub(crate) use rustfs_ecstore::api::object::SCANNER_PUBLICATION_LEASE_FENCE_METADATA_KEY;
 #[cfg(test)]
 pub(crate) use rustfs_ecstore::api::rebalance::{

--- a/scripts/error-other-format-baseline.txt
+++ b/scripts/error-other-format-baseline.txt
@@ -46,7 +46,7 @@
 1|crates/ecstore/src/object_api/types.rs
 3|crates/ecstore/src/runtime/sources.rs
 4|crates/ecstore/src/services/batch_processor.rs
-14|crates/ecstore/src/services/notification_sys.rs
+13|crates/ecstore/src/services/notification_sys.rs
 16|crates/ecstore/src/services/rebalance/control.rs
 1|crates/ecstore/src/services/rebalance/entry.rs
 8|crates/ecstore/src/services/rebalance/meta.rs


### PR DESCRIPTION
## Related Issues

Related to #5950.

## Summary of Changes

- Retain a structurally complete usage candidate while scanner publication activity or lease proof is temporarily unavailable, instead of restarting the namespace traversal.
- Retry only transport-like activity failures and explicitly transient lease capacity or safety-window failures with bounded backoff, while protocol, topology, generation, session, and data-movement mismatches remain fail-closed.
- Re-prove publication safety immediately before persistence, preserve cancellation, budget, dirty-generation, and persistence outcomes, and allow one peer reconnect within the existing scanner activity deadline.
- Add focused regression coverage for transient recovery, permanent rejection, cancellation, budget expiry, lease outcome preservation, and bounded peer reconnect behavior.

## Verification

- `rustfmt --edition 2024 crates/ecstore/src/api/mod.rs crates/ecstore/src/cluster/rpc/peer_rest_client.rs crates/ecstore/src/services/notification_sys.rs crates/scanner/src/scanner.rs crates/scanner/src/scanner/activity.rs crates/scanner/src/scanner/tests.rs crates/scanner/src/scanner_io.rs crates/scanner/src/scanner_io/io_cycle.rs crates/scanner/src/scanner_io/tests.rs crates/scanner/src/storage_api.rs`
- `git diff --check`
- `./scripts/check_logging_guardrails.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`

Local Cargo execution was not started because the shared-host safety gate reported swap usage above 1 GiB. CI is required to provide compilation and focused Rust test results for this draft.

## Impact

Long-running scans no longer discard completed aggregate work solely because publication proof is temporarily unavailable. The retained state contains bucket aggregates rather than object inventory, and retries are cancellation-aware and capped at a 30-second interval. There are no configuration, public API, wire-format, or on-disk format changes.

## Additional Notes

The change does not add degraded publication, quorum bypass, or topology bypass. Persistent protocol, topology, movement, session, or generation failures still reject the candidate. The draft should become ready only after CI succeeds and a non-production logical multi-node fault-injection run confirms that a transient post-scan proof outage recovers without a second namespace walk.
