### PR TITLE
test(e2e): poll for listing convergence after rolling upgrade restarts

### DIFF
--- a/crates/e2e_test/src/upgrade_compatibility_test.rs
+++ b/crates/e2e_test/src/upgrade_compatibility_test.rs
@@ -20,7 +20,9 @@ use aws_sdk_s3::types::{
     BucketVersioningStatus, CompletedMultipartUpload, CompletedPart, ServerSideEncryption, VersioningConfiguration,
 };
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use tokio::task::JoinSet;
+use tokio::time::{Instant, sleep};
 
 type TestResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
@@ -33,6 +35,10 @@ const MIXED_BUCKET: &str = "upgrade-mixed-version-data";
 const MIXED_NODE_COUNT: usize = 4;
 const MULTIPART_WORKERS: usize = 16;
 const MULTIPART_UPLOADS_PER_WORKER: usize = 16;
+// Peers keep a restarted node's drive in Suspect/Returning for roughly
+// probe_interval (2s) x success_threshold (3) after it comes back; 30s
+// comfortably covers that window plus CI scheduling jitter.
+const LISTING_CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn source_binary() -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
     let path = std::env::var_os(SOURCE_BINARY_ENV)
@@ -144,6 +150,43 @@ async fn write_multipart_load(clients: &[Client], phase: &str) -> Result<Vec<Str
     Ok(keys)
 }
 
+/// Assert that `client` eventually lists exactly `expected` objects under
+/// `{phase}/`, polling until [`LISTING_CONVERGENCE_TIMEOUT`].
+///
+/// A single-snapshot assertion here is racy by construction: each phase both
+/// writes and lists within seconds of a node restart. While a peer still holds
+/// the restarted node's drive in Suspect/Returning, strict-quorum listing
+/// consults only the remaining three drives and drops any object that was
+/// itself legally written at write quorum (3/4 drives) during an earlier
+/// node's identical post-restart window — its xl.meta is then visible on only
+/// two of the three consulted drives, below the required object quorum of
+/// three. GET still succeeds for such objects; only the listing under-counts
+/// until drive health converges. A genuine upgrade data-loss regression still
+/// fails after the deadline.
+async fn wait_for_phase_listing(client: &Client, phase: &str, expected: usize, context: &str) -> TestResult {
+    let deadline = Instant::now() + LISTING_CONVERGENCE_TIMEOUT;
+    loop {
+        let listed = client
+            .list_objects_v2()
+            .bucket(MIXED_BUCKET)
+            .prefix(format!("{phase}/"))
+            .send()
+            .await?;
+        let count = listed.contents().len();
+        if count == expected {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "{context}: listing under {phase}/ returned {count} of {expected} objects even after {}s of post-restart convergence",
+                LISTING_CONVERGENCE_TIMEOUT.as_secs()
+            )
+            .into());
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+}
+
 async fn exercise_mixed_cluster(
     cluster: &RustFSTestClusterEnvironment,
     phase: &str,
@@ -178,18 +221,14 @@ async fn exercise_mixed_cluster(
 
     let multipart_keys = write_multipart_load(&clients, phase).await?;
     let expected_count = multipart_keys.len() + 2;
-    for client in [current_client, previous_client] {
-        let listed = client
-            .list_objects_v2()
-            .bucket(MIXED_BUCKET)
-            .prefix(format!("{phase}/"))
-            .send()
-            .await?;
-        assert_eq!(
-            listed.contents().len(),
+    for (label, client) in [("current", current_client), ("previous", previous_client)] {
+        wait_for_phase_listing(
+            client,
+            phase,
             expected_count,
-            "both RustFS versions must stream the complete mixed-version listing"
-        );
+            &format!("the {label} RustFS version must stream the complete mixed-version listing"),
+        )
+        .await?;
     }
 
     let last_multipart_key = format!("{phase}/multipart/{:02}/{:02}", MULTIPART_WORKERS - 1, MULTIPART_UPLOADS_PER_WORKER - 1);
@@ -376,19 +415,15 @@ async fn rolling_upgrade_from_rc2_preserves_mixed_version_contracts() -> TestRes
     cluster.stop_node(3)?;
     cluster.start_node_from_binary(3, &current_binary).await?;
 
-    for client in cluster.create_all_clients()? {
+    for (node_idx, client) in cluster.create_all_clients()?.iter().enumerate() {
         for phase in ["one-current-node", "one-previous-node"] {
-            let listed = client
-                .list_objects_v2()
-                .bucket(MIXED_BUCKET)
-                .prefix(format!("{phase}/"))
-                .send()
-                .await?;
-            assert_eq!(
-                listed.contents().len(),
+            wait_for_phase_listing(
+                client,
+                phase,
                 MULTIPART_WORKERS * MULTIPART_UPLOADS_PER_WORKER + 2,
-                "the homogeneous current cluster must preserve every object from {phase}"
-            );
+                &format!("node {node_idx}: the homogeneous current cluster must preserve every object"),
+            )
+            .await?;
         }
     }
 


### PR DESCRIPTION
## Related Issues
N/A (fixes the intermittent CI failure of the `Mixed-version rolling upgrade from rc.2` lane introduced by #6950; observed on #6992 run 33478999853 and on unrelated PR branches, passing on rerun).

## Summary of Changes
The rolling-upgrade suite asserted a single `list_objects_v2` snapshot seconds after restarting a node, and failed intermittently with `left: 254, right: 258` on the `one-previous-node/` prefix. Root cause analysis against the failing run's server logs shows two stacked drive-health convergence windows, not an upgrade regression: (1) each phase starts its write load ~1s after a node restart, while a peer still holds the just-restarted node's drive in Suspect state (recovery takes ~probe_interval 2s x success_threshold 3), so a handful of objects are legally written at write quorum with xl.meta on 3 of 4 drives; (2) the final assertion listed ~3s after the last node's restart, while the serving node still excluded that node's drive, so strict-quorum listing consulted 3 drives, found those degraded objects on only 2 of them (below the required object quorum of 3), and dropped exactly them from the listing even though every object still served GET correctly. This change replaces the snapshot asserts with `wait_for_phase_listing`, a bounded convergence poll (30s deadline, 500ms interval) used by both the per-phase mixed-version listing checks and the final homogeneous-cluster check. A genuine upgrade data-loss regression still fails after the deadline, and failure messages now name the node and the observed/expected counts. The underlying product-level gap (strict listing hides write-quorum-degraded objects while another drive is offline) is tracked separately for an ecstore-side fix.

## Verification
- `cargo fmt --all`
- `cargo check -p e2e_test`
- `cargo clippy -p e2e_test --all-targets` (no warnings in the changed crate)
- `make pre-commit` equivalent: all steps pass; `test-wiring-check` was run as `uv run --python 3.12 scripts/check_test_wiring.py` because the local default Python lacks `tomllib` (environment issue, check passes)
- The upgrade tests themselves require the pinned rc.2 release binary (`RUSTFS_UPGRADE_SOURCE_BINARY`) and run in the `e2e-upgrade.yml` lane; the race is timing-dependent, so the lane on this PR plus the failing-run log correlation (node lifecycle timestamps vs. Suspect-state recovery timing) is the verification for the fix itself

## Impact
Test-only change; no production code affected. The upgrade-compatibility lane keeps its data-preservation contract but tolerates the documented post-restart drive-health convergence window instead of racing it.

## Additional Notes
Evidence chain from run 33478999853: node 1 marked node 2's remote drive Suspect at 07:37:07.52, write load began 07:37:08.6, so the first upload of each of the 4 workers routed through node 1 was written at 3/4 drives (exactly the 4 missing objects); the final listing ran at ~07:38:03-05, ~1-3s after node 3's restart, while node 0 had a transport failure to node 3 at 07:38:02.09. The drop point is `resolve_inner` in `crates/filemeta/src/metacache.rs` (`objs_valid < obj_quorum`) reached via `SetDisks::list_path` in `crates/ecstore/src/store/list_objects.rs`, which consults only online drives and has no fallback drives on a 4-drive set.
