### PR TITLE
chore(release): prepare 1.0.0-rc.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3916,7 +3916,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e_test"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -9386,7 +9386,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9527,7 +9527,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-audit"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "const-str",
  "futures",
@@ -9549,7 +9549,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-checksums"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9565,7 +9565,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-common"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "hotpath",
  "metrics",
@@ -9578,7 +9578,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-concurrency"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "hotpath",
  "insta",
@@ -9591,7 +9591,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-config"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "const-str",
  "hotpath",
@@ -9601,7 +9601,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-credentials"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "base64-simd",
  "hmac 0.13.0",
@@ -9615,7 +9615,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-crypto"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9636,7 +9636,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-data-usage"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "hotpath",
  "rmp-serde",
@@ -9646,7 +9646,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-ecstore"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -9781,7 +9781,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-extension-schema"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "hotpath",
  "serde",
@@ -9791,7 +9791,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-filemeta"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "arc-swap",
  "byteorder",
@@ -9818,7 +9818,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -9854,7 +9854,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal-contracts"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -9864,7 +9864,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-iam"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9912,7 +9912,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-core"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "bytes",
  "hotpath",
@@ -9924,7 +9924,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-metrics"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "criterion",
  "hotpath",
@@ -9988,7 +9988,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-keystone"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "bytes",
  "futures",
@@ -10015,7 +10015,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-kms"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -10065,7 +10065,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lifecycle"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-trait",
  "hotpath",
@@ -10088,7 +10088,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lock"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-trait",
  "compact_str",
@@ -10111,7 +10111,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-log-analyzer"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "chrono",
  "flate2",
@@ -10130,7 +10130,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-madmin"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "hotpath",
  "http 1.5.0",
@@ -10168,7 +10168,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-notify"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -10203,7 +10203,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-capacity"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "criterion",
  "futures",
@@ -10222,7 +10222,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-data-cache"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "bytes",
  "criterion",
@@ -10239,7 +10239,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-obs"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -10297,7 +10297,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-policy"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -10328,7 +10328,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protocols"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -10390,7 +10390,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protos"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "flatbuffers",
  "hotpath",
@@ -10415,7 +10415,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-replication"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "byteorder",
  "bytes",
@@ -10433,7 +10433,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -10474,7 +10474,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio-v2"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -10497,7 +10497,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-client"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -10541,7 +10541,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-ops"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "hotpath",
  "rustfs-s3-types",
@@ -10549,7 +10549,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-types"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "hotpath",
  "serde",
@@ -10558,7 +10558,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-api"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "arc-swap",
  "async-compression",
@@ -10593,7 +10593,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-query"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -10612,7 +10612,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10655,7 +10655,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner-contracts"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "chrono",
  "jiff",
@@ -10670,7 +10670,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-security-governance"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "hotpath",
  "thiserror 2.0.20",
@@ -10678,7 +10678,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-signer"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -10696,7 +10696,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-storage-api"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-trait",
  "hotpath",
@@ -10711,7 +10711,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-targets"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -10765,7 +10765,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-test-utils"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "hotpath",
  "rustfs-data-usage",
@@ -10781,7 +10781,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-tls-runtime"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "arc-swap",
  "hotpath",
@@ -10802,7 +10802,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-trusted-proxies"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -10839,7 +10839,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-utils"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "base64-simd",
  "blake2",
@@ -10881,7 +10881,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-zip"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-compression",
  "hotpath",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/rustfs/rustfs"
 rust-version = "1.97.1"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 homepage = "https://rustfs.com"
 description = "RustFS is a high-performance distributed object storage software built using Rust, one of the most popular languages worldwide. "
 keywords = ["RustFS", "Minio", "object-storage", "filesystem", "s3"]
@@ -89,55 +89,55 @@ redundant_clone = "warn"
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rustfs = { path = "./rustfs", version = "1.0.0-rc.4" }
-rustfs-heal = { path = "crates/heal", version = "1.0.0-rc.4" }
-rustfs-heal-contracts = { path = "crates/heal-contracts", version = "1.0.0-rc.4" }
-rustfs-scanner-contracts = { path = "crates/scanner-contracts", version = "1.0.0-rc.4" }
-rustfs-audit = { path = "crates/audit", version = "1.0.0-rc.4" }
-rustfs-checksums = { path = "crates/checksums", version = "1.0.0-rc.4" }
-rustfs-common = { path = "crates/common", version = "1.0.0-rc.4" }
-rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-rc.4" }
-rustfs-config = { path = "./crates/config", version = "1.0.0-rc.4" }
-rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-rc.4" }
-rustfs-credentials = { path = "crates/credentials", version = "1.0.0-rc.4" }
-rustfs-crypto = { path = "crates/crypto", version = "1.0.0-rc.4" }
-rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-rc.4" }
-rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-rc.4" }
-rustfs-iam = { path = "crates/iam", version = "1.0.0-rc.4" }
-rustfs-keystone = { path = "crates/keystone", version = "1.0.0-rc.4" }
-rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-rc.4" }
-rustfs-kms = { path = "crates/kms", version = "1.0.0-rc.4" }
-rustfs-lock = { path = "crates/lock", version = "1.0.0-rc.4" }
-rustfs-madmin = { path = "crates/madmin", version = "1.0.0-rc.4" }
-rustfs-notify = { path = "crates/notify", version = "1.0.0-rc.4" }
-rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-rc.4" }
-rustfs-io-core = { path = "crates/io-core", version = "1.0.0-rc.4" }
-rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-rc.4" }
-rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-rc.4", default-features = false }
-rustfs-log-analyzer = { path = "crates/log-analyzer", version = "1.0.0-rc.4" }
-rustfs-obs = { path = "crates/obs", version = "1.0.0-rc.4" }
-rustfs-policy = { path = "crates/policy", version = "1.0.0-rc.4" }
-rustfs-protos = { path = "crates/protos", version = "1.0.0-rc.4" }
-rustfs-protocols = { path = "crates/protocols", version = "1.0.0-rc.4" }
-rustfs-replication = { path = "crates/replication", version = "1.0.0-rc.4" }
-rustfs-rio = { path = "crates/rio", version = "1.0.0-rc.4" }
-rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-rc.4" }
-rustfs-s3-client = { path = "crates/s3-client", version = "1.0.0-rc.4" }
-rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-rc.4" }
-rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-rc.4" }
-rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-rc.4" }
-rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-rc.4" }
-rustfs-scanner = { path = "crates/scanner", version = "1.0.0-rc.4" }
-rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-rc.4" }
-rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-rc.4" }
-rustfs-signer = { path = "crates/signer", version = "1.0.0-rc.4" }
-rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-rc.4" }
-rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-rc.4" }
-rustfs-targets = { path = "crates/targets", version = "1.0.0-rc.4" }
-rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-rc.4" }
-rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-rc.4" }
-rustfs-utils = { path = "crates/utils", version = "1.0.0-rc.4" }
-rustfs-zip = { path = "./crates/zip", version = "1.0.0-rc.4" }
+rustfs = { path = "./rustfs", version = "1.0.0-rc.5" }
+rustfs-heal = { path = "crates/heal", version = "1.0.0-rc.5" }
+rustfs-heal-contracts = { path = "crates/heal-contracts", version = "1.0.0-rc.5" }
+rustfs-scanner-contracts = { path = "crates/scanner-contracts", version = "1.0.0-rc.5" }
+rustfs-audit = { path = "crates/audit", version = "1.0.0-rc.5" }
+rustfs-checksums = { path = "crates/checksums", version = "1.0.0-rc.5" }
+rustfs-common = { path = "crates/common", version = "1.0.0-rc.5" }
+rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-rc.5" }
+rustfs-config = { path = "./crates/config", version = "1.0.0-rc.5" }
+rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-rc.5" }
+rustfs-credentials = { path = "crates/credentials", version = "1.0.0-rc.5" }
+rustfs-crypto = { path = "crates/crypto", version = "1.0.0-rc.5" }
+rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-rc.5" }
+rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-rc.5" }
+rustfs-iam = { path = "crates/iam", version = "1.0.0-rc.5" }
+rustfs-keystone = { path = "crates/keystone", version = "1.0.0-rc.5" }
+rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-rc.5" }
+rustfs-kms = { path = "crates/kms", version = "1.0.0-rc.5" }
+rustfs-lock = { path = "crates/lock", version = "1.0.0-rc.5" }
+rustfs-madmin = { path = "crates/madmin", version = "1.0.0-rc.5" }
+rustfs-notify = { path = "crates/notify", version = "1.0.0-rc.5" }
+rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-rc.5" }
+rustfs-io-core = { path = "crates/io-core", version = "1.0.0-rc.5" }
+rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-rc.5" }
+rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-rc.5", default-features = false }
+rustfs-log-analyzer = { path = "crates/log-analyzer", version = "1.0.0-rc.5" }
+rustfs-obs = { path = "crates/obs", version = "1.0.0-rc.5" }
+rustfs-policy = { path = "crates/policy", version = "1.0.0-rc.5" }
+rustfs-protos = { path = "crates/protos", version = "1.0.0-rc.5" }
+rustfs-protocols = { path = "crates/protocols", version = "1.0.0-rc.5" }
+rustfs-replication = { path = "crates/replication", version = "1.0.0-rc.5" }
+rustfs-rio = { path = "crates/rio", version = "1.0.0-rc.5" }
+rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-rc.5" }
+rustfs-s3-client = { path = "crates/s3-client", version = "1.0.0-rc.5" }
+rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-rc.5" }
+rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-rc.5" }
+rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-rc.5" }
+rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-rc.5" }
+rustfs-scanner = { path = "crates/scanner", version = "1.0.0-rc.5" }
+rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-rc.5" }
+rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-rc.5" }
+rustfs-signer = { path = "crates/signer", version = "1.0.0-rc.5" }
+rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-rc.5" }
+rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-rc.5" }
+rustfs-targets = { path = "crates/targets", version = "1.0.0-rc.5" }
+rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-rc.5" }
+rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-rc.5" }
+rustfs-utils = { path = "crates/utils", version = "1.0.0-rc.5" }
+rustfs-zip = { path = "./crates/zip", version = "1.0.0-rc.5" }
 
 # Async Runtime and Networking
 async-channel = "2.5.0"

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # Using specific version
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.4
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.5
 ```
 
 If you use [podman](https://github.com/containers/podman) instead of docker, you can install the RustFS with the below command

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -112,7 +112,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # 使用指定版本运行
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.4
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.5
 ```
 
 如果您通过绑定挂载启用 TLS 证书目录，也请用同样方式准备该目录：

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
 
           rustfs = rustPlatform.buildRustPackage {
             pname = "rustfs";
-            version = "1.0.0-rc.4";
+            version = "1.0.0-rc.5";
 
             src = ./.;
 

--- a/helm/rustfs/Chart.yaml
+++ b/helm/rustfs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rustfs
 description: RustFS helm chart to deploy RustFS on kubernetes cluster.
 type: application
-version: "1.0.0-rc.4"
-appVersion: "1.0.0-rc.4"
+version: "1.0.0-rc.5"
+appVersion: "1.0.0-rc.5"
 home: https://rustfs.com
 icon: https://media.sys.truenas.net/apps/rustfs/icons/icon.svg
 maintainers:

--- a/rustfs.spec
+++ b/rustfs.spec
@@ -1,9 +1,9 @@
 %global _enable_debug_packages 0
 %global _empty_manifest_terminate_build 0
-%global prerelease rc.4
+%global prerelease rc.5
 Name:           rustfs
 Version:        1.0.0
-Release:        rc.4
+Release:        rc.5
 Summary:       High-performance distributed object storage for MinIO alternative
 
 License:        Apache-2.0
@@ -58,6 +58,9 @@ install %_builddir/%{name}-%{version}-%{prerelease}/target/%_arch/%_arch-unknown
 %_bindir/rustfs
 
 %changelog
+* Mon Aug 31 2026 overtrue <anzhengchao@gmail.com>
+- Update RPM package to RustFS 1.0.0-rc.5
+
 * Thu Aug 27 2026 overtrue <anzhengchao@gmail.com>
 - Update RPM package to RustFS 1.0.0-rc.4
 


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Prepare the repository version, package metadata, Docker examples, Helm chart, Nix package, and RPM changelog for 1.0.0-rc.5.

## Verification

- `git diff --check`
- `cargo metadata --locked --no-deps --format-version 1 --offline`
- `make pre-commit`

## Impact

Release metadata and distribution examples now target 1.0.0-rc.5.

## Additional Notes

N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
