### PR TITLE
test(admin): prove backup import rollback compatibility

### DIFF
--- a/rustfs/src/admin/handlers/bucket_meta.rs
+++ b/rustfs/src/admin/handlers/bucket_meta.rs
@@ -1014,6 +1014,66 @@ mod imported_config_apply_tests {
     }
 
     #[test]
+    fn g_d3_005_new_writer_backup_payloads_pass_old_import_validators() {
+        // Captured from the gateway persistence writers at a16e94426b36c6a454dc200a5639c711b590e1eb.
+        // Keep these bytes independent of RustFS's old serializer so rollback drift stays visible.
+        let new_writer_payloads: [(&str, &[u8]); 7] = [
+            (
+                BUCKET_NOTIFICATION_CONFIG,
+                b"<NotificationConfiguration></NotificationConfiguration>",
+            ),
+            (
+                BUCKET_LIFECYCLE_CONFIG,
+                b"<LifecycleConfiguration><Rule><Expiration><Days>30</Days></Expiration><Filter><Prefix>logs/</Prefix></Filter><ID>expire</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>",
+            ),
+            (
+                BUCKET_SSECONFIG,
+                b"<ServerSideEncryptionConfiguration><Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>AES256</SSEAlgorithm></ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>",
+            ),
+            (
+                BUCKET_TAGGING_CONFIG,
+                b"<Tagging><TagSet><Tag><Key>team</Key><Value>storage</Value></Tag></TagSet></Tagging>",
+            ),
+            (
+                OBJECT_LOCK_CONFIG,
+                b"<ObjectLockConfiguration><ObjectLockEnabled>Enabled</ObjectLockEnabled></ObjectLockConfiguration>",
+            ),
+            (
+                BUCKET_VERSIONING_CONFIG,
+                b"<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>",
+            ),
+            (
+                BUCKET_REPLICATION_CONFIG,
+                b"<ReplicationConfiguration><Role>arn:aws:iam::123456789012:role/replication</Role><Rule><DeleteMarkerReplication><Status>Disabled</Status></DeleteMarkerReplication><Destination><Bucket>arn:aws:s3:::backup</Bucket></Destination><Filter><Prefix></Prefix></Filter><Priority>1</Priority><Status>Enabled</Status></Rule></ReplicationConfiguration>",
+            ),
+        ];
+
+        let imported_xml_cases = import_cases()
+            .into_iter()
+            .filter(|case| case.conf_name != BUCKET_TARGETS_FILE)
+            .collect::<Vec<_>>();
+        assert_eq!(new_writer_payloads.len(), imported_xml_cases.len());
+        assert!(
+            imported_xml_cases
+                .iter()
+                .all(|case| new_writer_payloads.iter().any(|(name, _)| *name == case.conf_name))
+        );
+
+        let mut metadatas = imported_bucket();
+        for (conf_name, payload) in new_writer_payloads {
+            assert!(
+                apply_imported_bucket_config(&mut metadatas, BUCKET, conf_name, payload.to_vec(), imported_at())
+                    .unwrap_or_else(|error| panic!("new-writer {conf_name} must pass the old import validator: {error}"))
+            );
+            let case = imported_xml_cases
+                .iter()
+                .find(|case| case.conf_name == conf_name)
+                .unwrap_or_else(|| panic!("{conf_name} must have an import mapping"));
+            assert_eq!((case.payload)(&metadatas[BUCKET]), payload);
+        }
+    }
+
+    #[test]
     fn a_rejected_payload_leaves_the_field_untouched() {
         for case in import_cases() {
             let mut metadatas = imported_bucket();


### PR DESCRIPTION
## Related Issues

Part of rustfs/backlog#1733 (`g-d3-005`; this PR does not close the parent issue).

## Summary of Changes

- Pin the canonical XML emitted by the gateway persistence writers for every XML family accepted by the old RustFS bucket metadata import path.
- Feed all seven payloads through the production `apply_imported_bucket_config` dispatch, exercising the real `deserialize::<T>` validator selected for notification, lifecycle, encryption, tagging, object lock, versioning, and replication metadata.
- Assert the fixture set stays complete relative to the old import table and that every accepted payload lands in its production metadata field.

This complements the archive-level coverage in rustfs/gateway#486 without duplicating ZIP plumbing in RustFS.

## Verification

- `cargo fmt --all --check`
- `CARGO_TARGET_DIR=/Users/artisan/www/rustfs/target cargo test -p rustfs g_d3_005_new_writer_backup_payloads_pass_old_import_validators --lib`
- `CARGO_TARGET_DIR=/Users/artisan/www/rustfs/target cargo test -p rustfs admin::handlers::bucket_meta::imported_config_apply_tests --lib`
- `CARGO_TARGET_DIR=/Users/artisan/www/rustfs/target cargo clippy -p rustfs --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/Users/artisan/www/rustfs/target cargo check --workspace --all-targets`
- `CARGO_TARGET_DIR=/Users/artisan/www/rustfs/target make pre-commit`

TDD evidence: omitting the notification fixture failed the completeness assertion with `left: 6, right: 7`. Mutation evidence: temporarily routing `notification.xml` through `deserialize::<Tagging>` made the focused test fail with `unexpected tag name`; the production dispatch was then restored.

## Impact

Test-only rollback compatibility evidence. There is no production behavior, API, configuration, deployment, or persistence-format change.

## Additional Notes

### Role Verdicts

- `simplicity-adversary`: attacked duplicate archive coverage and unnecessary helpers; the test remains a single import-path oracle and delegates ZIP compatibility to rustfs/gateway#486 — no break found.
- `migration-safety-reviewer`: attacked missing families, same-serializer coupling, and proxy-only validation; fixed gateway writer bytes cover all seven actual old XML import mappings — no break found.
- `test-adversary`: attacked decorative assertions by removing one family and by mutating the real validator dispatch; both changes produced precise red results — no break found.
- `protocol-auditor`: attacked config-name, validator-type, and destination-field mismatches for all seven XML families — no break found.

No protected files are touched.
