### PR TITLE
fix(test): serialize transition matrix tests under nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -100,6 +100,16 @@ test-group = 'embedded-test-ports'
 filter = 'package(rustfs-ecstore) & test(manual_transition_page_checkpoint_persists_durable_job_progress)'
 test-group = 'ecstore-serial-flaky'
 
+# Serialize the transition matrix tests. They build a 4-disk hermetic erasure
+# set, populate the get_object_metadata_cache, and assert generation lifecycle
+# semantics. serial_test's #[serial] has no effect across nextest's process
+# boundary, so concurrent execution races the shared metadata-cache generation
+# counter and causes spurious "metadata read should publish the generation"
+# panics. Preventive serialization, no retries.
+[[profile.default.overrides]]
+filter = 'package(rustfs-ecstore) & test(set_disk::transition_matrix_tests::)'
+test-group = 'ecstore-serial-flaky'
+
 # The durable ILM decommission regressions build isolated multi-pool stores and
 # deliberately take source or target disks offline while checking fencing.
 [[profile.default.overrides]]
@@ -230,6 +240,12 @@ test-group = 'embedded-test-ports'
 # too. No retries: failures stay visible.
 [[profile.ci.overrides]]
 filter = 'package(rustfs-ecstore) & test(manual_transition_page_checkpoint_persists_durable_job_progress)'
+test-group = 'ecstore-serial-flaky'
+
+# Serialize the transition matrix tests under the ci profile too (see the
+# matching default-profile override near the top). No retries.
+[[profile.ci.overrides]]
+filter = 'package(rustfs-ecstore) & test(set_disk::transition_matrix_tests::)'
 test-group = 'ecstore-serial-flaky'
 
 [[profile.ci.overrides]]


### PR DESCRIPTION
## Problem

`make pre-pr` fails intermittently with 2 flaky test failures in `set_disk::transition_matrix_tests`:

- `transition_and_restore_reclaim_prior_metadata_generations`
- `prepared_snapshot_transition_duplicate_and_late_get_use_committed_remote_generation`

Both fail with: `metadata read should publish the generation under test` (line 36 in `prime_metadata_generation`).

## Root Cause

Both tests use `#[serial_test::serial]` which is a no-op under nextest (each test runs in a separate process). When running alongside ~4700 other ecstore tests, the metadata cache generation counter races, causing the cache assertion to fail intermittently.

**Evidence:**
- Tests pass consistently when run individually or with only `transition_matrix_tests` filtered
- Different tests fail each run (flaky, not deterministic)
- The `#[serial_test::serial]` attribute provides no cross-process isolation under nextest

## Fix

Add both transition matrix tests to the `ecstore-serial-flaky` nextest test group in both `default` and `ci` profiles, matching the existing pattern for similar 4-disk hermetic erasure set tests.

## Verification

- TOML syntax validated
- `cargo fmt --all --check` passes
- Tests pass individually: `cargo nextest run -p rustfs-ecstore --features test-util -E 'test(set_disk::transition_matrix_tests::)'`
- Baseline: `ff3ad30f0c537e6feba3180d713cea46b246200b`
