### PR TITLE
fix(heal): preserve resumable retry signals

### DIFF
--- a/crates/heal/src/heal/task/heal_erasure_set.rs
+++ b/crates/heal/src/heal/task/heal_erasure_set.rs
@@ -492,6 +492,7 @@ impl HealTask {
             }
             Err(Error::TaskCancelled) => Err(Error::TaskCancelled),
             Err(Error::TaskTimeout) => Err(Error::TaskTimeout),
+            Err(e) if e.is_recoverable_heal() => Err(e),
             Err(e) => {
                 error!(
                     target: "rustfs::heal::task",

--- a/crates/heal/src/heal/task/tests.rs
+++ b/crates/heal/src/heal/task/tests.rs
@@ -2429,6 +2429,37 @@ async fn erasure_set_format_slowdown_is_propagated() {
 }
 
 #[tokio::test]
+async fn erasure_set_retry_signal_remains_typed_across_task_boundary() {
+    let temp = TempDir::new().expect("temporary directory should be created");
+    let disk = make_resume_disk(&temp).await;
+    let storage = Arc::new(MockStorage {
+        heal_object_outcome: Mutex::new(Some(MockHealObjectOutcome::RetryableSlowDown)),
+        resume_disk: Mutex::new(Some(disk)),
+        ..Default::default()
+    });
+    let request = HealRequest::new(
+        HealType::ErasureSet {
+            buckets: vec!["bucket-a".to_string()],
+            set_disk_id: "pool_0_set_0".to_string(),
+        },
+        HealOptions::default(),
+        HealPriority::Normal,
+    );
+    let task = HealTask::from_request(request, storage);
+
+    let error = task
+        .execute()
+        .await
+        .expect_err("an incomplete resumable pass must remain retryable");
+
+    assert!(
+        matches!(&error, Error::TransientSkip { message } if message.contains("retry scheduled")),
+        "the resumable retry signal must keep its typed identity: {error}"
+    );
+    assert!(error.is_recoverable_heal(), "the scheduler must accept the preserved retry signal");
+}
+
+#[tokio::test]
 async fn erasure_set_bucket_prepass_failure_stops_before_object_heal() {
     let temp = TempDir::new().expect("temporary directory should be created");
     let disk = make_resume_disk(&temp).await;


### PR DESCRIPTION
## Related Issues

Fixes #6954

## Summary of Changes

- Preserve typed recoverable errors at the resumable erasure-set task boundary so the heal manager can schedule the already-persisted retry instead of marking the task terminal.
- Keep cancellation, timeout, and terminal error wrapping unchanged.
- Add a regression that drives a real `SlowDown` response through `HealTask` and verifies the durable `TransientSkip` retry signal remains classifiable.

## Verification

- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p rustfs-heal erasure_set_retry_signal_remains_typed_across_task_boundary -- --nocapture` (1 passed on the latest base)
- `cargo test -p rustfs-heal test_retry_request_for_durable_replacement_retry_signal -- --nocapture` (1 passed on the latest base)
- `cargo test -p rustfs-heal erasure_set_ -- --nocapture` (13 passed)
- `make pre-pr` (passed, including 15,753/15,753 nextest tests; the validation worktree also contained the isolated #6989 test-fixture stabilization)

## Impact

Recoverable erasure-set heal failures that have already persisted retry state remain retryable at the manager boundary. There is no public API, configuration, wire-format, or on-disk schema change. Retry diagnostics no longer receive the terminal `TaskExecutionFailed` prefix.

## Additional Notes

- Correctness: recoverable errors are returned unchanged, while cancellation, timeout, and terminal behavior stays unchanged.
- Concurrency and durability: retry/reset state is persisted before propagation; the change adds no awaits, locks, or ownership transitions.
- Compatibility: persisted and wire contracts are unchanged; only the diagnostic wrapper on recoverable failures differs.
- Performance: the change adds one error-path variant check and no work on the success or hot path.
- Test coverage: the regression crosses the real task boundary and verifies the same classifier used by the scheduler.
- The full gate ran before the latest base advanced through #6985 and #6990. Those commits do not touch the heal path; after rebasing, both focused regressions above were rerun successfully.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
