### PR TITLE
test(ecstore): pin default bucket config bytes

### DIFF
--- a/crates/ecstore/src/store/mod.rs
+++ b/crates/ecstore/src/store/mod.rs
@@ -1205,6 +1205,23 @@ mod tests {
     use serial_test::serial;
     use tempfile::TempDir;
 
+    #[test]
+    fn g_d2_008_default_versioning_config_keeps_persisted_bytes() {
+        let bytes = crate::bucket::utils::serialize::<VersioningConfiguration>(&ENABLED_VERSIONING_CONFIG)
+            .expect("the default Versioning configuration must serialize");
+        assert_eq!(bytes, b"<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>");
+    }
+
+    #[test]
+    fn g_d2_009_default_object_lock_config_keeps_persisted_bytes() {
+        let bytes = crate::bucket::utils::serialize::<ObjectLockConfiguration>(&ENABLED_OBJECT_LOCK_CONFIG)
+            .expect("the default Object Lock configuration must serialize");
+        assert_eq!(
+            bytes,
+            b"<ObjectLockConfiguration><ObjectLockEnabled>Enabled</ObjectLockEnabled></ObjectLockConfiguration>"
+        );
+    }
+
     #[tokio::test]
     async fn test_get_disk_infos() {
         let disks = vec![None, None]; // Empty disks for testing


### PR DESCRIPTION
## Related Issues

Part of rustfs/backlog#1733 (`g-d2-008` and `g-d2-009`).

## Summary of Changes

Pin the exact bytes produced by the existing ecstore persistence serializer for the two configurations written during bucket creation: enabled Versioning and enabled Object Lock. The tests consume the same private production constants used by `handle_make_bucket`, so a serializer-order, element-name, omission, or value-spelling drift fails before it can change newly persisted bucket metadata.

## Verification

- `cargo fmt --all --check` — passed
- `git diff --check` — passed
- `cargo test --package rustfs-ecstore g_d2_00` — 2 passed, 0 failed
- TDD red: both tests initially compared against empty goldens and failed while reporting the real production bytes
- Mutation red: changing the first byte of `Enabled` to lowercase in each expected document made both named tests fail; the mutations were reverted

The macOS linker emitted its existing oversized compact-unwind warning while linking the ecstore test binary; compilation and both tests completed successfully.

## Impact

Test-only. No production function, public API, dependency, configuration, or persisted byte is changed. Future drift in the two create-bucket default XML documents becomes an immediate test failure.

## Additional Notes

The expected bytes are observations from the live `crate::bucket::utils::serialize` path, not a second serializer or a reconstructed DTO.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
