### PR TITLE
fix(admin): replicate user secret-key rotation to peer sites

### DIFF
--- a/crates/iam/src/manager.rs
+++ b/crates/iam/src/manager.rs
@@ -1537,7 +1537,7 @@ where
         Ok(deleted_at)
     }
 
-    pub async fn update_user_secret_key(&self, access_key: &str, secret_key: &str) -> Result<()> {
+    pub async fn update_user_secret_key(&self, access_key: &str, secret_key: &str) -> Result<(OffsetDateTime, AccountStatus)> {
         if access_key.is_empty() || secret_key.is_empty() {
             return Err(Error::InvalidArgument);
         }
@@ -1552,7 +1552,16 @@ where
         let mut cred = u.credentials.clone();
         cred.secret_key = secret_key.to_string();
 
+        // Status is captured from the same credential snapshot the new secret
+        // is persisted with, so a caller replicating the rotation broadcasts
+        // exactly what was written rather than re-reading racily.
+        let status = if cred.is_valid() {
+            AccountStatus::Enabled
+        } else {
+            AccountStatus::Disabled
+        };
         let u = UserIdentity::from(cred);
+        let updated_at = u.update_at.unwrap_or_else(OffsetDateTime::now_utc);
         drop(cache);
         drop(users);
 
@@ -1560,7 +1569,8 @@ where
             .save_user_identity(access_key, UserType::Reg, u.clone(), None)
             .await?;
 
-        self.update_user_with_claims(access_key, u)
+        self.update_user_with_claims(access_key, u)?;
+        Ok((updated_at, status))
     }
 
     /// Add SSH public key for a user (for SFTP authentication)

--- a/crates/iam/src/sys.rs
+++ b/crates/iam/src/sys.rs
@@ -960,7 +960,11 @@ impl<T: Store> IamSys<T> {
         Ok(updated_at)
     }
 
-    pub async fn set_user_secret_key(&self, access_key: &str, secret_key: &str) -> Result<()> {
+    pub async fn set_user_secret_key(
+        &self,
+        access_key: &str,
+        secret_key: &str,
+    ) -> Result<(OffsetDateTime, rustfs_madmin::AccountStatus)> {
         if !is_access_key_valid(access_key) {
             return Err(IamError::InvalidAccessKeyLength);
         }
@@ -969,7 +973,9 @@ impl<T: Store> IamSys<T> {
             return Err(IamError::InvalidSecretKeyLength);
         }
 
-        self.store.update_user_secret_key(access_key, secret_key).await
+        let (updated_at, status) = self.store.update_user_secret_key(access_key, secret_key).await?;
+        self.notify_for_user(access_key, false).await;
+        Ok((updated_at, status))
     }
 
     /// Add SSH public key for a user (for SFTP authentication)

--- a/rustfs/src/admin/handlers/account.rs
+++ b/rustfs/src/admin/handlers/account.rs
@@ -33,6 +33,7 @@ use super::account_audit::{
 };
 use super::admin_json_response;
 use super::iam_error::iam_error_to_s3_error;
+use super::site_replication::site_replication_iam_change_hook;
 use super::supervise_admin_mutation;
 use crate::admin::auth::validate_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
@@ -48,6 +49,7 @@ use matchit::Params;
 use rustfs_config::MAX_ADMIN_REQUEST_BODY_SIZE;
 use rustfs_iam::mfa::service as mfa_service;
 use rustfs_madmin::account::{AccountMfaSummary, ChangePasswordRequest, IdentityType, SelfAccountInfo, SetUserSecretKeyRequest};
+use rustfs_madmin::{AccountStatus, AddOrUpdateUserReq, SITE_REPL_API_VERSION, SRIAMItem, SRIAMUser};
 use rustfs_policy::auth::is_secret_key_valid;
 use rustfs_policy::policy::action::{Action, AdminAction};
 use rustfs_utils::MaskedAccessKey;
@@ -239,7 +241,7 @@ impl Operation for ChangeOwnPasswordHandler {
             let iam_store =
                 current_ready_iam_handle().map_err(|_| s3::error(S3ErrorCode::InternalError, "iam is not initialized"))?;
 
-            iam_store
+            let (updated_at, status) = iam_store
                 .set_user_secret_key(&access_key, &new_secret_key)
                 .await
                 .map_err(iam_error_to_s3_error)?;
@@ -282,6 +284,11 @@ impl Operation for ChangeOwnPasswordHandler {
                 result = "changed",
                 "admin account state"
             );
+
+            // After the local revocation: peer delivery has no ordering
+            // dependency on it, and a slow peer must not delay killing the
+            // old sessions here.
+            broadcast_secret_key_rotation("change_own_password", &access_key, &new_secret_key, status, updated_at).await;
 
             Ok(revoked)
         })
@@ -390,7 +397,19 @@ impl Operation for SetUserSecretKeyHandler {
             let iam_store =
                 current_ready_iam_handle().map_err(|_| s3::error(S3ErrorCode::InternalError, "iam is not initialized"))?;
 
-            iam_store
+            // Derived credentials live outside the `iam-user` replication
+            // item: rotating one here would succeed locally and silently skip
+            // the peer broadcast, leaving the sites permanently diverged.
+            if let Some(existing) = iam_store.get_user(&target).await
+                && (existing.credentials.is_temp() || existing.credentials.is_service_account())
+            {
+                return Err(s3::error(
+                    S3ErrorCode::InvalidRequest,
+                    "the target access key is a derived credential; rotate service accounts through update-service-account",
+                ));
+            }
+
+            let (updated_at, status) = iam_store
                 .set_user_secret_key(&target, &request.secret_key)
                 .await
                 .map_err(iam_error_to_s3_error)?;
@@ -430,6 +449,11 @@ impl Operation for SetUserSecretKeyHandler {
                 "admin account state"
             );
 
+            // After the local revocation: peer delivery has no ordering
+            // dependency on it, and a slow peer must not delay killing the
+            // old sessions here.
+            broadcast_secret_key_rotation("set_user_secret_key", &target, &request.secret_key, status, updated_at).await;
+
             Ok(revoked)
         })
         .await?;
@@ -450,6 +474,58 @@ impl Operation for SetUserSecretKeyHandler {
 #[derive(Debug, serde::Serialize)]
 struct ChangePasswordResult {
     sessions_revoked: u32,
+}
+
+/// The `iam-user` item a secret rotation fans out to peer sites.
+///
+/// The non-empty secret routes the peer through its create-user path (not the
+/// status-only path), so the persisted status must ride along or a disabled
+/// account would be re-enabled on the peer.
+fn secret_key_rotation_item(access_key: &str, secret_key: &str, status: AccountStatus, updated_at: OffsetDateTime) -> SRIAMItem {
+    SRIAMItem {
+        r#type: "iam-user".to_string(),
+        iam_user: Some(SRIAMUser {
+            access_key: access_key.to_string(),
+            is_delete_req: false,
+            user_req: Some(AddOrUpdateUserReq {
+                secret_key: secret_key.to_string(),
+                policy: None,
+                status,
+            }),
+            api_version: Some(SITE_REPL_API_VERSION.to_string()),
+        }),
+        updated_at: Some(updated_at),
+        api_version: Some(SITE_REPL_API_VERSION.to_string()),
+        ..Default::default()
+    }
+}
+
+/// Fan a rotated secret out to peer sites.
+///
+/// The rotation is already durable locally; a broadcast failure only logs,
+/// matching the other IAM site-replication hooks. `status` and `updated_at`
+/// come from the persisting write itself, so the item carries exactly the
+/// state that was stored.
+async fn broadcast_secret_key_rotation(
+    action: &'static str,
+    access_key: &str,
+    secret_key: &str,
+    status: AccountStatus,
+    updated_at: OffsetDateTime,
+) {
+    if let Err(err) = site_replication_iam_change_hook(secret_key_rotation_item(access_key, secret_key, status, updated_at)).await
+    {
+        warn!(
+            component = LOG_COMPONENT_ADMIN,
+            subsystem = LOG_SUBSYSTEM_ACCOUNT,
+            event = EVENT_ADMIN_ACCOUNT_STATE,
+            action,
+            access_key = %MaskedAccessKey(access_key),
+            result = "site_replication_hook_failed",
+            error = ?err,
+            "admin account state"
+        );
+    }
 }
 
 /// Reject a new secret that would be useless or a no-op.
@@ -497,6 +573,49 @@ mod tests {
     #[test]
     fn a_valid_rotation_passes_validation() {
         validate_new_secret_key(&change_request("old-secret-key", "new-secret-key")).expect("must accept");
+    }
+
+    #[test]
+    fn rotation_item_takes_the_peer_create_path_and_preserves_status() {
+        let ts = OffsetDateTime::now_utc();
+        let item = secret_key_rotation_item("rotated-user", "new-secret-key", AccountStatus::Disabled, ts);
+
+        assert_eq!(item.r#type, "iam-user");
+        assert_eq!(item.updated_at, Some(ts));
+        assert!(item.api_version.is_some());
+
+        let user = item.iam_user.expect("iam-user payload");
+        assert_eq!(user.access_key, "rotated-user");
+        assert!(!user.is_delete_req);
+
+        let req = user.user_req.expect("user_req payload");
+        // A non-empty secret is what routes the peer through create-user
+        // instead of the status-only path.
+        assert_eq!(req.secret_key, "new-secret-key");
+        // Policy must stay unset so the peer's policy mapping is untouched.
+        assert!(req.policy.is_none());
+        // A disabled account must stay disabled on the peer.
+        assert_eq!(req.status, AccountStatus::Disabled);
+    }
+
+    #[test]
+    fn both_rotation_handlers_broadcast_after_revoking_sessions() {
+        let src = include_str!("account.rs");
+        for marker in [
+            "impl Operation for ChangeOwnPasswordHandler",
+            "impl Operation for SetUserSecretKeyHandler",
+        ] {
+            let start = src.find(marker).expect("handler should exist");
+            let block = &src[start..];
+            let block = &block[..block.find("\n}\n").expect("handler block end")];
+            let revoke = block
+                .find("revoke_sts_sessions_for_parent")
+                .expect("handler must revoke sessions");
+            let broadcast = block
+                .find("broadcast_secret_key_rotation(")
+                .expect("handler must broadcast the rotation to peer sites");
+            assert!(revoke < broadcast, "{marker}: peer broadcast must not delay the local session revocation");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

Fixes #6851.

## Summary of Changes

`set-user-secret-key` and the self-service `change own password` endpoint updated IAM locally but never fanned the rotation out through site replication, so a revoked secret stayed valid on every peer site indefinitely (verified in round-2 real-VM testing, rustfs/backlog#2080 case R2.8).

- Both rotation handlers now broadcast an `iam-user` `SRIAMItem` after the local write, the same item type `add-user` / `set-user-status` use. The peer's existing `apply_iam_user_item` consumes it unchanged: a non-empty secret routes through the peer create-user path.
- `IamManager::update_user_secret_key` now returns the persisted `updated_at` (for peer LWW) together with the `AccountStatus` captured from the same credential snapshot the secret is written with. Broadcasting the persisted status (instead of re-reading after the write) closes a race with a concurrent `set-user-status` and guarantees a disabled account stays disabled on the peer.
- `IamSys::set_user_secret_key` additionally calls `notify_for_user`, matching `create_user`/`set_user_status`; without it, other nodes of the same cluster kept authenticating the old secret in non-watcher deployments.
- The broadcast runs after the local STS session revocation, so an unreachable peer cannot delay killing sessions minted under the old secret.
- `set-user-secret-key` now rejects service-account/STS access keys as targets. Previously such a rotation "succeeded" locally (writing the credential into the Reg-user store path) and would now silently skip the peer broadcast; service accounts have their own replicated rotation path (`update-service-account`).

Adversarial validation (two independent reviewers, all lenses): security — broadcast channel is the same SigV4-signed peer endpoint `add-user` uses, access keys masked in new logs, disabled-stays-disabled verified; concurrency/durability — status/timestamp captured atomically with the persisting write, `notify_for_user` is fire-and-forget with no lock held; compatibility — `policy: None` is skip-serialized, old peers apply the item through the pre-existing create-user branch, no protocol change; performance — one broadcast per rotation, placed off the revocation path.

Pre-existing gaps surfaced by the review, out of scope here and tracked separately: the IAM retry/bootstrap snapshot never carries `iam-user` items (built from `list_users()`, which omits secrets), the peer applies items with its local clock so the LWW stale check compares across clock domains, the peer broadcast loop stops at the first failed peer, and the peer create-user apply path rebuilds credentials without claims.

## Verification

- `make pre-commit` (test-wiring step re-run with Python 3.12 due to a local `tomllib` gap; all steps pass, including workspace `quick-check`)
- `cargo clippy -p rustfs-iam -p rustfs --all-targets` (clean)
- `cargo test -p rustfs --lib admin::handlers::account` (19 passed, including two new regression tests: the rotation item preserves status/targets the peer create path, and both handlers broadcast after revoking sessions)
- `cargo test -p rustfs-iam --lib` (338 passed)

## Impact

- Admin API behavior change: `set-user-secret-key` now returns `InvalidRequest` for service-account/STS targets instead of corrupting the Reg store path. Rotations of regular users now propagate to peer sites and to other cluster nodes.
- `IamSys::set_user_secret_key` / `IamManager::update_user_secret_key` return types changed (all callers in-tree updated).
- No on-wire or on-disk format change; the broadcast reuses the existing `iam-user` item.

## Additional Notes

The peer applies the non-empty-secret item through its create-user path, which rebuilds the credential from access key + secret + status; per-user claims that are not site-replicated (e.g. SSH public keys) are not preserved by that pre-existing apply path.
