### PR TITLE
ci: allow macOS release builds to finish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,7 +244,7 @@ jobs:
     needs: [ build-check, prepare-platform-matrix ]
     if: needs.build-check.outputs.should_build == 'true' && needs.prepare-platform-matrix.result == 'success'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 150
+    timeout-minutes: 180
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       # Release binaries ship without dial9 telemetry and therefore do not need


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Increase the release build job timeout from 150 to 180 minutes. The macOS arm64 preview build reached the current limit twice without a compiler error.

## Verification

- `git diff --check`
- `actionlint .github/workflows/build.yml`

## Impact

Release builds may run for up to 30 minutes longer before GitHub Actions cancels them. Runtime behavior is unchanged.

## Additional Notes

This unblocks the 1.0.0-rc.5 preview build.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
