### PR TITLE
fix(ecstore): use capacity info override for decommission race test

### DIFF
--- a/crates/ecstore/src/services/rebalance/control.rs
+++ b/crates/ecstore/src/services/rebalance/control.rs
@@ -1329,8 +1329,9 @@ mod tests {
     use super::*;
     use crate::config::com::delete_config;
     use crate::core::pools::{
-        POOL_META_NAME, PoolActivationDurableSaveBarrier, PoolActivationStartKind, PoolActivationStartProbe, PoolMetaWriteState,
-        persist_pool_meta_identity_for_startup,
+        DecommissionErasureLayout, DecommissionPoolCapacityInfo, POOL_META_NAME, PoolActivationDurableSaveBarrier,
+        PoolActivationStartKind, PoolActivationStartProbe, PoolMetaWriteState, persist_pool_meta_identity_for_startup,
+        set_decommission_capacity_info_overrides_for_test,
     };
     use crate::object_api::NamespaceLockFence;
     use crate::set_disk::{PutObjectCommitBarrier, PutObjectCommitPause, hermetic_set_disks_isolated};
@@ -1751,25 +1752,18 @@ mod tests {
         ];
         set_rebalance_disk_stats_override_for_test(rebalance_store.id, disk_stats.clone());
         set_rebalance_disk_stats_override_for_test(decommission_store.id, disk_stats);
-        crate::core::pools::set_decommission_space_info_override_for_test(
+        let capacity_layout = DecommissionErasureLayout { data: 4, parity: 4 };
+        set_decommission_capacity_info_overrides_for_test(
             decommission_store.id,
             vec![
-                (
-                    0,
-                    crate::core::pools::PoolSpaceInfo {
-                        free: 0,
-                        total: 100,
-                        used: 100,
-                    },
-                ),
-                (
-                    1,
-                    crate::core::pools::PoolSpaceInfo {
-                        free: 200,
-                        total: 200,
-                        used: 0,
-                    },
-                ),
+                vec![
+                    DecommissionPoolCapacityInfo::for_test(0, capacity_layout, 0, 100, 100),
+                    DecommissionPoolCapacityInfo::for_test(1, capacity_layout, 200, 200, 0),
+                ],
+                vec![
+                    DecommissionPoolCapacityInfo::for_test(0, capacity_layout, 0, 100, 100),
+                    DecommissionPoolCapacityInfo::for_test(1, capacity_layout, 200, 200, 0),
+                ],
             ],
         );
         let (first_object, competing_object, competing_kind) = match paused_kind {


### PR DESCRIPTION
## Related Issues

N/A — hourly automated verification caught this regression.

## Summary of Changes

PR #6917 ("reserve decommission capacity safely") introduced a new capacity
reservation model for decommission. The existing
`assert_real_activation_start_race` test was not updated for the new model.

The test used `set_decommission_space_info_override_for_test` which creates
capacity infos via `from_logical` with `take` semantics (consumed on first
access). After the new capacity reservation model was introduced, the capacity
check reads actual physical disk space when the override has already been
consumed, causing the test to fail with real disk values (~11TB required vs
~2TB available on a local Mac).

**Fix:** Switch to `set_decommission_capacity_info_overrides_for_test` which
uses a `VecDeque` (supports multiple snapshots for repeated access) and
provides properly formed `DecommissionPoolCapacityInfo` values with matching
erasure layout.

## Verification

- `cargo fmt --all --check` — passed
- `cargo clippy -p rustfs-ecstore --all-targets` — passed (pre-existing dead
  code warnings in test code, not from this change)
- `cargo nextest run -p rustfs-ecstore -- real_rebalance_and_decommission_starts_commit_at_most_one_side` — passed
- Full `cargo nextest run --all --exclude e2e_test` — 8771 passed, 1 failed
  (pre-existing flaky `transition_matrix_tests` in `ecstore-serial-flaky`
  group, unrelated to this change)

## Impact

Test-only fix. No runtime, API, or user-facing impact.
