### PR TITLE
chore(capacity): update default refresh tuning

### DIFF
--- a/crates/config/src/constants/capacity.rs
+++ b/crates/config/src/constants/capacity.rs
@@ -59,20 +59,20 @@ pub const ENV_CAPACITY_MAX_TIMEOUT: &str = "RUSTFS_CAPACITY_MAX_TIMEOUT";
 // ============================================================================
 
 /// Scheduled update interval in seconds
-/// Default: 120 seconds (2 minutes)
-pub const DEFAULT_SCHEDULED_UPDATE_INTERVAL_SECS: u64 = 120;
+/// Default: 600 seconds (10 minutes)
+pub const DEFAULT_SCHEDULED_UPDATE_INTERVAL_SECS: u64 = 600;
 
 /// Write trigger delay in seconds
-/// Default: 5 seconds
-pub const DEFAULT_WRITE_TRIGGER_DELAY_SECS: u64 = 5;
+/// Default: 30 seconds
+pub const DEFAULT_WRITE_TRIGGER_DELAY_SECS: u64 = 30;
 
 /// Write frequency threshold (writes per minute)
-/// Default: 5 writes/minute
-pub const DEFAULT_WRITE_FREQUENCY_THRESHOLD: usize = 5;
+/// Default: 20 writes/minute
+pub const DEFAULT_WRITE_FREQUENCY_THRESHOLD: usize = 20;
 
 /// Fast update threshold in seconds
-/// Default: 30 seconds
-pub const DEFAULT_FAST_UPDATE_THRESHOLD_SECS: u64 = 30;
+/// Default: 120 seconds
+pub const DEFAULT_FAST_UPDATE_THRESHOLD_SECS: u64 = 120;
 
 /// Maximum files threshold for sampling
 /// Default: 200,000 files
@@ -128,5 +128,17 @@ mod tests {
         assert_eq!(ENV_CAPACITY_ENABLE_DYNAMIC_TIMEOUT, "RUSTFS_CAPACITY_ENABLE_DYNAMIC_TIMEOUT");
         assert_eq!(ENV_CAPACITY_MIN_TIMEOUT, "RUSTFS_CAPACITY_MIN_TIMEOUT");
         assert_eq!(ENV_CAPACITY_MAX_TIMEOUT, "RUSTFS_CAPACITY_MAX_TIMEOUT");
+    }
+
+    #[test]
+    fn test_capacity_default_values() {
+        assert_eq!(DEFAULT_SCHEDULED_UPDATE_INTERVAL_SECS, 600);
+        assert_eq!(DEFAULT_WRITE_TRIGGER_DELAY_SECS, 30);
+        assert_eq!(DEFAULT_WRITE_FREQUENCY_THRESHOLD, 20);
+        assert_eq!(DEFAULT_FAST_UPDATE_THRESHOLD_SECS, 120);
+        assert_eq!(DEFAULT_MAX_FILES_THRESHOLD, 200_000);
+        assert_eq!(DEFAULT_STAT_TIMEOUT_SECS, 3);
+        assert_eq!(DEFAULT_SAMPLE_RATE, 200);
+        assert_eq!(DEFAULT_CAPACITY_METRICS_INTERVAL_SECS, 600);
     }
 }

--- a/crates/object-capacity/README.md
+++ b/crates/object-capacity/README.md
@@ -282,10 +282,10 @@ The configuration constants are defined in `crates/config/src/constants/capacity
 
 | Environment Variable | Default | Description |
 | --- | --- | --- |
-| `RUSTFS_CAPACITY_SCHEDULED_INTERVAL` | `120s` | Scheduled refresh interval |
-| `RUSTFS_CAPACITY_WRITE_TRIGGER_DELAY` | `5s` | Debounce delay after writes |
-| `RUSTFS_CAPACITY_WRITE_FREQUENCY_THRESHOLD` | `5` | Recent 60-second write-frequency threshold |
-| `RUSTFS_CAPACITY_FAST_UPDATE_THRESHOLD` | `30s` | Cache age required before fast refresh is considered |
+| `RUSTFS_CAPACITY_SCHEDULED_INTERVAL` | `600s` | Scheduled refresh interval |
+| `RUSTFS_CAPACITY_WRITE_TRIGGER_DELAY` | `30s` | Debounce delay after writes |
+| `RUSTFS_CAPACITY_WRITE_FREQUENCY_THRESHOLD` | `20` | Recent 60-second write-frequency threshold |
+| `RUSTFS_CAPACITY_FAST_UPDATE_THRESHOLD` | `120s` | Cache age required before fast refresh is considered |
 | `RUSTFS_CAPACITY_MAX_FILES_THRESHOLD` | `200000` | Exact-count file threshold |
 | `RUSTFS_CAPACITY_STAT_TIMEOUT` | `3s` (`60s` with `RUSTFS_DRIVE_TIMEOUT_PROFILE=high_latency`) | Base scan timeout |
 | `RUSTFS_CAPACITY_SAMPLE_RATE` | `200` | Overflow-file sampling interval |

--- a/crates/object-capacity/README_ZH.md
+++ b/crates/object-capacity/README_ZH.md
@@ -282,10 +282,10 @@ get_capacity_manager()
 
 | 环境变量 | 默认值 | 说明 |
 | --- | --- | --- |
-| `RUSTFS_CAPACITY_SCHEDULED_INTERVAL` | `120s` | 定时刷新间隔 |
-| `RUSTFS_CAPACITY_WRITE_TRIGGER_DELAY` | `5s` | 写后防抖延迟 |
-| `RUSTFS_CAPACITY_WRITE_FREQUENCY_THRESHOLD` | `5` | 最近 60 秒写频率阈值 |
-| `RUSTFS_CAPACITY_FAST_UPDATE_THRESHOLD` | `30s` | 缓存超过该年龄后才考虑快速刷新 |
+| `RUSTFS_CAPACITY_SCHEDULED_INTERVAL` | `600s` | 定时刷新间隔 |
+| `RUSTFS_CAPACITY_WRITE_TRIGGER_DELAY` | `30s` | 写后防抖延迟 |
+| `RUSTFS_CAPACITY_WRITE_FREQUENCY_THRESHOLD` | `20` | 最近 60 秒写频率阈值 |
+| `RUSTFS_CAPACITY_FAST_UPDATE_THRESHOLD` | `120s` | 缓存超过该年龄后才考虑快速刷新 |
 | `RUSTFS_CAPACITY_MAX_FILES_THRESHOLD` | `200000` | 精确统计文件数阈值 |
 | `RUSTFS_CAPACITY_STAT_TIMEOUT` | `3s` | 基础扫描超时 |
 | `RUSTFS_CAPACITY_SAMPLE_RATE` | `200` | overflow 文件采样间隔 |

--- a/crates/object-capacity/src/capacity_manager.rs
+++ b/crates/object-capacity/src/capacity_manager.rs
@@ -1705,22 +1705,22 @@ mod tests {
             (
                 ENV_CAPACITY_SCHEDULED_INTERVAL,
                 || get_scheduled_update_interval().as_secs(),
-                120,
+                600,
                 "600",
                 600,
             ),
-            (ENV_CAPACITY_WRITE_TRIGGER_DELAY, || get_write_trigger_delay().as_secs(), 5, "20", 20),
+            (ENV_CAPACITY_WRITE_TRIGGER_DELAY, || get_write_trigger_delay().as_secs(), 30, "20", 20),
             (
                 ENV_CAPACITY_WRITE_FREQUENCY_THRESHOLD,
                 || get_write_frequency_threshold() as u64,
-                5,
+                20,
                 "20",
                 20,
             ),
             (
                 ENV_CAPACITY_FAST_UPDATE_THRESHOLD,
                 || get_fast_update_threshold().as_secs(),
-                30,
+                120,
                 "120",
                 120,
             ),
@@ -2773,10 +2773,10 @@ mod tests {
         let config = HybridStrategyConfig::from_env();
 
         // Check default values
-        assert_eq!(config.scheduled_update_interval, Duration::from_secs(120));
-        assert_eq!(config.write_trigger_delay, Duration::from_secs(5));
-        assert_eq!(config.write_frequency_threshold, 5);
-        assert_eq!(config.fast_update_threshold, Duration::from_secs(30));
+        assert_eq!(config.scheduled_update_interval, Duration::from_secs(600));
+        assert_eq!(config.write_trigger_delay, Duration::from_secs(30));
+        assert_eq!(config.write_frequency_threshold, 20);
+        assert_eq!(config.fast_update_threshold, Duration::from_secs(120));
         assert!(config.enable_smart_update);
         assert!(config.enable_write_trigger);
     }

--- a/rustfs/src/capacity/mod.rs
+++ b/rustfs/src/capacity/mod.rs
@@ -23,10 +23,10 @@
 //! ## Configuration
 //!
 //! All configuration is via environment variables (see `rustfs_config`):
-//! - `RUSTFS_CAPACITY_SCHEDULED_INTERVAL` - Update interval in seconds (default: 120)
-//! - `RUSTFS_CAPACITY_WRITE_TRIGGER_DELAY` - Write trigger delay (default: 5s)
-//! - `RUSTFS_CAPACITY_WRITE_FREQUENCY_THRESHOLD` - Write frequency threshold (default: 5 writes/min)
-//! - `RUSTFS_CAPACITY_FAST_UPDATE_THRESHOLD` - Fast update threshold (default: 30s)
+//! - `RUSTFS_CAPACITY_SCHEDULED_INTERVAL` - Update interval in seconds (default: 600)
+//! - `RUSTFS_CAPACITY_WRITE_TRIGGER_DELAY` - Write trigger delay (default: 30s)
+//! - `RUSTFS_CAPACITY_WRITE_FREQUENCY_THRESHOLD` - Write frequency threshold (default: 20 writes/min)
+//! - `RUSTFS_CAPACITY_FAST_UPDATE_THRESHOLD` - Fast update threshold (default: 120s)
 //! - `RUSTFS_CAPACITY_MAX_FILES_THRESHOLD` - Max files before sampling (default: 200,000)
 //! - `RUSTFS_CAPACITY_STAT_TIMEOUT` - Stat operation timeout (default: 3s)
 //! - `RUSTFS_CAPACITY_SAMPLE_RATE` - Sampling rate for metrics (default: 200)

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -312,46 +312,46 @@ export RUSTFS_TRUST_SYSTEM_CA=true
 # --- Basic Configuration ---
 # Scheduled update interval (seconds)
 # How often to perform full capacity recalculation
-# Default: 300 (5 minutes)
+# Default: 600 (10 minutes)
 # Recommended: 300-600 for production, 60-120 for testing
-export RUSTFS_CAPACITY_SCHEDULED_INTERVAL=300
+export RUSTFS_CAPACITY_SCHEDULED_INTERVAL=600
 
 # Write trigger delay (seconds)
 # Delay after write operation before triggering capacity update
-# Default: 10
-# Recommended: 5-15
-export RUSTFS_CAPACITY_WRITE_TRIGGER_DELAY=10
+# Default: 30
+# Recommended: 5-30
+export RUSTFS_CAPACITY_WRITE_TRIGGER_DELAY=30
 
 # Write frequency threshold (writes per minute)
 # Threshold for triggering fast updates during high write frequency
-# Default: 10
+# Default: 20
 # Recommended: 5-20
-export RUSTFS_CAPACITY_WRITE_FREQUENCY_THRESHOLD=10
+export RUSTFS_CAPACITY_WRITE_FREQUENCY_THRESHOLD=20
 
 # Fast update threshold (seconds)
 # Cache age threshold for considering data as fresh
-# Default: 60
+# Default: 120
 # Recommended: 30-120
-export RUSTFS_CAPACITY_FAST_UPDATE_THRESHOLD=60
+export RUSTFS_CAPACITY_FAST_UPDATE_THRESHOLD=120
 
 # --- Performance Protection ---
 # Maximum files threshold
 # When file count exceeds this, sampling is used for performance
-# Default: 1000000 (1 million)
-# Recommended: 500000-2000000
-export RUSTFS_CAPACITY_MAX_FILES_THRESHOLD=1000000
+# Default: 200000
+# Recommended: 200000-2000000
+export RUSTFS_CAPACITY_MAX_FILES_THRESHOLD=200000
 
 # Statistics timeout (seconds)
 # Maximum time to wait for capacity calculation
-# Default: 5
+# Default: 3
 # Recommended: 3-10
-export RUSTFS_CAPACITY_STAT_TIMEOUT=5
+export RUSTFS_CAPACITY_STAT_TIMEOUT=3
 
 # Sample rate
 # When sampling is enabled, check every N files
-# Default: 100
+# Default: 200
 # Recommended: 50-200
-export RUSTFS_CAPACITY_SAMPLE_RATE=100
+export RUSTFS_CAPACITY_SAMPLE_RATE=200
 
 # --- Monitoring Configuration ---
 # Metrics logging interval (seconds)


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Update the object-capacity default refresh interval to 600 seconds, write-trigger delay to 30 seconds, write-frequency threshold to 20 writes per minute, and fast-update threshold to 120 seconds.
- Keep the existing defaults for max-file sampling threshold, stat timeout, sample rate, and metrics interval while adding explicit assertions for the complete capacity default set.
- Align the object-capacity docs, rustfs capacity module notes, and local run script examples with the effective capacity defaults.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs-config constants::capacity::tests::test_capacity_default_values`
- `cargo test -p rustfs-object-capacity test_config_getter_defaults`
- `cargo test -p rustfs-object-capacity test_config_getter_env_overrides`
- `cargo test -p rustfs-object-capacity test_config_from_env`
- `cargo test -p rustfs-object-capacity`
- `git diff --check`

## Impact
The default object-capacity background refresh path now runs less aggressively when operators do not set explicit `RUSTFS_CAPACITY_*` environment variables. Existing explicit environment values keep their precedence. `RUSTFS_SCANNER_BITROT_CYCLE_SECS`, runtime thread stack sizing, and internode replay-cache defaults are unchanged.

## Additional Notes
The narrower scope intentionally limits this PR to `RUSTFS_CAPACITY_*` defaults and related documentation/tests.
