### PR TITLE
fix(ecstore): fence snapshot stream polls on lock loss

### DIFF
--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -884,8 +884,7 @@ impl AsyncRead for SelectObjectSnapshotReader {
         }
         let filled_before = buf.filled().len();
         let poll = Pin::new(&mut self.inner).poll_read(cx, buf);
-        let reached_eof = matches!(&poll, Poll::Ready(Ok(()))) && buf.filled().len() == filled_before;
-        if self.lease.is_lost() || (reached_eof && self.lease.check().is_err()) {
+        if self.lease.check().is_err() {
             buf.set_filled(filled_before);
             return Poll::Ready(Err(std::io::Error::other(SnapshotConsistencyError::LockLost)));
         }
@@ -4209,7 +4208,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn select_snapshot_reader_checks_guards_at_eof_before_monitor_runs() {
+    async fn select_snapshot_reader_checks_guards_before_monitor_runs() {
         let (guard, signal, client) = refresh_failure_test_guard("select-snapshot-eof-fence").await;
         client.reject_refreshes();
         client
@@ -4234,7 +4233,7 @@ mod tests {
             .await
             .expect_err("EOF fence must reject a lease lost before its monitor is scheduled");
 
-        assert_eq!(output, b"old-generation");
+        assert!(output.is_empty(), "bytes from a known-lost snapshot must not escape");
         assert_eq!(error.kind(), std::io::ErrorKind::Other);
     }
 


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#1313.

## Summary of Changes

Make the existing SelectObjectContent snapshot reader synchronously validate its namespace-lock guards after every inner stream poll instead of waiting for EOF when the asynchronous lock-loss monitor has not run yet. If the lock is lost during that poll, the reader rolls back newly filled bytes and returns the existing snapshot consistency error. The pre-poll watch/atomic fast path remains unchanged.

Update the current-thread regression so a known-lost lock cannot expose the old-generation bytes while the monitor has made no progress.

## Verification

- `cargo test -p rustfs-ecstore select_snapshot_reader_rolls_back_bytes_when_lock_is_lost_during_poll --lib -- --nocapture` — passed.
- `cargo test -p rustfs-ecstore select_snapshot_reader_checks_guards_before_monitor_runs --lib -- --nocapture` — passed.
- `cargo test -p rustfs-ecstore select_snapshot_lock_loss_is_broadcast_to_remaining_pending_readers --lib -- --nocapture` — passed.
- `cargo fmt --all --check` — passed.
- `git diff --check` — passed.
- `cargo clippy -p rustfs-ecstore --lib --tests -- -D warnings` — passed.

## Impact

No lock domain, lock acquisition order, RPC fanout, configuration, public API, or wire-format change. A SelectObjectContent stream whose lock is already lost now fails before exposing bytes, and a lock lost during an inner poll rolls back that poll's bytes. The reader performs one synchronous guard validation after each poll; the existing lightweight watch/atomic fast path remains before the poll.

## Additional Notes

Two independent final-diff reviews covering correctness/concurrency and performance/compatibility passed. This change intentionally does not alter ordinary GET locking or introduce an O(pool) production lock-acquisition strategy.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
