### PR TITLE
test(e2e): exercise cluster volume fault proxy

### DIFF
--- a/crates/e2e_test/src/cluster_multidrive_pool_test.rs
+++ b/crates/e2e_test/src/cluster_multidrive_pool_test.rs
@@ -27,8 +27,10 @@
 //! Readiness is established by the harness's `start()` handshake (TCP reachability
 //! plus an S3 `ListBuckets` poll) — there are no fixed sleeps.
 //!
-//! Out of scope for this block (tracked separately): network fault injection
-//! (toxiproxy / socket proxy) and 5GiB large-object budgets.
+//! The volume-proxy smoke below also proves that the socket-level fault proxy
+//! can be installed before startup without changing the client-facing node URL.
+//! A full lock-plane partition matrix and 5GiB large-object budget remain
+//! tracked separately.
 
 use crate::common::{ClusterTopology, RustFSTestClusterEnvironment};
 
@@ -124,4 +126,28 @@ async fn cluster_two_pool_smoke() -> TestResult {
     let payload = vec![0x5Au8; 256 * 1024];
     put_get_roundtrip(&cluster, "twopool/object", &payload).await?;
     Ok(())
+}
+
+/// A real cluster smoke for the volume FaultProxy wiring. The proxy target is
+/// not listening yet when it is created; cluster startup must still converge
+/// once the target node starts, and peer disk/RPC traffic must traverse it.
+#[tokio::test]
+async fn cluster_volume_fault_proxy_pass_smoke() -> TestResult {
+    crate::common::init_logging();
+
+    let mut cluster = RustFSTestClusterEnvironment::with_topology(ClusterTopology::single_pool_multidrive(2, 2)).await?;
+    let proxy = cluster.start_volume_proxy_for_node(0).await?;
+    let proxied = proxy.local_addr().to_string();
+    assert!(cluster.rustfs_volumes_arg().contains(&proxied));
+
+    let result: TestResult = async {
+        cluster.start().await?;
+        cluster.create_test_bucket(BUCKET).await?;
+        let payload = vec![0x6Du8; 256 * 1024];
+        put_get_roundtrip(&cluster, "volume-proxy/object", &payload).await
+    }
+    .await;
+
+    proxy.shutdown().await;
+    result
 }

--- a/docs/testing/e2e-suite-inventory.md
+++ b/docs/testing/e2e-suite-inventory.md
@@ -30,7 +30,7 @@
 | chaos | 2 |  |
 | checksum_upload_test | 7 |  |
 | cluster_concurrency_test | 3 | 🌙 |
-| cluster_multidrive_pool_test | 3 | 🌙 |
+| cluster_multidrive_pool_test | 4 | 🌙 |
 | common | 17 |  |
 | compression_test | 6 | ✅ |
 | connection_cap_test | 2 |  |
@@ -103,4 +103,4 @@
 | tls_hot_reload_test | 1 | ✅ |
 | version_id_regression_test | 10 | ✅ |
 
-**Total listed: 620 tests across 86 modules · PR smoke: 165 tests / 36 modules · merge/main full: 495 tests / 77 modules · nightly replication: 56 tests · nightly cluster faults: 30 tests / 7 modules · nightly protocols: 16 tests** · updated 2026-08-31.
+**Total listed: 621 tests across 86 modules · PR smoke: 165 tests / 36 modules · merge/main full: 495 tests / 77 modules · nightly replication: 56 tests · nightly cluster faults: 31 tests / 7 modules · nightly protocols: 16 tests** · updated 2026-08-31.


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#1325.

## Summary of Changes

Add a real cluster smoke for the FaultProxy volume-endpoint wiring introduced by #6909. The test starts a 2-node x 2-drive single-pool cluster with one node's volume endpoints routed through a local FaultProxy before startup, then verifies cluster readiness and a PUT/GET round trip. This covers the process boundary that the earlier process-free endpoint rewrite test could not exercise.

## Verification

- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p e2e_test common::tests::volume_proxy_rewrites_cluster_volume_endpoint --lib -- --nocapture` — passed.
- `cargo test -p e2e_test fault_proxy::tests --lib -- --nocapture` — 7 passed.
- `cargo test -p e2e_test cluster_multidrive_pool_test --lib --no-run` — passed.
- The real cluster smoke was attempted locally but the runner returned `no available E2E test port found` before server startup; no behavioral pass is claimed locally.

## Impact

Test-only cluster coverage and e2e inventory maintenance. No production behavior, API, wire protocol, or configuration impact.

## Additional Notes

The scenario remains in the serial `e2e-nightly` cluster lane. The proxy currently routes the selected node's shared volume endpoint, so a true lock-plane-only partition still requires an independently configured internal RPC listener. Cross-host two-pool topology and 5 GiB budget coverage remain outside this single-host slice.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](https://github.com/rustfs/rustfs/blob/main/CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
