### PR TITLE
test(ecstore): stabilize activation race capacity

### DIFF
--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -7369,50 +7369,14 @@ impl DecommissionPoolCapacityInfo {
             physical_used,
         }
     }
-
-    #[cfg(test)]
-    fn from_logical(pool_index: usize, space: PoolSpaceInfo) -> Self {
-        Self {
-            pool_index,
-            space,
-            layout: DecommissionErasureLayout { data: 1, parity: 0 },
-            physical_free: space.free,
-            physical_total: space.total,
-            physical_used: space.used,
-        }
-    }
 }
-
-#[cfg(test)]
-type DecommissionSpaceInfoOverrides = std::sync::Mutex<HashMap<uuid::Uuid, Vec<(usize, PoolSpaceInfo)>>>;
 
 #[cfg(test)]
 type DecommissionCapacityInfoOverrides =
     std::sync::Mutex<HashMap<uuid::Uuid, std::collections::VecDeque<Vec<DecommissionPoolCapacityInfo>>>>;
 
 #[cfg(test)]
-static DECOMMISSION_SPACE_INFO_OVERRIDES: std::sync::OnceLock<DecommissionSpaceInfoOverrides> = std::sync::OnceLock::new();
-
-#[cfg(test)]
 static DECOMMISSION_CAPACITY_INFO_OVERRIDES: std::sync::OnceLock<DecommissionCapacityInfoOverrides> = std::sync::OnceLock::new();
-
-#[cfg(test)]
-pub(crate) fn set_decommission_space_info_override_for_test(store_id: uuid::Uuid, space_infos: Vec<(usize, PoolSpaceInfo)>) {
-    DECOMMISSION_SPACE_INFO_OVERRIDES
-        .get_or_init(|| std::sync::Mutex::new(HashMap::new()))
-        .lock()
-        .expect("decommission space info override should not be poisoned")
-        .insert(store_id, space_infos);
-}
-
-#[cfg(test)]
-fn take_decommission_space_info_override_for_test(store_id: uuid::Uuid) -> Option<Vec<(usize, PoolSpaceInfo)>> {
-    DECOMMISSION_SPACE_INFO_OVERRIDES
-        .get_or_init(|| std::sync::Mutex::new(HashMap::new()))
-        .lock()
-        .expect("decommission space info override should not be poisoned")
-        .remove(&store_id)
-}
 
 #[cfg(test)]
 pub(crate) fn set_decommission_capacity_info_overrides_for_test(
@@ -9154,14 +9118,6 @@ impl ECStore {
         #[cfg(test)]
         if let Some(capacity_infos) = take_decommission_capacity_info_override_for_test(self.id) {
             return Ok(capacity_infos);
-        }
-
-        #[cfg(test)]
-        if let Some(space_infos) = take_decommission_space_info_override_for_test(self.id) {
-            return Ok(space_infos
-                .into_iter()
-                .map(|(pool_index, space)| DecommissionPoolCapacityInfo::from_logical(pool_index, space))
-                .collect());
         }
 
         let mut capacity_infos = Vec::with_capacity(self.pools.len());

--- a/crates/ecstore/src/services/rebalance/control.rs
+++ b/crates/ecstore/src/services/rebalance/control.rs
@@ -1329,8 +1329,9 @@ mod tests {
     use super::*;
     use crate::config::com::delete_config;
     use crate::core::pools::{
-        POOL_META_NAME, PoolActivationDurableSaveBarrier, PoolActivationStartKind, PoolActivationStartProbe, PoolMetaWriteState,
-        persist_pool_meta_identity_for_startup,
+        DecommissionErasureLayout, DecommissionPoolCapacityInfo, POOL_META_NAME, PoolActivationDurableSaveBarrier,
+        PoolActivationStartKind, PoolActivationStartProbe, PoolMetaWriteState, persist_pool_meta_identity_for_startup,
+        set_decommission_capacity_info_overrides_for_test,
     };
     use crate::object_api::NamespaceLockFence;
     use crate::set_disk::{PutObjectCommitBarrier, PutObjectCommitPause, hermetic_set_disks_isolated};
@@ -1751,26 +1752,15 @@ mod tests {
         ];
         set_rebalance_disk_stats_override_for_test(rebalance_store.id, disk_stats.clone());
         set_rebalance_disk_stats_override_for_test(decommission_store.id, disk_stats);
-        crate::core::pools::set_decommission_space_info_override_for_test(
+        let layout = DecommissionErasureLayout { data: 1, parity: 0 };
+        let capacity_snapshot = vec![
+            DecommissionPoolCapacityInfo::for_test(0, layout, 0, 100, 100),
+            DecommissionPoolCapacityInfo::for_test(1, layout, 200, 200, 0),
+        ];
+        // Decommission start samples capacity before and inside its durable activation fence.
+        set_decommission_capacity_info_overrides_for_test(
             decommission_store.id,
-            vec![
-                (
-                    0,
-                    crate::core::pools::PoolSpaceInfo {
-                        free: 0,
-                        total: 100,
-                        used: 100,
-                    },
-                ),
-                (
-                    1,
-                    crate::core::pools::PoolSpaceInfo {
-                        free: 200,
-                        total: 200,
-                        used: 0,
-                    },
-                ),
-            ],
+            vec![capacity_snapshot.clone(), capacity_snapshot],
         );
         let (first_object, competing_object, competing_kind) = match paused_kind {
             PoolActivationStartKind::Rebalance => {


### PR DESCRIPTION
## Related Issues

Fixes #6986.

## Summary of Changes

- Provide deterministic physical-capacity snapshots for both decommission activation reads in the rebalance/decommission race test.
- Remove the obsolete one-shot logical-capacity test override after its final caller moves to the physical-capacity fixture.
- Keep the regression independent of the host filesystem's available space.

## Verification

- `cargo fmt --all --check`
- `cargo nextest run -p rustfs-ecstore real_rebalance_and_decommission_starts_commit_at_most_one_side --failure-output immediate-final --status-level pass --final-status-level pass --show-progress none --no-pager --color never`
- `git diff --check origin/main...HEAD`

## Impact

Test-only change. There is no runtime, API, wire-format, on-disk, deployment, or configuration impact.

## Additional Notes

The fixture supplies exactly the two capacity samples taken before and inside the durable activation fence. The focused race test passes for both paused activation directions.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
