### PR TITLE
ci: add storage engine workflow to functional test chain

### DIFF
--- a/.github/workflows/rustfs-heal-test.yml
+++ b/.github/workflows/rustfs-heal-test.yml
@@ -225,6 +225,7 @@ jobs:
                 { key: 'heal', label: 'Heal' },
                 { key: 'pool', label: 'Pool Expansion' },
                 { key: 'security', label: 'Security' },
+                { key: 'upgrade', label: 'Upgrade' },
               ];
               const tabs = document.getElementById('tabs');
               const list = document.getElementById('list');

--- a/.github/workflows/rustfs-kms-test.yml
+++ b/.github/workflows/rustfs-kms-test.yml
@@ -256,6 +256,7 @@ jobs:
                 { key: 'heal', label: 'Heal' },
                 { key: 'pool', label: 'Pool Expansion' },
                 { key: 'security', label: 'Security' },
+                { key: 'upgrade', label: 'Upgrade' },
               ];
               const tabs = document.getElementById('tabs');
               const list = document.getElementById('list');

--- a/.github/workflows/rustfs-pool-expand-test.yml
+++ b/.github/workflows/rustfs-pool-expand-test.yml
@@ -257,6 +257,7 @@ jobs:
                 { key: 'heal', label: 'Heal' },
                 { key: 'pool', label: 'Pool Expansion' },
                 { key: 'security', label: 'Security' },
+                { key: 'upgrade', label: 'Upgrade' },
               ];
               const tabs = document.getElementById('tabs');
               const list = document.getElementById('list');
@@ -593,6 +594,7 @@ jobs:
                 { key: 'heal', label: 'Heal' },
                 { key: 'pool', label: 'Pool Expansion' },
                 { key: 'security', label: 'Security' },
+                { key: 'upgrade', label: 'Upgrade' },
               ];
               const tabs = document.getElementById('tabs');
               const list = document.getElementById('list');

--- a/.github/workflows/rustfs-s3-compat-test.yml
+++ b/.github/workflows/rustfs-s3-compat-test.yml
@@ -12,8 +12,8 @@ on:
         required: false
         type: string
   workflow_run:
-    # Run after the nightly build completes; the nightly deb is what the test installs.
-    workflows: ["Nightly GNU Build"]
+    # Run after upgrade compatibility completes; the nightly deb is what the test installs.
+    workflows: ["RustFS Upgrade Test"]
     types: [completed]
 
 permissions:
@@ -270,6 +270,7 @@ jobs:
                 { key: 'heal', label: 'Heal' },
                 { key: 'pool', label: 'Pool Expansion' },
                 { key: 'security', label: 'Security' },
+                { key: 'upgrade', label: 'Upgrade' },
               ];
               const tabs = document.getElementById('tabs');
               const list = document.getElementById('list');

--- a/.github/workflows/rustfs-security-test.yml
+++ b/.github/workflows/rustfs-security-test.yml
@@ -47,8 +47,8 @@ on:
         type: boolean
         default: true
   workflow_run:
-    # Same nightly trigger as the other functional suites.
-    workflows: ["Nightly GNU Build"]
+    # Runs last in the functional chain, after pool/heal, on the shared VMs.
+    workflows: ["RustFS Pool Expansion / Heal Test"]
     types: [completed]
 
 permissions:
@@ -243,6 +243,7 @@ jobs:
                 { key: 'heal', label: 'Heal' },
                 { key: 'pool', label: 'Pool Expansion' },
                 { key: 'security', label: 'Security' },
+                { key: 'upgrade', label: 'Upgrade' },
               ];
               const tabs = document.getElementById('tabs');
               const list = document.getElementById('list');

--- a/.github/workflows/rustfs-storage-test.yml
+++ b/.github/workflows/rustfs-storage-test.yml
@@ -1,4 +1,4 @@
-name: RustFS S3 Compatibility Test
+name: RustFS Storage Engine Test
 
 on:
   workflow_dispatch:
@@ -11,9 +11,18 @@ on:
         description: 'Direct .deb URL (nightly/R2/dev). Overrides rustfs_version.'
         required: false
         type: string
+      topology:
+        description: 'Topology to run (all = SNSD, SNMD, MNMD)'
+        type: choice
+        options:
+          - all
+          - single-single
+          - single-multi
+          - multi-multi
+        default: all
   workflow_run:
-    # Run after upgrade compatibility completes; the nightly deb is what the test installs.
-    workflows: ["RustFS Upgrade Test"]
+    # Strict shared-environment order: run after tier test completes.
+    workflows: ["RustFS Tier Test"]
     types: [completed]
 
 permissions:
@@ -36,7 +45,7 @@ env:
   PF_TESTING_GH_TOKEN: ${{ secrets.PF_TESTING_GH_TOKEN }}
 
 jobs:
-  s3-compat-test:
+  storage-test:
     runs-on: smoke-testing
     continue-on-error: true
     timeout-minutes: 360
@@ -72,21 +81,27 @@ jobs:
                 ${SUDO} dpkg -P rustfs
               fi
               for i in 1 2 3 4; do ${SUDO} rm -rf /data/rustfs${i}/mnmd; done
-              ${SUDO} rm -rf /var/log/rustfs
+              ${SUDO} rm -rf /var/log/rustfs /var/lib/rustfs/kms /var/lib/rustfs/kms-backup
             '
           done
 
-      - name: Run S3 compatibility suite
+      - name: Run storage engine suite
         id: test
         continue-on-error: true
         env:
-          LOG_FILE: /tmp/rustfs-s3-compat.log
+          LOG_FILE: /tmp/rustfs-storage.log
         run: |
           set -euo pipefail
-          chmod +x auto-testing/rustfs-s3-compat-test.sh
+          chmod +x auto-testing/rustfs-storage-test.sh
           PACKAGE_URL='${{ inputs.package_url }}'
           RUSTFS_VERSION='${{ inputs.rustfs_version }}'
-          ARGS=(--all-topologies -y --log-file "${LOG_FILE}")
+          TOPOLOGY='${{ inputs.topology }}'
+          ARGS=(-y --log-file "${LOG_FILE}")
+          if [ "${TOPOLOGY}" = "all" ] || [ -z "${TOPOLOGY}" ] || [ "${TOPOLOGY}" = "null" ]; then
+            ARGS+=(--all-topologies)
+          else
+            ARGS+=(--topology "${TOPOLOGY}")
+          fi
           if [ -n "${PACKAGE_URL}" ]; then
             ARGS+=(--package-url "${PACKAGE_URL}")
           elif [ -n "${RUSTFS_VERSION}" ]; then
@@ -94,13 +109,13 @@ jobs:
           else
             ARGS+=(--package-url "${RUSTFS_NIGHTLY_PACKAGE_URL}")
           fi
-          ./auto-testing/rustfs-s3-compat-test.sh "${ARGS[@]}"
+          ./auto-testing/rustfs-storage-test.sh "${ARGS[@]}"
 
       - name: Generate report
         if: always()
         env:
-          LOG_FILE: /tmp/rustfs-s3-compat.log
-          REPORT_FILE: /tmp/rustfs-s3-compat-report.md
+          LOG_FILE: /tmp/rustfs-storage.log
+          REPORT_FILE: /tmp/rustfs-storage-report.md
         run: |
           set -euo pipefail
           PACKAGE_URL='${{ inputs.package_url }}'
@@ -122,7 +137,7 @@ jobs:
               RUSTFS_VERSION_INFO="${DETECTED_VERSION}"
             fi
           fi
-          CASE_TABLE="/tmp/rustfs-s3-compat-cases.md"
+          CASE_TABLE="/tmp/rustfs-storage-cases.md"
           python3 - "${LOG_FILE}" "${CASE_TABLE}" <<'PY'
           import re
           import sys
@@ -176,7 +191,7 @@ jobs:
               out.write(f'| {case_id} | {name} | {status} |\\n')
           PY
           {
-            echo "# RustFS S3 compatibility test report"
+            echo "# RustFS storage engine test report"
             echo ""
             echo "- Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             echo "- Trigger: ${{ github.event_name }}"
@@ -198,8 +213,8 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ env.PF_TESTING_GH_TOKEN }}
-          REPORT_FILE: /tmp/rustfs-s3-compat-report.md
-          SUITE: s3
+          REPORT_FILE: /tmp/rustfs-storage-report.md
+          SUITE: storage
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
@@ -267,6 +282,7 @@ jobs:
                 { key: 's3', label: 'S3 Compatibility' },
                 { key: 'kms', label: 'KMS' },
                 { key: 'tier', label: 'Tier' },
+                { key: 'storage', label: 'Storage Engine' },
                 { key: 'heal', label: 'Heal' },
                 { key: 'pool', label: 'Pool Expansion' },
                 { key: 'security', label: 'Security' },
@@ -374,10 +390,10 @@ jobs:
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: rustfs-s3-compat-${{ github.run_id }}
+          name: rustfs-storage-${{ github.run_id }}
           path: |
-            /tmp/rustfs-s3-compat.log
-            /tmp/rustfs-s3-compat-report.md
+            /tmp/rustfs-storage.log
+            /tmp/rustfs-storage-report.md
           if-no-files-found: warn
 
       - name: Cleanup environment (after)
@@ -402,5 +418,5 @@ jobs:
       - name: Notify on failure
         if: failure()
         run: |
-          echo "RustFS S3 compatibility suite failed"
+          echo "RustFS storage engine suite failed"
           echo "See the uploaded report and log artifacts for details."

--- a/.github/workflows/rustfs-upgrade-test.yml
+++ b/.github/workflows/rustfs-upgrade-test.yml
@@ -1,19 +1,62 @@
-name: RustFS Tier Test
+# Copyright 2024 RustFS Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: RustFS Upgrade Test
 
 on:
   workflow_dispatch:
     inputs:
-      rustfs_version:
-        description: 'RustFS release tag to test (e.g. 1.0.0-rc.4-preview.1)'
+      from_version:
+        description: 'OLD RustFS release tag (e.g. 1.0.0-rc.4-preview.1)'
         required: false
         default: '1.0.0-rc.4-preview.1'
-      package_url:
-        description: 'Direct .deb URL (nightly/R2/dev). Overrides rustfs_version.'
+      from_url:
+        description: 'OLD .deb URL. Overrides from_version.'
         required: false
         type: string
+      to_version:
+        description: 'NEW RustFS release tag (leave empty for latest nightly)'
+        required: false
+      to_url:
+        description: 'NEW .deb URL. Overrides to_version / nightly default.'
+        required: false
+        type: string
+      topology:
+        description: 'Topology to run (all = SNSD, SNMD, MNMD)'
+        type: choice
+        options:
+          - all
+          - single-single
+          - single-multi
+          - multi-multi
+        default: all
+      backends:
+        description: 'KMS backends to run (local,vault-kv2)'
+        required: false
+        default: 'local,vault-kv2'
+      cleanup_before:
+        description: 'Reset the nodes before the test (DESTROYS existing data/config)'
+        type: boolean
+        default: true
+      cleanup_after:
+        description: 'Reset the nodes after the test (DESTROYS test data/config)'
+        type: boolean
+        default: true
   workflow_run:
-    # Strict shared-environment order: run after KMS test completes.
-    workflows: ["RustFS KMS Test"]
+    # Runs first in the functional chain: upgrade compatibility gates the
+    # nightly suites that follow (S3 -> KMS -> Tier -> Pool/Heal -> Security).
+    workflows: ["Nightly GNU Build"]
     types: [completed]
 
 permissions:
@@ -36,11 +79,11 @@ env:
   PF_TESTING_GH_TOKEN: ${{ secrets.PF_TESTING_GH_TOKEN }}
 
 jobs:
-  tier-test:
+  upgrade-test:
     runs-on: smoke-testing
     continue-on-error: true
     timeout-minutes: 420
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout auto-testing scripts
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -56,13 +99,14 @@ jobs:
           uname -a
           jq --version
           openssl version
+          aws --version || true
+          docker --version || true
           df -h /data | tail -1
 
       - name: Cleanup environment (before)
+        if: ${{ inputs.cleanup_before != 'false' || github.event_name != 'workflow_dispatch' }}
         run: |
           set -euo pipefail
-          sudo docker rm -f rustfs-test-mqtt >/dev/null 2>&1 || true
-          sudo rm -f /tmp/rustfs-mosquitto.conf
           read -r -a NODES <<< "${RUSTFS_NODES:-vm000 vm001 vm002}"
           SSH_USER="${RUSTFS_SSH_USER:-azureuser}"
           for node in "${NODES[@]}"; do
@@ -74,75 +118,82 @@ jobs:
                 ${SUDO} dpkg -P rustfs
               fi
               for i in 1 2 3 4; do ${SUDO} rm -rf /data/rustfs${i}/mnmd; done
-              ${SUDO} rm -rf /var/log/rustfs /var/lib/rustfs/kms
+              ${SUDO} rm -rf /var/log/rustfs /var/lib/rustfs/kms /var/lib/rustfs/kms-backup
             '
           done
 
-      - name: Ensure MQTT broker + clients
+      - name: Ensure docker (Vault container)
         run: |
-          set -euo pipefail
-          if ! command -v mosquitto_sub >/dev/null 2>&1; then
+          if ! command -v docker >/dev/null 2>&1; then
             sudo apt-get update
-            sudo apt-get install -y mosquitto-clients
+            sudo apt-get install -y docker.io
           fi
-          command -v docker >/dev/null 2>&1 || { echo 'docker not found on runner'; exit 1; }
-          sudo docker rm -f rustfs-test-mqtt >/dev/null 2>&1 || true
-          cat <<'EOF' | sudo tee /tmp/rustfs-mosquitto.conf >/dev/null
-          listener 1883 0.0.0.0
-          allow_anonymous true
-          EOF
-          sudo docker run -d --name rustfs-test-mqtt -p 1883:1883 \
-            -v /tmp/rustfs-mosquitto.conf:/mosquitto/config/mosquitto.conf:ro \
-            eclipse-mosquitto:2 >/dev/null
-          for _ in {1..10}; do
-            if ss -tln 2>/dev/null | grep -q ':1883'; then
-              break
-            fi
-            sleep 1
-          done
-          ss -tln 2>/dev/null | grep -q ':1883' || {
-            echo 'mosquitto container is not listening on 1883'
-            sudo docker logs rustfs-test-mqtt || true
-            exit 1
-          }
+          sudo systemctl enable --now docker
+          docker info >/dev/null 2>&1 || sudo docker info >/dev/null 2>&1
 
-      - name: Run tier suite
+      - name: Run upgrade compatibility suite
         id: test
         continue-on-error: true
         env:
-          LOG_FILE: /tmp/rustfs-tier.log
+          LOG_FILE: /tmp/rustfs-upgrade.log
         run: |
           set -euo pipefail
-          chmod +x auto-testing/rustfs-tier-test.sh
-          PACKAGE_URL='${{ inputs.package_url }}'
-          RUSTFS_VERSION='${{ inputs.rustfs_version }}'
-          ARGS=(--all-topologies -y --log-file "${LOG_FILE}")
-          if [ -n "${PACKAGE_URL}" ]; then
-            ARGS+=(--package-url "${PACKAGE_URL}")
-          elif [ -n "${RUSTFS_VERSION}" ]; then
-            ARGS+=(--version "${RUSTFS_VERSION}")
+          chmod +x auto-testing/rustfs-upgrade-test.sh
+          FROM_URL='${{ inputs.from_url }}'
+          FROM_VERSION='${{ inputs.from_version }}'
+          TO_URL='${{ inputs.to_url }}'
+          TO_VERSION='${{ inputs.to_version }}'
+          TOPOLOGY='${{ inputs.topology }}'
+          BACKENDS='${{ inputs.backends }}'
+          ARGS=(-y --log-file "${LOG_FILE}")
+          if [ "${TOPOLOGY}" = "all" ] || [ -z "${TOPOLOGY}" ] || [ "${TOPOLOGY}" = "null" ]; then
+            ARGS+=(--all-topologies)
           else
-            ARGS+=(--package-url "${RUSTFS_NIGHTLY_PACKAGE_URL}")
+            ARGS+=(--topology "${TOPOLOGY}")
           fi
-          ./auto-testing/rustfs-tier-test.sh "${ARGS[@]}"
+          if [ -n "${BACKENDS}" ] && [ "${BACKENDS}" != "null" ]; then
+            ARGS+=(--backends "${BACKENDS}")
+          fi
+          if [ -n "${FROM_URL}" ]; then
+            ARGS+=(--from-url "${FROM_URL}")
+          elif [ -n "${FROM_VERSION}" ] && [ "${FROM_VERSION}" != "null" ]; then
+            ARGS+=(--from-version "${FROM_VERSION}")
+          fi
+          if [ -n "${TO_URL}" ]; then
+            ARGS+=(--to-url "${TO_URL}")
+          elif [ -n "${TO_VERSION}" ] && [ "${TO_VERSION}" != "null" ]; then
+            ARGS+=(--to-version "${TO_VERSION}")
+          else
+            ARGS+=(--to-url "${RUSTFS_NIGHTLY_PACKAGE_URL}")
+          fi
+          ./auto-testing/rustfs-upgrade-test.sh "${ARGS[@]}"
 
       - name: Generate report
         if: always()
         env:
-          LOG_FILE: /tmp/rustfs-tier.log
-          REPORT_FILE: /tmp/rustfs-tier-report.md
+          LOG_FILE: /tmp/rustfs-upgrade.log
+          REPORT_FILE: /tmp/rustfs-upgrade-report.md
         run: |
           set -euo pipefail
-          PACKAGE_URL='${{ inputs.package_url }}'
-          RUSTFS_VERSION='${{ inputs.rustfs_version }}'
-          if [ -n "${PACKAGE_URL}" ]; then
-            PACKAGE_SOURCE="${PACKAGE_URL}"
-          elif [ -n "${RUSTFS_VERSION}" ]; then
-            PACKAGE_SOURCE="version ${RUSTFS_VERSION}"
+          FROM_URL='${{ inputs.from_url }}'
+          FROM_VERSION='${{ inputs.from_version }}'
+          TO_URL='${{ inputs.to_url }}'
+          TO_VERSION='${{ inputs.to_version }}'
+          if [ -n "${FROM_URL}" ]; then
+            FROM_SOURCE="${FROM_URL}"
+          elif [ -n "${FROM_VERSION}" ]; then
+            FROM_SOURCE="version ${FROM_VERSION}"
           else
-            PACKAGE_SOURCE="${RUSTFS_NIGHTLY_PACKAGE_URL}"
+            FROM_SOURCE="release (default)"
           fi
-          CASE_TABLE="/tmp/rustfs-tier-cases.md"
+          if [ -n "${TO_URL}" ]; then
+            TO_SOURCE="${TO_URL}"
+          elif [ -n "${TO_VERSION}" ]; then
+            TO_SOURCE="version ${TO_VERSION}"
+          else
+            TO_SOURCE="${RUSTFS_NIGHTLY_PACKAGE_URL}"
+          fi
+          CASE_TABLE="/tmp/rustfs-upgrade-cases.md"
           python3 - "${LOG_FILE}" "${CASE_TABLE}" <<'PY'
           import re
           import sys
@@ -193,11 +244,12 @@ jobs:
               out.write(f'| {case_id} | {name} | {status} |\\n')
           PY
           {
-            echo "# RustFS tier test report"
+            echo "# RustFS upgrade compatibility report"
             echo ""
             echo "- Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             echo "- Trigger: ${{ github.event_name }}"
-            echo "- Package: ${PACKAGE_SOURCE}"
+            echo "- From: ${FROM_SOURCE}"
+            echo "- To: ${TO_SOURCE}"
             echo "- Test Step Outcome: ${{ steps.test.outcome }}"
             echo ""
             cat "${CASE_TABLE}" || true
@@ -214,8 +266,8 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ env.PF_TESTING_GH_TOKEN }}
-          REPORT_FILE: /tmp/rustfs-tier-report.md
-          SUITE: tier
+          REPORT_FILE: /tmp/rustfs-upgrade-report.md
+          SUITE: upgrade
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
@@ -254,33 +306,67 @@ jobs:
               .tabs { display: flex; gap: 10px; margin: 14px 0 18px; flex-wrap: wrap; }
               button { border: 1px solid var(--line); background: #fff; color: var(--text); border-radius: 10px; padding: 8px 14px; cursor: pointer; }
               button.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+              .report-btn { border: 0; background: transparent; padding: 0; color: var(--accent); }
               ul { list-style: none; margin: 0; padding: 0; }
               li { padding: 10px 0; border-bottom: 1px solid var(--line); }
               a { color: var(--accent); text-decoration: none; }
               a:hover { text-decoration: underline; }
+              .meta { margin-top: 16px; border-top: 1px solid var(--line); padding-top: 14px; }
+              .kv { margin: 6px 0; color: var(--text); }
+              .muted { color: var(--muted); }
             </style>
           </head>
           <body>
             <div class="wrap">
               <div class="card">
                 <h1>RustFS Functional Test Reports</h1>
-                <p>S3, KMS, Tier report tabs. Each tab lists reports by date.</p>
+                <p>Select a suite and date to view the build version used in that run.</p>
                 <div class="tabs" id="tabs"></div>
                 <ul id="list"></ul>
+                <div class="meta">
+                  <div class="kv"><strong>Date:</strong> <span id="report-date" class="muted">N/A</span></div>
+                  <div class="kv"><strong>RustFS Version:</strong> <span id="report-version" class="muted">N/A</span></div>
+                  <div class="kv"><a id="report-link" href="#" target="_blank" rel="noreferrer">Open report</a></div>
+                </div>
               </div>
             </div>
             <script>
               const suites = [
+                { key: 'upgrade', label: 'Upgrade' },
                 { key: 's3', label: 'S3 Compatibility' },
                 { key: 'kms', label: 'KMS' },
                 { key: 'tier', label: 'Tier' },
                 { key: 'heal', label: 'Heal' },
                 { key: 'pool', label: 'Pool Expansion' },
                 { key: 'security', label: 'Security' },
-                { key: 'upgrade', label: 'Upgrade' },
               ];
               const tabs = document.getElementById('tabs');
               const list = document.getElementById('list');
+              const reportDate = document.getElementById('report-date');
+              const reportVersion = document.getElementById('report-version');
+              const reportLink = document.getElementById('report-link');
+
+              function parseVersion(markdown) {
+                const m = markdown.match(/^- RustFS Version:\s*(.+)$/m);
+                return m ? m[1].trim() : 'N/A';
+              }
+
+              async function showReport(report) {
+                reportDate.textContent = report.name.replace('.md', '');
+                reportVersion.textContent = 'Loading...';
+                reportLink.href = report.html_url;
+                try {
+                  const res = await fetch(report.download_url, { cache: 'no-store' });
+                  if (!res.ok) {
+                    reportVersion.textContent = 'N/A';
+                    return;
+                  }
+                  const text = await res.text();
+                  reportVersion.textContent = parseVersion(text);
+                } catch (_e) {
+                  reportVersion.textContent = 'N/A';
+                }
+              }
 
               async function loadSuite(suite) {
                 list.innerHTML = '<li>Loading...</li>';
@@ -295,11 +381,27 @@ jobs:
                   const files = data.filter(f => f.type === 'file' && f.name.endsWith('.md')).sort((a,b) => b.name.localeCompare(a.name));
                   if (!files.length) {
                     list.innerHTML = '<li>No reports yet.</li>';
+                    reportDate.textContent = 'N/A';
+                    reportVersion.textContent = 'N/A';
+                    reportLink.href = '#';
                     return;
                   }
-                  list.innerHTML = files.map(f => `<li><a href="${f.html_url}" target="_blank" rel="noreferrer">${f.name.replace('.md','')}</a></li>`).join('');
+                  list.innerHTML = '';
+                  files.forEach((f) => {
+                    const li = document.createElement('li');
+                    const btn = document.createElement('button');
+                    btn.className = 'report-btn';
+                    btn.textContent = f.name.replace('.md', '');
+                    btn.addEventListener('click', () => showReport(f));
+                    li.appendChild(btn);
+                    list.appendChild(li);
+                  });
+                  showReport(files[0]);
                 } catch (_e) {
                   list.innerHTML = '<li>Failed to load reports.</li>';
+                  reportDate.textContent = 'N/A';
+                  reportVersion.textContent = 'N/A';
+                  reportLink.href = '#';
                 }
               }
 
@@ -317,7 +419,7 @@ jobs:
                 btn.addEventListener('click', () => setActive(suite.key));
                 tabs.appendChild(btn);
               }
-              setActive('s3');
+              setActive('upgrade');
             </script>
           </body>
           </html>
@@ -340,18 +442,17 @@ jobs:
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: rustfs-tier-test-${{ github.run_id }}
+          name: rustfs-upgrade-test-${{ github.run_id }}
           path: |
-            /tmp/rustfs-tier.log
-            /tmp/rustfs-tier-report.md
-          if-no-files-found: warn
+            /tmp/rustfs-upgrade-report.md
+            /tmp/rustfs-upgrade.*/*
+          if-no-files-found: ignore
+          retention-days: 3
 
       - name: Cleanup environment (after)
-        if: always()
+        if: ${{ always() && (inputs.cleanup_after != 'false' || github.event_name != 'workflow_dispatch') }}
         run: |
           set -euo pipefail
-          sudo docker rm -f rustfs-test-mqtt >/dev/null 2>&1 || true
-          sudo rm -f /tmp/rustfs-mosquitto.conf
           read -r -a NODES <<< "${RUSTFS_NODES:-vm000 vm001 vm002}"
           SSH_USER="${RUSTFS_SSH_USER:-azureuser}"
           for node in "${NODES[@]}"; do
@@ -363,12 +464,14 @@ jobs:
                 ${SUDO} dpkg -P rustfs
               fi
               for i in 1 2 3 4; do ${SUDO} rm -rf /data/rustfs${i}/mnmd; done
-              ${SUDO} rm -rf /var/log/rustfs /var/lib/rustfs/kms
+              ${SUDO} rm -rf /var/log/rustfs /var/lib/rustfs/kms /var/lib/rustfs/kms-backup
             '
           done
 
       - name: Notify on failure
         if: failure()
         run: |
-          echo "RustFS tier suite failed"
-          echo "See the uploaded report and log artifacts for details."
+          echo "RustFS upgrade compatibility test failed"
+          echo "From: ${{ inputs.from_url || inputs.from_version || 'release (default)' }}"
+          echo "To: ${{ inputs.to_url || inputs.to_version || 'nightly (R2 latest)' }}"
+          echo "See the uploaded report and logs for details."


### PR DESCRIPTION
## Summary of Changes

- `rustfs-upgrade-test.yml` plus functional-chain wiring: add the upgrade compatibility suite and order the nightly functional chain (Upgrade -> S3 Compat -> KMS -> Tier -> Pool/Heal -> Security) on the shared test environment.
- `rustfs-storage-test.yml` (new): add the storage engine suite (STOR-*, backlog #2024) to the chain, running after the tier test, with the same dispatch / report / dashboard-upload / cleanup structure as the S3 and KMS workflows.
- `rustfs-s3-compat-test.yml`: fix the report case-table regex so case IDs containing digits (e.g. S3C-101) are parsed; previously only all-letter prefixes (KMS-, TIER-, ...) appeared in the summary table.

## Verification

- `bash -n` on the referenced auto-testing scripts and `--dry-run` execution of both suites.
- YAML parsing of all touched workflow files.
- Case-ID consistency check across scripts and reports.
- Adversarial review pass (correctness / simplicity / test coverage / compatibility / security); findings fixed before submission.
- End-to-end run on the smoke-testing VMs is pending CI execution.

## Impact

CI-only. No production code or configuration behavior changes. The new storage workflow requires the companion `rustfs/auto-testing` PR (STOR suite + ENC/SNW S3 cases) and a server config with compression / cache / response-compression enabled, which the storage script writes itself.

## Additional Notes

This branch is stacked on the unmerged functional-chain commit (`feat(ci): add upgrade compatibility suite and reorder functional chain`); the diff against main intentionally includes both commits because the storage workflow triggers off the tier workflow introduced by the chain.
