### PR TITLE
test(e2e): cover four-node four-drive cluster topology

### DIFF
--- a/crates/e2e_test/src/cluster_multidrive_pool_test.rs
+++ b/crates/e2e_test/src/cluster_multidrive_pool_test.rs
@@ -76,6 +76,28 @@ async fn cluster_multidrive_single_pool_smoke() -> TestResult {
     Ok(())
 }
 
+/// 4 nodes x 4 drives, single pool: exercise the maximum local erasure layout
+/// supported by the cluster harness. This remains in the nightly lane because
+/// it starts four real server processes and sixteen data directories.
+#[tokio::test]
+async fn cluster_four_node_four_drive_single_pool_smoke() -> TestResult {
+    crate::common::init_logging();
+
+    let mut cluster = RustFSTestClusterEnvironment::with_topology(ClusterTopology::single_pool_multidrive(4, 4)).await?;
+
+    let volumes = cluster.rustfs_volumes_arg();
+    assert_eq!(volumes.split(' ').count(), 16, "expected 16 explicit endpoints, got: {volumes}");
+    assert!(!volumes.contains('{'), "single-pool layout must not use ellipses: {volumes}");
+    assert!(cluster.nodes.iter().all(|node| node.data_dirs.len() == 4));
+
+    cluster.start().await?;
+    cluster.create_test_bucket(BUCKET).await?;
+
+    let payload = vec![0x3Cu8; 1024 * 1024];
+    put_get_roundtrip(&cluster, "multidrive-4/object", &payload).await?;
+    Ok(())
+}
+
 /// Two single-node pools, 2 drives each: the multi-pool layout boots and
 /// round-trips. Every pool is a distinct erasure pool (`pool_idx` 0 and 1).
 #[tokio::test]

--- a/docs/testing/e2e-suite-inventory.md
+++ b/docs/testing/e2e-suite-inventory.md
@@ -30,7 +30,7 @@
 | chaos | 2 |  |
 | checksum_upload_test | 7 |  |
 | cluster_concurrency_test | 3 | 🌙 |
-| cluster_multidrive_pool_test | 2 | 🌙 |
+| cluster_multidrive_pool_test | 3 | 🌙 |
 | common | 17 |  |
 | compression_test | 6 | ✅ |
 | connection_cap_test | 2 |  |
@@ -103,4 +103,4 @@
 | tls_hot_reload_test | 1 | ✅ |
 | version_id_regression_test | 10 | ✅ |
 
-**Total listed: 619 tests across 86 modules · PR smoke: 165 tests / 36 modules · merge/main full: 495 tests / 77 modules · nightly replication: 56 tests · nightly cluster faults: 29 tests / 7 modules · nightly protocols: 16 tests** · updated 2026-08-26.
+**Total listed: 620 tests across 86 modules · PR smoke: 165 tests / 36 modules · merge/main full: 495 tests / 77 modules · nightly replication: 56 tests · nightly cluster faults: 30 tests / 7 modules · nightly protocols: 16 tests** · updated 2026-08-31.


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#1325.

## Summary of Changes

Extend the existing cluster test-infrastructure smoke coverage with a real 4-node x 4-drive single-pool scenario. The test exercises the maximum local erasure layout supported by the harness, verifies all sixteen drive endpoints are assembled explicitly, starts the nightly cluster, and validates a PUT/GET byte-for-byte round trip. Update the committed e2e inventory and nightly test count accordingly.

This is intentionally a focused follow-up to the already merged #4914, #4936, #4937, #4938, and #6886 infrastructure blocks. Cross-host two-pool wiring and network proxy integration remain outside this single-host slice because they require multi-host address/path isolation.

## Verification

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p e2e_test --lib --no-run`
- `cargo test -p e2e_test common::tests::topology_single_pool_accepts_any_drive_count --lib -- --nocapture`
- `cargo nextest list --profile e2e-nightly -p e2e_test --message-format json` — the nightly cluster module lists 3 tests.
- The focused 4-node x 4-drive e2e execution was attempted, but this runner reported `no available E2E test port found` before starting a server; no behavioral pass is claimed from that attempt.

## Impact

Test-only and documentation-only changes. No production behavior, API, configuration, compatibility, or deployment impact.

## Additional Notes

The new scenario remains excluded from merge-gate `e2e-full` and is selected by the serial `e2e-nightly` cluster lane. The test uses the existing readiness handshake and isolated temporary directories; it does not add fixed sleeps or retries.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](https://github.com/rustfs/rustfs/blob/main/CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
