### PR TITLE
test(ecstore): deflake inline fanout gate assertion under load

### DIFF
--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -1638,10 +1638,13 @@ mod prepared_get_object_metadata_tests {
         .await;
     }
 
-    #[tokio::test]
+    #[test]
     #[serial_test::serial(body_cache_hook)]
-    async fn non_inline_data_read_early_stop_does_not_add_inline_fanout_on_unequal_layout() {
-        let (_dirs, set_disks) = make_local_set_disks(6, 2).await;
+    fn non_inline_data_read_early_stop_does_not_add_inline_fanout_on_unequal_layout() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime should build");
         let bucket = "inline-read-plan-unequal";
         let object = object_with_initial_data_shards_for_geometry(bucket, "inline-object", 6, 2);
         let payload = b"inline quorum payload".repeat(256);
@@ -1650,55 +1653,65 @@ mod prepared_get_object_metadata_tests {
             ..Default::default()
         };
 
-        set_disks
-            .make_bucket(bucket, &MakeBucketOptions::default())
-            .await
-            .expect("bucket should be created");
-        let mut put_reader = PutObjReader::from_vec(payload.clone());
-        set_disks
-            .put_object(bucket, &object, &mut put_reader, &opts)
-            .await
-            .expect("inline object should be written");
-
-        let read_once = |enabled: bool| {
-            let set_disks = Arc::clone(&set_disks);
-            let bucket = bucket.to_string();
-            let object = object.clone();
-            let payload = payload.clone();
-            let opts = opts.clone();
-            async move {
-                temp_env::async_with_vars(
-                    [
-                        (
-                            "RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE",
-                            Some(if enabled { "true" } else { "false" }),
-                        ),
-                        ("RUSTFS_GET_METADATA_EARLY_STOP_ENABLE", Some("true")),
-                        ("RUSTFS_GET_METADATA_EARLY_STOP_BOUNDED_FANOUT", Some("true")),
-                    ],
-                    async {
-                        let calls = disk_call_counters::observe(&object);
-                        let mut reader = set_disks
-                            .get_object_reader(&bucket, &object, None, HeaderMap::new(), &opts)
-                            .await
-                            .expect("inline GET reader should open");
-                        let mut restored = Vec::new();
-                        reader
-                            .stream
-                            .read_to_end(&mut restored)
-                            .await
-                            .expect("inline GET body should stream");
-                        assert_eq!(restored, payload);
-                        calls.total(disk_call_counters::KIND_READ_VERSION)
-                    },
-                )
+        let (_dirs, set_disks) = runtime.block_on(async {
+            let (dirs, set_disks) = make_local_set_disks(6, 2).await;
+            set_disks
+                .make_bucket(bucket, &MakeBucketOptions::default())
                 .await
-            }
-        };
+                .expect("bucket should be created");
+            let mut put_reader = PutObjReader::from_vec(payload.clone());
+            set_disks
+                .put_object(bucket, &object, &mut put_reader, &opts)
+                .await
+                .expect("inline object should be written");
+            (dirs, set_disks)
+        });
 
-        let gate_off_calls = read_once(false).await;
-        let gate_on_calls = read_once(true).await;
-        assert_eq!(gate_on_calls, gate_off_calls, "inline gate must not add reserve fanout");
+        // disk_call_counters counts tasks that started running, so an
+        // early-stop abort races the single-pending inline hedge into a ±1
+        // count per read. The fanout lifecycle histogram records the
+        // scheduling decision itself and stays deterministic under load.
+        let recorder = CapturingRecorder::default();
+        let previous_gate = rustfs_io_metrics::get_stage_metrics_enabled();
+        rustfs_io_metrics::set_get_stage_metrics_enabled(true);
+        metrics::with_local_recorder(&recorder, || {
+            runtime.block_on(async {
+                for enabled in [false, true] {
+                    temp_env::async_with_vars(
+                        [
+                            (
+                                "RUSTFS_GET_METADATA_TWO_PHASE_READ_PLAN_ENABLE",
+                                Some(if enabled { "true" } else { "false" }),
+                            ),
+                            ("RUSTFS_GET_METADATA_EARLY_STOP_ENABLE", Some("true")),
+                            ("RUSTFS_GET_METADATA_EARLY_STOP_BOUNDED_FANOUT", Some("true")),
+                        ],
+                        async {
+                            let mut reader = set_disks
+                                .get_object_reader(bucket, &object, None, HeaderMap::new(), &opts)
+                                .await
+                                .expect("inline GET reader should open");
+                            let mut restored = Vec::new();
+                            reader
+                                .stream
+                                .read_to_end(&mut restored)
+                                .await
+                                .expect("inline GET body should stream");
+                            assert_eq!(restored, payload);
+                        },
+                    )
+                    .await;
+                }
+            })
+        });
+        rustfs_io_metrics::set_get_stage_metrics_enabled(previous_gate);
+
+        let scheduled = recorder.histogram_values(
+            "rustfs_io_get_object_metadata_fanout_scheduled",
+            &[("path", GET_OBJECT_PATH_LEGACY_DUPLEX)],
+        );
+        assert_eq!(scheduled.len(), 2, "each GET should run exactly one metadata fanout");
+        assert_eq!(scheduled[1], scheduled[0], "inline gate must not add reserve fanout");
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues
N/A (CI flake first seen on PR #6961, Test and Lint run 33392753724, 2026-08-31; that PR did not touch ecstore.)

## Summary of Changes
`set_disk::prepared_get_object_metadata_tests::non_inline_data_read_early_stop_does_not_add_inline_fanout_on_unequal_layout` compared `disk_call_counters::KIND_READ_VERSION` totals between the two-phase read-plan gate being off and on. That counter records inside each spawned fanout task, and on a healthy 6-disk/2-parity inline GET the fanout loop deterministically schedules one single-pending inline hedge read after the third response. Whether that hedge task gets its first poll before the early-stop `abort_all()` cancels it decides a 4-vs-5 count per read, so under concurrent nextest load the two reads can disagree and the equality assertion fails. This is an intra-test scheduling race, not cross-test shared state: nextest runs each test in its own process, so serialization (the #6940 pattern) would not help here. The fix asserts on the `rustfs_io_get_object_metadata_fanout_scheduled` histogram instead, which records the scheduling decision synchronously in the fanout loop and is deterministic, reusing the `CapturingRecorder` + current-thread runtime pattern already used by the neighboring tests in this module. No production code changes.

## Verification
- Reproduced the pre-fix race locally: running the old assertion beside one other test flaked 2/40 rounds, with the exact CI signature (`assertion left == right failed: inline gate must not add reserve fanout, left: 4, right: 5`); 60 solo rounds never failed, matching the reported 5/5 solo stability.
- `cargo nextest run -p rustfs-ecstore -E 'test(prepared_get_object_metadata_tests)'` — 16/16 pass, plus 30 consecutive full-module rounds with 0 failures.
- `cargo nextest run -p rustfs-ecstore --no-fail-fast` — 4 full-concurrency rounds; the changed test passed every round. Unrelated pre-existing load flakes in `set_disk::ops` (e.g. `metadata_semantic_mutation_generation_matrix_retires_cached_snapshot`) reproduce identically on unmodified main and are out of scope.
- `make pre-commit` (fmt, arch/guardrail checks, quick-check) and `cargo clippy -p rustfs-ecstore --tests` — clean.

## Impact
N/A (test-only change; no user-facing, API, or configuration impact.)

## Additional Notes
The single-pending inline hedge means a healthy unequal-layout inline GET legitimately schedules 5 metadata reads in both gate modes; the test intentionally asserts equality of the scheduled counts rather than an absolute value, since absolute-count coverage lives in `non_inline_data_read_early_stop_keeps_reserve_on_unequal_layout`.
