### PR TITLE
perf(ecstore): gate quorum-aware GET early stop

### DIFF
--- a/crates/ecstore/src/set_disk/core/io_primitives.rs
+++ b/crates/ecstore/src/set_disk/core/io_primitives.rs
@@ -1108,20 +1108,24 @@ fn non_inline_data_read_candidate_is_safe(
     ) else {
         return false;
     };
-    let mut data_shards = vec![false; erasure.data_shards];
+    // The regular reader setup can reconstruct missing data shards from any
+    // `data_shards` matching metadata entries. Requiring every data slot here
+    // would unnecessarily wait for one slow data disk even when parity and
+    // the remaining data shards already form a read quorum.
+    let mut available_shards = vec![false; erasure.data_shards + erasure.parity_shards];
     for ((file_info, disk), &erasure_index) in parts_metadata
         .iter()
         .zip(disks.iter())
         .zip(candidate.erasure.distribution.iter())
     {
-        if erasure_index == 0 || erasure_index > erasure.data_shards || disk.is_none() {
+        if erasure_index == 0 || erasure_index > available_shards.len() || disk.is_none() {
             continue;
         }
         if metadata_early_stop_candidate_matches(file_info, candidate) && file_info.erasure.index == erasure_index {
-            data_shards[erasure_index - 1] = true;
+            available_shards[erasure_index - 1] = true;
         }
     }
-    data_shards.into_iter().all(|present| present)
+    available_shards.into_iter().filter(|present| *present).count() >= erasure.data_shards
 }
 
 fn data_read_inline_missing_shards_are_pending(

--- a/crates/ecstore/src/set_disk/core/io_primitives.rs
+++ b/crates/ecstore/src/set_disk/core/io_primitives.rs
@@ -49,10 +49,11 @@ use super::super::{
     capacity_scope_from_disks, coding, collect_inline_data_shard_fileinfos_by_index_or_reason, current_dirty_generation, debug,
     disk, file_info_is_valid_for_metadata, get_metadata_slowtail_fault_request, info, inline_erasure_shard_file_offset,
     inline_erasure_shard_size, is_err_object_not_found, is_err_version_not_found, is_get_metadata_data_read_early_stop_enabled,
-    is_get_metadata_early_stop_bounded_fanout_enabled, is_get_metadata_early_stop_enabled, is_object_dangling,
-    is_version_early_stop_enabled, issue3031_diag_enabled, join_all, join_errs, log_multipart_write_quorum_failure,
-    merge_file_meta_versions, path_join_buf, record_global_dirty_scope, reduce_read_quorum_errs, reduce_write_quorum_errs,
-    send_heal_request_with_admission, should_prevent_write, to_object_err, try_read_inline_data_shards_direct, warn,
+    is_get_metadata_early_stop_bounded_fanout_enabled, is_get_metadata_early_stop_enabled,
+    is_get_metadata_two_phase_read_plan_enabled, is_object_dangling, is_version_early_stop_enabled, issue3031_diag_enabled,
+    join_all, join_errs, log_multipart_write_quorum_failure, merge_file_meta_versions, path_join_buf, record_global_dirty_scope,
+    reduce_read_quorum_errs, reduce_write_quorum_errs, send_heal_request_with_admission, should_prevent_write, to_object_err,
+    try_read_inline_data_shards_direct, warn,
 };
 #[cfg(test)]
 use crate::bucket::lifecycle::lifecycle::TRANSITION_COMPLETE;
@@ -1081,6 +1082,46 @@ fn data_read_early_stop_inline_candidate_miss_reason(candidate: &FileInfo) -> Op
         return Some(GET_METADATA_EARLY_STOP_REASON_DATA_READ_INLINE_SIZE);
     }
     None
+}
+
+fn non_inline_data_read_candidate_is_safe(
+    candidate: &FileInfo,
+    parts_metadata: &[FileInfo],
+    disks: &[Option<DiskStore>],
+) -> bool {
+    if candidate.inline_data()
+        || candidate.is_compressed()
+        || candidate.is_remote()
+        || candidate
+            .metadata
+            .keys()
+            .any(|key| rustfs_utils::http::is_object_encryption_marker(key))
+        || candidate.parts.len() != 1
+    {
+        return false;
+    }
+    let Ok(erasure) = coding::Erasure::try_new_with_options(
+        candidate.erasure.data_blocks,
+        candidate.erasure.parity_blocks,
+        candidate.erasure.block_size,
+        candidate.uses_legacy_checksum,
+    ) else {
+        return false;
+    };
+    let mut data_shards = vec![false; erasure.data_shards];
+    for ((file_info, disk), &erasure_index) in parts_metadata
+        .iter()
+        .zip(disks.iter())
+        .zip(candidate.erasure.distribution.iter())
+    {
+        if erasure_index == 0 || erasure_index > erasure.data_shards || disk.is_none() {
+            continue;
+        }
+        if metadata_early_stop_candidate_matches(file_info, candidate) && file_info.erasure.index == erasure_index {
+            data_shards[erasure_index - 1] = true;
+        }
+    }
+    data_shards.into_iter().all(|present| present)
 }
 
 fn data_read_inline_missing_shards_are_pending(
@@ -2869,6 +2910,7 @@ impl SetDisks {
                 read_data,
                 healing,
                 incl_free_versions,
+                read_data && is_get_metadata_two_phase_read_plan_enabled(),
                 default_parity_count,
                 allow_coalescing,
             )
@@ -3008,6 +3050,7 @@ impl SetDisks {
         read_data: bool,
         healing: bool,
         incl_free_versions: bool,
+        allow_non_inline_data_read_early_stop: bool,
         default_parity_count: usize,
         allow_coalescing: bool,
     ) -> disk::error::Result<(Vec<FileInfo>, Vec<Option<DiskError>>, MetadataFanoutDiagnostics)> {
@@ -3096,6 +3139,8 @@ impl SetDisks {
                             && read_data
                             && !force_full_wait
                             && let Some(reason) = data_read_early_stop_inline_candidate_miss_reason(&file_info)
+                            && !(allow_non_inline_data_read_early_stop
+                                && reason == GET_METADATA_EARLY_STOP_REASON_DATA_READ_INLINE_NOT_INLINE)
                         {
                             force_full_wait = true;
                             final_miss_reason_override.get_or_insert(reason);
@@ -3126,6 +3171,12 @@ impl SetDisks {
             {
                 let should_return_early = if read_data {
                     match accumulator.candidate.as_ref() {
+                        Some(candidate)
+                            if allow_non_inline_data_read_early_stop
+                                && non_inline_data_read_candidate_is_safe(candidate, &ress, disks) =>
+                        {
+                            true
+                        }
                         Some(candidate) => match data_read_early_stop_inline_body_miss_reason(
                             bucket.as_ref(),
                             object.as_ref(),

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -1180,8 +1180,8 @@ mod prepared_get_object_metadata_tests {
     async fn two_phase_read_plan_uses_metadata_only_for_non_inline_get() {
         let (_dirs, set_disks) = make_local_set_disks(4, 2).await;
         let bucket = "two-phase-read-plan";
-        let object = "non-inline-object.bin";
-        let payload = vec![0x5a; 256 * 1024];
+        let object = object_with_initial_data_shards(bucket, "non-inline-object");
+        let payload = vec![0x5a; 2 * 1024 * 1024];
         let opts = ObjectOptions {
             no_lock: true,
             ..Default::default()
@@ -1193,7 +1193,7 @@ mod prepared_get_object_metadata_tests {
             .expect("bucket should be created");
         let mut put_reader = PutObjReader::from_vec(payload.clone());
         set_disks
-            .put_object(bucket, object, &mut put_reader, &opts)
+            .put_object(bucket, &object, &mut put_reader, &opts)
             .await
             .expect("object should be written");
 
@@ -1204,9 +1204,10 @@ mod prepared_get_object_metadata_tests {
                 ("RUSTFS_GET_METADATA_EARLY_STOP_BOUNDED_FANOUT", Some("true")),
             ],
             async {
-                let calls = disk_call_counters::observe(object);
+                let calls = disk_call_counters::observe(&object);
+                reset_test_get_object_reader_path();
                 let mut reader = set_disks
-                    .get_object_reader(bucket, object, None, HeaderMap::new(), &opts)
+                    .get_object_reader(bucket, &object, None, HeaderMap::new(), &opts)
                     .await
                     .expect("two-phase GET reader should open");
                 let mut restored = Vec::new();
@@ -1227,7 +1228,7 @@ mod prepared_get_object_metadata_tests {
 
     #[tokio::test]
     #[serial_test::serial(body_cache_hook)]
-    async fn two_phase_read_plan_hydrates_only_inline_data_shards() {
+    async fn two_phase_read_plan_preserves_inline_early_stop_path() {
         let (_dirs, set_disks) = make_local_set_disks(4, 2).await;
         let bucket = "two-phase-read-plan-inline";
         let object = object_with_initial_data_shards(bucket, "inline-object");
@@ -1266,10 +1267,12 @@ mod prepared_get_object_metadata_tests {
                     .await
                     .expect("two-phase inline GET body should stream");
                 assert_eq!(restored, payload);
-                assert!(
-                    calls.total(disk_call_counters::KIND_READ_VERSION) <= 6,
-                    "inline two-phase GET should hydrate only the data-shard slots"
+                assert_eq!(
+                    test_get_object_reader_path_id(),
+                    3,
+                    "inline GET should retain the direct inline reader path"
                 );
+                assert!(calls.total(disk_call_counters::KIND_READ_VERSION) <= 4);
             },
         )
         .await;

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -773,6 +773,13 @@ const DEFAULT_RUSTFS_GET_METADATA_VERSION_EARLY_STOP_ENABLE: bool = false;
 const ENV_RUSTFS_GET_METADATA_DATA_READ_EARLY_STOP_ENABLE: &str = "RUSTFS_GET_METADATA_DATA_READ_EARLY_STOP_ENABLE";
 const DEFAULT_RUSTFS_GET_METADATA_DATA_READ_EARLY_STOP_ENABLE: bool = true;
 
+// Two-phase metadata/read-plan rollout (backlog#1309). The first phase reads
+// metadata without inline payloads and only fetches inline data from the
+// selected data-shard slots. Keep this opt-in until the Linux multi-node
+// slow-tail and small-inline cost gates are complete.
+const ENV_RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE: &str = "RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE";
+const DEFAULT_RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE: bool = false;
+
 const ENV_RUSTFS_GET_METADATA_EARLY_STOP_BOUNDED_FANOUT: &str = "RUSTFS_GET_METADATA_EARLY_STOP_BOUNDED_FANOUT";
 const DEFAULT_RUSTFS_GET_METADATA_EARLY_STOP_BOUNDED_FANOUT: bool = true;
 
@@ -1166,6 +1173,106 @@ mod prepared_get_object_metadata_tests {
             4,
             "reader construction must consume prepared metadata instead of repeating the fanout"
         );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(body_cache_hook)]
+    async fn two_phase_read_plan_uses_metadata_only_for_non_inline_get() {
+        let (_dirs, set_disks) = make_local_set_disks(4, 2).await;
+        let bucket = "two-phase-read-plan";
+        let object = "non-inline-object.bin";
+        let payload = vec![0x5a; 256 * 1024];
+        let opts = ObjectOptions {
+            no_lock: true,
+            ..Default::default()
+        };
+
+        set_disks
+            .make_bucket(bucket, &MakeBucketOptions::default())
+            .await
+            .expect("bucket should be created");
+        let mut put_reader = PutObjReader::from_vec(payload.clone());
+        set_disks
+            .put_object(bucket, object, &mut put_reader, &opts)
+            .await
+            .expect("object should be written");
+
+        temp_env::async_with_vars(
+            [
+                ("RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE", Some("true")),
+                ("RUSTFS_GET_METADATA_EARLY_STOP_ENABLE", Some("true")),
+                ("RUSTFS_GET_METADATA_EARLY_STOP_BOUNDED_FANOUT", Some("true")),
+            ],
+            async {
+                let calls = disk_call_counters::observe(object);
+                let mut reader = set_disks
+                    .get_object_reader(bucket, object, None, HeaderMap::new(), &opts)
+                    .await
+                    .expect("two-phase GET reader should open");
+                let mut restored = Vec::new();
+                reader
+                    .stream
+                    .read_to_end(&mut restored)
+                    .await
+                    .expect("two-phase GET body should stream");
+                assert_eq!(restored, payload);
+                assert!(
+                    calls.total(disk_call_counters::KIND_READ_VERSION) < 4,
+                    "non-inline two-phase GET should stop metadata fanout at a quorum"
+                );
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(body_cache_hook)]
+    async fn two_phase_read_plan_hydrates_only_inline_data_shards() {
+        let (_dirs, set_disks) = make_local_set_disks(4, 2).await;
+        let bucket = "two-phase-read-plan-inline";
+        let object = object_with_initial_data_shards(bucket, "inline-object");
+        let payload = b"two-phase inline payload".repeat(256);
+        let opts = ObjectOptions {
+            no_lock: true,
+            ..Default::default()
+        };
+
+        set_disks
+            .make_bucket(bucket, &MakeBucketOptions::default())
+            .await
+            .expect("bucket should be created");
+        let mut put_reader = PutObjReader::from_vec(payload.clone());
+        set_disks
+            .put_object(bucket, &object, &mut put_reader, &opts)
+            .await
+            .expect("inline object should be written");
+
+        temp_env::async_with_vars(
+            [
+                ("RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE", Some("true")),
+                ("RUSTFS_GET_METADATA_EARLY_STOP_ENABLE", Some("true")),
+                ("RUSTFS_GET_METADATA_EARLY_STOP_BOUNDED_FANOUT", Some("true")),
+            ],
+            async {
+                let calls = disk_call_counters::observe(&object);
+                let mut reader = set_disks
+                    .get_object_reader(bucket, &object, None, HeaderMap::new(), &opts)
+                    .await
+                    .expect("two-phase inline GET reader should open");
+                let mut restored = Vec::new();
+                reader
+                    .stream
+                    .read_to_end(&mut restored)
+                    .await
+                    .expect("two-phase inline GET body should stream");
+                assert_eq!(restored, payload);
+                assert!(
+                    calls.total(disk_call_counters::KIND_READ_VERSION) <= 6,
+                    "inline two-phase GET should hydrate only the data-shard slots"
+                );
+            },
+        )
+        .await;
     }
 
     #[test]
@@ -1909,6 +2016,26 @@ fn is_get_metadata_data_read_early_stop_enabled() -> bool {
             rustfs_utils::get_env_bool(
                 ENV_RUSTFS_GET_METADATA_DATA_READ_EARLY_STOP_ENABLE,
                 DEFAULT_RUSTFS_GET_METADATA_DATA_READ_EARLY_STOP_ENABLE,
+            )
+        })
+    }
+}
+
+fn is_get_metadata_two_phase_read_plan_enabled() -> bool {
+    #[cfg(test)]
+    {
+        rustfs_utils::get_env_bool(
+            ENV_RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE,
+            DEFAULT_RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE,
+        )
+    }
+    #[cfg(not(test))]
+    {
+        static CACHED: OnceLock<bool> = OnceLock::new();
+        *CACHED.get_or_init(|| {
+            rustfs_utils::get_env_bool(
+                ENV_RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE,
+                DEFAULT_RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE,
             )
         })
     }

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -19,9 +19,8 @@ use super::{
     ReadOptions, Result, SetDisks, StorageError, adaptive_duplex_buffer_size, build_get_codec_streaming_decode_engine,
     build_inline_bitrot_readers_from_refs, collect_inline_data_shard_fileinfos_by_index, debug, error,
     get_codec_streaming_metrics_path, get_codec_streaming_multipart_max_parts, get_object_read_policy,
-    is_codec_streaming_multipart_enabled, is_get_metadata_two_phase_read_plan_enabled,
-    is_multipart_reader_setup_prefetch_enabled, object_fits_single_block, reduce_read_quorum_errs, to_object_err,
-    try_read_inline_data_shards_direct, warn,
+    is_codec_streaming_multipart_enabled, is_multipart_reader_setup_prefetch_enabled, object_fits_single_block,
+    reduce_read_quorum_errs, to_object_err, try_read_inline_data_shards_direct, warn,
 };
 use crate::diagnostics::get::{
     GET_DIRECT_MEMORY_SUBPATH_DISK_DATA_BLOCKS, GET_DIRECT_MEMORY_SUBPATH_INLINE_BUFFERED, GET_METADATA_CACHE_DECISION_HIT,
@@ -44,7 +43,6 @@ use crate::io_support::bitrot::{BitrotReaderStageMetrics, DeferredReaderStripeHa
 use crate::set_disk::coding;
 use crate::set_disk::runtime_sources;
 use crate::set_disk::shard_source::ShardReadCost;
-use futures::future::join_all;
 use std::{
     future::Future,
     io::IoSlice,
@@ -129,6 +127,8 @@ use super::is_get_metadata_data_read_early_stop_enabled;
 use super::is_get_metadata_early_stop_bounded_fanout_enabled;
 #[cfg(test)]
 use super::is_get_metadata_early_stop_enabled;
+#[cfg(test)]
+use super::is_get_metadata_two_phase_read_plan_enabled;
 #[cfg(test)]
 use super::is_version_early_stop_enabled;
 #[cfg(test)]
@@ -399,11 +399,6 @@ impl SetDisks {
     ) -> Result<GetObjectFileInfo> {
         let allow_read_version_coalescing = !crate::bucket::utils::is_meta_bucketname(bucket)
             && crate::runtime::global::get_metadata_read_version_coalescing_service_ready();
-        if read_data && caller_allows_early_stop && is_get_metadata_two_phase_read_plan_enabled() {
-            return self
-                .get_object_fileinfo_two_phase_read_plan(bucket, object, opts, allow_read_version_coalescing)
-                .await;
-        }
         self.get_object_fileinfo_gated_inner(
             bucket,
             object,
@@ -413,175 +408,6 @@ impl SetDisks {
             allow_read_version_coalescing,
         )
         .await
-    }
-
-    /// Resolve a safe metadata candidate first, then fetch inline payload only
-    /// from the data-shard slots required by that candidate. Non-inline
-    /// objects never need a second read-data fanout. Any identity, geometry,
-    /// or data-shard quorum mismatch falls back to the established full
-    /// read-data path before returning a snapshot.
-    async fn get_object_fileinfo_two_phase_read_plan(
-        &self,
-        bucket: &str,
-        object: &str,
-        opts: &ObjectOptions,
-        allow_read_version_coalescing: bool,
-    ) -> Result<GetObjectFileInfo> {
-        let metadata_snapshot = self
-            .get_object_fileinfo_gated_inner(bucket, object, opts, false, true, allow_read_version_coalescing)
-            .await?;
-
-        if !metadata_snapshot.fi().inline_data() {
-            if Self::metadata_snapshot_covers_all_data_shards(&metadata_snapshot) {
-                return Ok(metadata_snapshot);
-            }
-            return self
-                .get_object_fileinfo_gated_inner(bucket, object, opts, true, true, allow_read_version_coalescing)
-                .await;
-        }
-
-        let (mut fi, mut parts_metadata, mut online_disks) = metadata_snapshot.into_owned();
-        let Ok(erasure) = coding::Erasure::try_new_with_options(
-            fi.erasure.data_blocks,
-            fi.erasure.parity_blocks,
-            fi.erasure.block_size,
-            fi.uses_legacy_checksum,
-        ) else {
-            return self
-                .get_object_fileinfo_gated_inner(bucket, object, opts, true, true, allow_read_version_coalescing)
-                .await;
-        };
-        let data_shards = erasure.data_shards;
-        if data_shards == 0 || fi.erasure.distribution.len() < self.set_drive_count {
-            return self
-                .get_object_fileinfo_gated_inner(bucket, object, opts, true, true, allow_read_version_coalescing)
-                .await;
-        }
-
-        let read_version = fi
-            .version_id
-            .filter(|version| !version.is_nil())
-            .map(|version| version.to_string())
-            .unwrap_or_default();
-        let read_opts = ReadOptions {
-            read_data: true,
-            incl_free_versions: opts.incl_free_versions,
-            healing: false,
-        };
-        let disks = self.disks.read().await.clone();
-        let mut read_tasks = Vec::with_capacity(data_shards);
-        let mut requested_data_shards = vec![false; data_shards];
-        let mut failed = false;
-
-        for (disk_index, disk) in disks.iter().enumerate() {
-            let Some(&erasure_index) = fi.erasure.distribution.get(disk_index) else {
-                failed = true;
-                break;
-            };
-            if erasure_index == 0 || erasure_index > data_shards {
-                continue;
-            }
-            let data_slot = erasure_index - 1;
-            if requested_data_shards[data_slot] {
-                failed = true;
-                break;
-            }
-            requested_data_shards[data_slot] = true;
-            let Some(disk) = disk.clone() else {
-                failed = true;
-                break;
-            };
-
-            let bucket = bucket.to_owned();
-            let object = object.to_owned();
-            let read_version = read_version.clone();
-            read_tasks.push(async move {
-                (
-                    disk_index,
-                    erasure_index,
-                    disk.clone(),
-                    disk.read_version("", &bucket, &object, &read_version, &read_opts).await,
-                )
-            });
-        }
-
-        if requested_data_shards.iter().any(|requested| !requested) {
-            failed = true;
-        }
-
-        let mut hydrated_data_shards = 0usize;
-        for (disk_index, erasure_index, disk, result) in join_all(read_tasks).await {
-            match result {
-                Ok(data_file_info)
-                    if data_file_info.erasure.index == erasure_index
-                        && metadata_early_stop_candidate_matches(&data_file_info, &fi)
-                        && data_file_info.data.as_ref().is_some_and(|data| !data.is_empty()) =>
-                {
-                    if let Some(slot) = parts_metadata.get_mut(disk_index) {
-                        *slot = data_file_info;
-                        hydrated_data_shards = hydrated_data_shards.saturating_add(1);
-                        if let Some(online_slot) = online_disks.get_mut(disk_index) {
-                            *online_slot = Some(disk);
-                        } else {
-                            failed = true;
-                        }
-                    } else {
-                        failed = true;
-                    }
-                }
-                _ => {
-                    failed = true;
-                }
-            }
-        }
-
-        if failed || hydrated_data_shards < data_shards {
-            return self
-                .get_object_fileinfo_gated_inner(bucket, object, opts, true, true, allow_read_version_coalescing)
-                .await;
-        }
-
-        fi.data = parts_metadata
-            .iter()
-            .filter(|file_info| file_info.erasure.index > 0 && file_info.erasure.index <= data_shards)
-            .find_map(|file_info| file_info.data.clone());
-        if fi.data.is_none() {
-            return self
-                .get_object_fileinfo_gated_inner(bucket, object, opts, true, true, allow_read_version_coalescing)
-                .await;
-        }
-
-        Ok(GetObjectFileInfo::owned(fi, parts_metadata, online_disks))
-    }
-
-    fn metadata_snapshot_covers_all_data_shards(snapshot: &GetObjectFileInfo) -> bool {
-        let fi = snapshot.fi();
-        let Ok(erasure) = coding::Erasure::try_new_with_options(
-            fi.erasure.data_blocks,
-            fi.erasure.parity_blocks,
-            fi.erasure.block_size,
-            fi.uses_legacy_checksum,
-        ) else {
-            return false;
-        };
-        let mut data_shards = vec![false; erasure.data_shards];
-        for ((file_info, disk), &erasure_index) in snapshot
-            .parts_metadata()
-            .iter()
-            .zip(snapshot.online_disks())
-            .zip(fi.erasure.distribution.iter())
-        {
-            if erasure_index == 0 || erasure_index > erasure.data_shards || disk.is_none() {
-                continue;
-            }
-            if metadata_early_stop_candidate_matches(file_info, fi)
-                && file_info.erasure.index == erasure_index
-                && file_info.name == fi.name
-            {
-                data_shards[erasure_index - 1] = true;
-            }
-        }
-        data_shards.into_iter().all(|present| present)
     }
 
     /// Like `get_object_fileinfo`, but `allow_early_stop=false` forces the full

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -19,8 +19,9 @@ use super::{
     ReadOptions, Result, SetDisks, StorageError, adaptive_duplex_buffer_size, build_get_codec_streaming_decode_engine,
     build_inline_bitrot_readers_from_refs, collect_inline_data_shard_fileinfos_by_index, debug, error,
     get_codec_streaming_metrics_path, get_codec_streaming_multipart_max_parts, get_object_read_policy,
-    is_codec_streaming_multipart_enabled, is_multipart_reader_setup_prefetch_enabled, object_fits_single_block,
-    reduce_read_quorum_errs, to_object_err, try_read_inline_data_shards_direct, warn,
+    is_codec_streaming_multipart_enabled, is_get_metadata_two_phase_read_plan_enabled,
+    is_multipart_reader_setup_prefetch_enabled, object_fits_single_block, reduce_read_quorum_errs, to_object_err,
+    try_read_inline_data_shards_direct, warn,
 };
 use crate::diagnostics::get::{
     GET_DIRECT_MEMORY_SUBPATH_DISK_DATA_BLOCKS, GET_DIRECT_MEMORY_SUBPATH_INLINE_BUFFERED, GET_METADATA_CACHE_DECISION_HIT,
@@ -43,6 +44,7 @@ use crate::io_support::bitrot::{BitrotReaderStageMetrics, DeferredReaderStripeHa
 use crate::set_disk::coding;
 use crate::set_disk::runtime_sources;
 use crate::set_disk::shard_source::ShardReadCost;
+use futures::future::join_all;
 use std::{
     future::Future,
     io::IoSlice,
@@ -88,6 +90,8 @@ use super::ENV_RUSTFS_GET_METADATA_DATA_READ_EARLY_STOP_ENABLE;
 use super::ENV_RUSTFS_GET_METADATA_EARLY_STOP_BOUNDED_FANOUT;
 #[cfg(test)]
 use super::ENV_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE;
+#[cfg(test)]
+use super::ENV_RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE;
 #[cfg(test)]
 use super::ENV_RUSTFS_GET_METADATA_VERSION_EARLY_STOP_ENABLE;
 #[cfg(test)]
@@ -395,6 +399,11 @@ impl SetDisks {
     ) -> Result<GetObjectFileInfo> {
         let allow_read_version_coalescing = !crate::bucket::utils::is_meta_bucketname(bucket)
             && crate::runtime::global::get_metadata_read_version_coalescing_service_ready();
+        if read_data && caller_allows_early_stop && is_get_metadata_two_phase_read_plan_enabled() {
+            return self
+                .get_object_fileinfo_two_phase_read_plan(bucket, object, opts, allow_read_version_coalescing)
+                .await;
+        }
         self.get_object_fileinfo_gated_inner(
             bucket,
             object,
@@ -404,6 +413,140 @@ impl SetDisks {
             allow_read_version_coalescing,
         )
         .await
+    }
+
+    /// Resolve a safe metadata candidate first, then fetch inline payload only
+    /// from the data-shard slots required by that candidate. Non-inline
+    /// objects never need a second read-data fanout. Any identity, geometry,
+    /// or data-shard quorum mismatch falls back to the established full
+    /// read-data path before returning a snapshot.
+    async fn get_object_fileinfo_two_phase_read_plan(
+        &self,
+        bucket: &str,
+        object: &str,
+        opts: &ObjectOptions,
+        allow_read_version_coalescing: bool,
+    ) -> Result<GetObjectFileInfo> {
+        let metadata_snapshot = self
+            .get_object_fileinfo_gated_inner(bucket, object, opts, false, true, allow_read_version_coalescing)
+            .await?;
+
+        if !metadata_snapshot.fi().inline_data() {
+            return Ok(metadata_snapshot);
+        }
+
+        let (mut fi, mut parts_metadata, mut online_disks) = metadata_snapshot.into_owned();
+        let Ok(erasure) = coding::Erasure::try_new_with_options(
+            fi.erasure.data_blocks,
+            fi.erasure.parity_blocks,
+            fi.erasure.block_size,
+            fi.uses_legacy_checksum,
+        ) else {
+            return self
+                .get_object_fileinfo_gated_inner(bucket, object, opts, true, true, allow_read_version_coalescing)
+                .await;
+        };
+        let data_shards = erasure.data_shards;
+        if data_shards == 0 || fi.erasure.distribution.len() < self.set_drive_count {
+            return self
+                .get_object_fileinfo_gated_inner(bucket, object, opts, true, true, allow_read_version_coalescing)
+                .await;
+        }
+
+        let read_version = fi
+            .version_id
+            .filter(|version| !version.is_nil())
+            .map(|version| version.to_string())
+            .unwrap_or_default();
+        let read_opts = ReadOptions {
+            read_data: true,
+            incl_free_versions: opts.incl_free_versions,
+            healing: false,
+        };
+        let disks = self.disks.read().await.clone();
+        let mut read_tasks = Vec::with_capacity(data_shards);
+        let mut requested_data_shards = vec![false; data_shards];
+        let mut failed = false;
+
+        for (disk_index, disk) in disks.iter().enumerate() {
+            let Some(&erasure_index) = fi.erasure.distribution.get(disk_index) else {
+                failed = true;
+                break;
+            };
+            if erasure_index == 0 || erasure_index > data_shards {
+                continue;
+            }
+            let data_slot = erasure_index - 1;
+            if requested_data_shards[data_slot] {
+                failed = true;
+                break;
+            }
+            requested_data_shards[data_slot] = true;
+            let Some(disk) = disk.clone() else {
+                failed = true;
+                break;
+            };
+
+            let bucket = bucket.to_owned();
+            let object = object.to_owned();
+            let read_version = read_version.clone();
+            read_tasks.push(async move {
+                (
+                    disk_index,
+                    erasure_index,
+                    disk.clone(),
+                    disk.read_version("", &bucket, &object, &read_version, &read_opts).await,
+                )
+            });
+        }
+
+        if requested_data_shards.iter().any(|requested| !requested) {
+            failed = true;
+        }
+
+        let mut hydrated_data_shards = 0usize;
+        for (disk_index, erasure_index, disk, result) in join_all(read_tasks).await {
+            match result {
+                Ok(data_file_info)
+                    if data_file_info.erasure.index == erasure_index
+                        && metadata_early_stop_candidate_matches(&data_file_info, &fi)
+                        && data_file_info.data.as_ref().is_some_and(|data| !data.is_empty()) =>
+                {
+                    if let Some(slot) = parts_metadata.get_mut(disk_index) {
+                        *slot = data_file_info;
+                        hydrated_data_shards = hydrated_data_shards.saturating_add(1);
+                        if let Some(online_slot) = online_disks.get_mut(disk_index) {
+                            *online_slot = Some(disk);
+                        } else {
+                            failed = true;
+                        }
+                    } else {
+                        failed = true;
+                    }
+                }
+                _ => {
+                    failed = true;
+                }
+            }
+        }
+
+        if failed || hydrated_data_shards < data_shards {
+            return self
+                .get_object_fileinfo_gated_inner(bucket, object, opts, true, true, allow_read_version_coalescing)
+                .await;
+        }
+
+        fi.data = parts_metadata
+            .iter()
+            .filter(|file_info| file_info.erasure.index > 0 && file_info.erasure.index <= data_shards)
+            .find_map(|file_info| file_info.data.clone());
+        if fi.data.is_none() {
+            return self
+                .get_object_fileinfo_gated_inner(bucket, object, opts, true, true, allow_read_version_coalescing)
+                .await;
+        }
+
+        Ok(GetObjectFileInfo::owned(fi, parts_metadata, online_disks))
     }
 
     /// Like `get_object_fileinfo`, but `allow_early_stop=false` forces the full
@@ -4265,6 +4408,19 @@ mod tests {
                 assert!(is_get_metadata_early_stop_bounded_fanout_enabled());
             },
         );
+    }
+
+    #[test]
+    fn two_phase_read_plan_gate_defaults_off_and_honors_override() {
+        temp_env::with_var(ENV_RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE, None::<&str>, || {
+            assert!(!is_get_metadata_two_phase_read_plan_enabled());
+        });
+        temp_env::with_var(ENV_RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE, Some("true"), || {
+            assert!(is_get_metadata_two_phase_read_plan_enabled());
+        });
+        temp_env::with_var(ENV_RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE, Some("false"), || {
+            assert!(!is_get_metadata_two_phase_read_plan_enabled());
+        });
     }
 
     #[test]

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -432,7 +432,12 @@ impl SetDisks {
             .await?;
 
         if !metadata_snapshot.fi().inline_data() {
-            return Ok(metadata_snapshot);
+            if Self::metadata_snapshot_covers_all_data_shards(&metadata_snapshot) {
+                return Ok(metadata_snapshot);
+            }
+            return self
+                .get_object_fileinfo_gated_inner(bucket, object, opts, true, true, allow_read_version_coalescing)
+                .await;
         }
 
         let (mut fi, mut parts_metadata, mut online_disks) = metadata_snapshot.into_owned();
@@ -547,6 +552,36 @@ impl SetDisks {
         }
 
         Ok(GetObjectFileInfo::owned(fi, parts_metadata, online_disks))
+    }
+
+    fn metadata_snapshot_covers_all_data_shards(snapshot: &GetObjectFileInfo) -> bool {
+        let fi = snapshot.fi();
+        let Ok(erasure) = coding::Erasure::try_new_with_options(
+            fi.erasure.data_blocks,
+            fi.erasure.parity_blocks,
+            fi.erasure.block_size,
+            fi.uses_legacy_checksum,
+        ) else {
+            return false;
+        };
+        let mut data_shards = vec![false; erasure.data_shards];
+        for ((file_info, disk), &erasure_index) in snapshot
+            .parts_metadata()
+            .iter()
+            .zip(snapshot.online_disks())
+            .zip(fi.erasure.distribution.iter())
+        {
+            if erasure_index == 0 || erasure_index > erasure.data_shards || disk.is_none() {
+                continue;
+            }
+            if metadata_early_stop_candidate_matches(file_info, fi)
+                && file_info.erasure.index == erasure_index
+                && file_info.name == fi.name
+            {
+                data_shards[erasure_index - 1] = true;
+            }
+        }
+        data_shards.into_iter().all(|present| present)
     }
 
     /// Like `get_object_fileinfo`, but `allow_early_stop=false` forces the full


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#1309.

## Summary of Changes

Add a rollout-gated quorum-aware GET early-stop path for plain, single-part, non-inline objects. The path accepts a canonical metadata candidate once matching data or parity shard metadata reaches the normal data-shard read quorum, avoiding an unnecessary wait for every data disk while preserving the existing inline verifier and full-fanout fallback for unsafe or insufficiently covered candidates. The gate defaults off while testing1 validation is reviewed.

## Verification

- `cargo fmt --all --check` — passed.
- `git diff --check` — passed.
- `cargo test -p rustfs-ecstore two_phase_read_plan --lib -- --nocapture` — passed (3 tests).
- `cargo clippy -p rustfs-ecstore --lib --tests -- -D warnings` — passed.
- `make pre-commit` — passed with the repository Python compatibility shim.
- testing1 slow-tail: a task-scoped 2-second single-node `ReadVersion` delay measured 4/5 gate-on reads near 2.0 seconds versus 3/3 gate-off reads near 4.0 seconds; one gate-on sample remained near 4.0 seconds, so rollout remains gated off.
- testing1 4×4 black-box matrix (four nodes, four drives per node, round-robin, concurrency 64): gate-on GET averaged 13,179.55 obj/s at 64KiB, 11,939.93 obj/s at 256KiB, 2,747.69 obj/s at 2MiB, and 1,333.95 obj/s at 4MiB. The 64KiB and 2MiB gate-off controls averaged 13,094.87 obj/s and 2,733.91 obj/s respectively.

## Impact

No default behavior, wire-format, on-disk metadata, public API, or deployment contract changes. With `RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE` disabled, the existing GET path is unchanged. When enabled, only safe non-inline candidates may stop at a quorum-complete data/parity set; inline, compressed, encrypted, remote, multipart, mismatched, malformed, or insufficiently covered candidates retain the established full-fanout behavior.

## Additional Notes

Correctness: candidate identity and erasure-index matching remain required, and unsafe or incomplete candidates fall back to full fanout. Performance: the revised coverage rule allows parity-backed quorum completion without waiting for one slow data disk; the residual slow-tail outlier needs follow-up before rollout. Compatibility: no wire or persistent-format requirement is introduced and the gate remains disabled by default. Rollback is to unset or disable `RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE`.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
