### PR TITLE
test(filemeta): pin persisted metadata key literals

### DIFF
--- a/crates/filemeta/tests/persisted_metadata_keys.rs
+++ b/crates/filemeta/tests/persisted_metadata_keys.rs
@@ -1,0 +1,29 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use s3s::header::{
+    X_AMZ_OBJECT_LOCK_LEGAL_HOLD, X_AMZ_OBJECT_LOCK_MODE, X_AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE, X_AMZ_RESTORE,
+    X_AMZ_SERVER_SIDE_ENCRYPTION,
+};
+
+#[test]
+fn persisted_metadata_keys_are_byte_stable() {
+    // These HTTP-header constants are also persisted xl.meta map keys. A drift can make an
+    // existing WORM retention appear absent or make a restored object's data directory reclaimable.
+    assert_eq!(X_AMZ_OBJECT_LOCK_LEGAL_HOLD.as_str(), "x-amz-object-lock-legal-hold");
+    assert_eq!(X_AMZ_OBJECT_LOCK_MODE.as_str(), "x-amz-object-lock-mode");
+    assert_eq!(X_AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE.as_str(), "x-amz-object-lock-retain-until-date");
+    assert_eq!(X_AMZ_RESTORE.as_str(), "x-amz-restore");
+    assert_eq!(X_AMZ_SERVER_SIDE_ENCRYPTION.as_str(), "x-amz-server-side-encryption");
+}


### PR DESCRIPTION
## Related Issues

rustfs/backlog#1733

## Summary of Changes

Add a required rustfs-filemeta integration test that pins the five s3s header literals also used as persisted xl.meta map keys. This protects existing WORM retention metadata and restored-object data-directory accounting from silent key drift without changing production behavior.

## Verification

- `cargo test -p rustfs-filemeta --test persisted_metadata_keys` — passed
- `cargo fmt --all --check` — passed
- `cargo clippy --all-targets -p rustfs-filemeta -- -D warnings` — passed
- `cargo check --workspace --all-targets` — passed in 10m 44s
- Mutation: changed the expected x-amz-restore literal and confirmed the integration test failed with the exact byte mismatch before restoring it

## Impact

No runtime, API, deployment, configuration, or on-disk-format behavior changes. CI will fail if any of the five persisted key literals drift.

## Additional Notes

- Correctness adversary: attacked all five issue-specified literals and the required nextest-visible integration-test placement — no break found.
- Simplicity adversary: attacked the one-file test-only diff for a smaller equivalent and duplicate scaffolding — no smaller meaningful diff found.
- Security advisory review: checked the WORM fail-open and restored-data reclamation failure classes; this diff changes no reader, writer, authorization, or logging path.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
