### PR TITLE
test(ecstore): make heal rename fixture deterministic

### DIFF
--- a/crates/ecstore/src/set_disk/ops/heal.rs
+++ b/crates/ecstore/src/set_disk/ops/heal.rs
@@ -3065,9 +3065,20 @@ mod heal_result_report_tests {
 
             let payload = vec![0x5a; 1024 * 1024];
             let mut reader = PutObjReader::from_vec(payload);
-            set.put_object(&bucket, object, &mut reader, &ObjectOptions::default())
-                .await
-                .expect("source object should be written");
+            // This fixture removes physical shards immediately after PUT. A
+            // lock-owning PUT may quorum-ack before its rename tail drains, so
+            // keep the isolated setup on the full-fanout commit path.
+            set.put_object(
+                &bucket,
+                object,
+                &mut reader,
+                &ObjectOptions {
+                    no_lock: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("source object should be written");
             let source = disks[2]
                 .read_version("", &bucket, object, "", &ReadOptions::default())
                 .await


### PR DESCRIPTION
## Related Issues

Fixes rustfs/rustfs#6931.

## Summary of Changes

- Make the heal rename outcome fixture use the full-fanout commit path by setting `no_lock: true` on its source PUT.
- Keep the production heal implementation unchanged while ensuring physical shards exist before the test removes them.

## Verification

- Focused repeat of `heal_rename_outcome_matrix_reports_partial_and_retries_failed_targets`: 20 passed, 0 failed.
- Existing `no_lock_put_waits_for_rename_tail_under_outer_guard`: 1 passed, 0 failed.
- Modified ecstore full-nextest run: the target test passed; unrelated flakes remain tracked separately.
- `cargo fmt --all --check` — passed.
- `git diff --check` — passed.

## Impact

Test-only change. No production behavior, API, persistence format, or deployment configuration changes.

## Additional Notes

The original failure occurred under full-nextest I/O load when a lock-owning PUT could quorum-ack before its rename tail drained; the test then removed a shard path that did not yet exist. The fix uses the existing no-lock contract and does not add sleeps, retries, quarantines, or weakened assertions. This is a Draft PR while the companion full-suite flake fixes are reviewed.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
