### PR TITLE
test(perf): align GET attribution harness with backlog 2093

### DIFF
--- a/scripts/run_get_1mib_abba_stage_metrics.sh
+++ b/scripts/run_get_1mib_abba_stage_metrics.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Dedicated exact-1MiB GET attribution harness for rustfs/backlog#1434.
+# Dedicated exact-1MiB GET attribution harness for rustfs/backlog#2093.
 #
 # The heavy lifting stays in run_get_codec_streaming_smoke.sh. This wrapper only
 # fixes the experiment matrix so a reviewer can reproduce the isolated-host
@@ -59,7 +59,7 @@ Usage:
   scripts/run_get_1mib_abba_stage_metrics.sh [options]
 
 Purpose:
-  Run the rustfs/backlog#1434 exact-1MiB isolated-host GET attribution matrix:
+  Run the rustfs/backlog#2093 exact-1MiB isolated-host GET attribution matrix:
   - object size fixed to 1MiB / 1048576 bytes
   - legacy and codec-legacy read-path profiles
   - normal and reverse profile ordering for ABBA order-bias checks
@@ -256,7 +256,7 @@ rustc_version="$(rustc --version 2>/dev/null || echo unavailable)"
 cargo_version="$(cargo --version 2>/dev/null || echo unavailable)"
 
 cat >"${OUT_DIR}/manifest.env" <<EOF
-issue=rustfs/backlog#1434
+issue=rustfs/backlog#2093
 generated_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 branch=${branch}
 git_head=${git_head}
@@ -297,6 +297,11 @@ warp_object_lifecycle=${WARP_OBJECT_LIFECYCLE}
 warp_prepare_duration=${WARP_PREPARE_DURATION}
 warp_extra_args=${WARP_EXTRA_ARGS}
 warp_warmup_get_before_bench=${WARP_WARMUP_GET_BEFORE_BENCH}
+get_seek_buffer_enable=${RUSTFS_GET_SEEK_BUFFER_ENABLE:-unset}
+get_small_body_once_enable=${RUSTFS_GET_SMALL_BODY_ONCE_ENABLE:-unset}
+get_lockstep_data_shards_only_enable=${RUSTFS_GET_LOCKSTEP_DATA_SHARDS_ONLY_ENABLE:-unset}
+get_metadata_read_version_coalesce=${RUSTFS_GET_METADATA_READ_VERSION_COALESCE:-unset}
+object_data_cache_mode=${RUSTFS_OBJECT_DATA_CACHE_MODE:-unset}
 skip_build=${SKIP_BUILD}
 dry_run=${DRY_RUN}
 rustfs_bin=${RUSTFS_BIN}

--- a/scripts/test_get_1mib_abba_stage_metrics.sh
+++ b/scripts/test_get_1mib_abba_stage_metrics.sh
@@ -25,7 +25,7 @@ trap cleanup EXIT
   --skip-build \
   --dry-run >/dev/null
 
-rg -qx 'issue=rustfs/backlog#1434' "${OUT_DIR}/manifest.env"
+rg -qx 'issue=rustfs/backlog#2093' "${OUT_DIR}/manifest.env"
 rg -qx 'exact_size=1MiB' "${OUT_DIR}/manifest.env"
 rg -qx 'exact_size_bytes=1048576' "${OUT_DIR}/manifest.env"
 rg -qx 'read_path_profiles=legacy,codec-legacy' "${OUT_DIR}/manifest.env"
@@ -41,6 +41,11 @@ rg -qx 'diagnostic_obs_metric_endpoint=http://127.0.0.1:4318/v1/metrics' "${OUT_
 rg -qx 'diagnostic_obs_meter_interval=1' "${OUT_DIR}/manifest.env"
 rg -qx 'compressed_fallback_probe=true' "${OUT_DIR}/manifest.env"
 rg -qx 'performance_conclusion=not_encoded_by_harness_collect_raw_abba_stage_metrics_first' "${OUT_DIR}/manifest.env"
+rg -qx 'get_seek_buffer_enable=unset' "${OUT_DIR}/manifest.env"
+rg -qx 'get_small_body_once_enable=unset' "${OUT_DIR}/manifest.env"
+rg -qx 'get_lockstep_data_shards_only_enable=unset' "${OUT_DIR}/manifest.env"
+rg -qx 'get_metadata_read_version_coalesce=unset' "${OUT_DIR}/manifest.env"
+rg -qx 'object_data_cache_mode=unset' "${OUT_DIR}/manifest.env"
 rg -Fq '("service.name", "service_name", "job", "otel_scope_name")' "${SCRIPT_DIR}/run_get_codec_streaming_smoke.sh"
 rg -Fq '("service_name", "service.name", "job", "otel_scope_name")' "${SCRIPT_DIR}/run_get_codec_streaming_smoke.sh"
 rg -Fq 'compressed_size = max(object_size, codec_min_size, 128 * 1024)' "${SCRIPT_DIR}/run_get_codec_streaming_smoke.sh"


### PR DESCRIPTION
## Related Issues

Relates to rustfs/backlog#2093.

## Summary of Changes

Align the exact-1MiB GET attribution harness with backlog #2093 instead of the stale #1434 reference. Record seek/materialize, lockstep, metadata coalescer, and object-cache environment values in the run manifest so ABBA results remain reproducible and comparable. Extend the wiring test to assert the new provenance fields.

## Verification

- `bash scripts/test_get_1mib_abba_stage_metrics.sh`
- `bash -n scripts/run_get_1mib_abba_stage_metrics.sh scripts/test_get_1mib_abba_stage_metrics.sh`
- `git diff --check`

## Impact

Test-harness and manifest-only change. No RustFS runtime, API, wire-format, metadata, or default configuration behavior changes.

## Additional Notes

The harness remains diagnostic-only and does not encode a performance conclusion. Runtime ABBA evidence and limitations are recorded in backlog #2093. Rollback is a single commit revert.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
