### PR TITLE
perf(storage): keep 1MiB PUTs on eager path

### DIFF
--- a/rustfs/src/app/object/put.rs
+++ b/rustfs/src/app/object/put.rs
@@ -25,15 +25,14 @@ const ENV_ZERO_COPY_EAGER_PUT_MAX_SIZE_BYTES: &str = "RUSTFS_ZERO_COPY_EAGER_PUT
 
 /// Maximum body size materialized by the ordinary eager PUT path.
 ///
-/// Bodies above this boundary stay streaming so a 1 MiB request does not
-/// reserve a full request-sized buffer while the EC writer is consuming it.
-/// The environment override keeps the boundary reversible for workload A/B
-/// tests and for deployments whose measured workload favors eager ingestion.
+/// Bodies above this boundary stay streaming while the EC writer consumes them.
+/// The environment override keeps the boundary reversible for workload A/B tests
+/// and for deployments whose measured workload favors streaming ingestion.
 const ENV_SMALL_EAGER_PUT_MAX_SIZE_BYTES: &str = "RUSTFS_SMALL_EAGER_PUT_MAX_SIZE_BYTES";
 
 const DEFAULT_ZERO_COPY_EAGER_PUT_MAX_SIZE_BYTES: usize = 16 * 1024 * 1024;
 
-const DEFAULT_SMALL_EAGER_PUT_MAX_SIZE_BYTES: usize = 512 * 1024;
+const DEFAULT_SMALL_EAGER_PUT_MAX_SIZE_BYTES: usize = 1024 * 1024;
 
 // Keep bounded conditional writes eager through the historical 1 MiB boundary
 // so the old object remains readable until the replacement body is complete.
@@ -2325,20 +2324,20 @@ mod tests {
         assert!(should_use_small_eager_put_path(1024, &headers, false, false, false));
         assert!(should_use_small_eager_put_path(128 * 1024, &headers, false, false, false));
         assert!(should_use_small_eager_put_path(512 * 1024, &headers, false, false, false));
-        assert!(!should_use_small_eager_put_path(512 * 1024 + 1, &headers, false, false, false));
-        assert!(!should_use_small_eager_put_path(1024 * 1024, &headers, false, false, false));
+        assert!(should_use_small_eager_put_path(1024 * 1024, &headers, false, false, false));
+        assert!(!should_use_small_eager_put_path(1024 * 1024 + 1, &headers, false, false, false));
     }
 
     #[test]
     fn select_put_path_switches_at_small_eager_boundary() {
         let headers = HeaderMap::new();
 
-        let (small_path, _, use_zero_copy, use_small_eager) = select_put_path(512 * 1024, &headers, false, false, false);
+        let (small_path, _, use_zero_copy, use_small_eager) = select_put_path(1024 * 1024, &headers, false, false, false);
         assert_eq!(small_path, "small_eager");
         assert!(!use_zero_copy);
         assert!(use_small_eager);
 
-        let (streaming_path, _, use_zero_copy, use_small_eager) = select_put_path(512 * 1024 + 1, &headers, false, false, false);
+        let (streaming_path, _, use_zero_copy, use_small_eager) = select_put_path(1024 * 1024 + 1, &headers, false, false, false);
         assert_eq!(streaming_path, "streaming");
         assert!(!use_zero_copy);
         assert!(!use_small_eager);


### PR DESCRIPTION
## Related Issues
Related: rustfs/backlog#2087

## Summary of Changes
Raise the default ordinary small-eager PUT boundary from 512 KiB to 1 MiB.
Known-length, unencrypted, uncompressed 1 MiB PUTs now use the eager ingestion path that materializes the request before EC storage processing; the existing `RUSTFS_SMALL_EAGER_PUT_MAX_SIZE_BYTES` override remains available for rollback and A/B testing.

The change is intentionally limited to the PUT path selector. EC encoding, bitrot, quorum, rename, conditional-write handling, encryption, compression, and extract requests retain their existing gates.

## Verification
- `CARGO_TARGET_DIR=<isolated-target> cargo test -p rustfs should_use_small_eager_put_path --lib` (7 passed)
- `cargo fmt --all --check`
- `git diff --check`
- Remote testing on Warp v1.6.1, testing `node1...4:29000`, 1 MiB PUT, `--disable-multipart`: c8/15s baseline 214.32 MiB/s, candidate 240.99 MiB/s; B2 274.24 MiB/s; A2 269.75 MiB/s. The short ABBA pair is noisy and does not prove a fixed percentage gain.
- A c64/60s attempt produced repeated service-unavailable responses before a valid report and was excluded from throughput conclusions.

## Impact
Ordinary 1 MiB PUTs allocate up to one request-sized eager buffer per in-flight request. The default memory footprint therefore increases with concurrency; operators can set `RUSTFS_SMALL_EAGER_PUT_MAX_SIZE_BYTES=524288` to restore the prior boundary. No API or on-disk format changes.

## Additional Notes
The runtime evidence supports the intended path change but is not a claim that every topology will reach the historical 459 MiB/s target. Further c64/5m validation should be repeated after the testing cluster's service-unavailable condition is resolved.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
