### PR TITLE
build(make): resolve a Python 3.11+ interpreter for guard scripts

### DIFF
--- a/.config/make/coverage.mak
+++ b/.config/make/coverage.mak
@@ -23,4 +23,4 @@ coverage: core-deps ## Workspace line coverage (cargo-llvm-cov + nextest; slow, 
 	@mkdir -p target/llvm-cov
 	cargo llvm-cov report --lcov --output-path target/llvm-cov/lcov.info
 	cargo llvm-cov report --json --output-path target/llvm-cov/coverage.json
-	python3 scripts/coverage_per_crate.py target/llvm-cov/coverage.json
+	$(RUSTFS_PYTHON_BIN) scripts/coverage_per_crate.py target/llvm-cov/coverage.json

--- a/.config/make/lint-fmt.mak
+++ b/.config/make/lint-fmt.mak
@@ -88,7 +88,7 @@ offline-enrollment-e2e-check: core-deps ## Build and exercise the dedicated offl
 .PHONY: test-wiring-check
 test-wiring-check: ## Check tests stay registered and selected by their intended runners
 	@echo "🧪 Checking test wiring..."
-	python3 ./scripts/check_test_wiring.py
+	$(RUSTFS_PYTHON_BIN) ./scripts/check_test_wiring.py
 
 .PHONY: log-analyzer-rules-check
 log-analyzer-rules-check: core-deps ## Check log-analyzer rule anchors still exist verbatim in source

--- a/.config/make/tests.mak
+++ b/.config/make/tests.mak
@@ -35,13 +35,14 @@ script-tests: ## Run shell script tests
 	./scripts/test_pinned_paired_abba_bench.sh
 	./scripts/test_manual_transition_runbooks.sh
 	./scripts/test_fuzz_runner.sh
+	./scripts/test_python_bin.sh
 	./scripts/check_embedded_secrets.sh --self-test
-	python3 ./scripts/check_test_wiring.py --self-test
-	python3 ./scripts/check_security_coverage.py --self-test
-	python3 ./scripts/check_scheduled_validation_freshness.py --self-test
-	python3 ./scripts/s3-tests/test_report_compat.py
+	$(RUSTFS_PYTHON_BIN) ./scripts/check_test_wiring.py --self-test
+	$(RUSTFS_PYTHON_BIN) ./scripts/check_security_coverage.py --self-test
+	$(RUSTFS_PYTHON_BIN) ./scripts/check_scheduled_validation_freshness.py --self-test
+	$(RUSTFS_PYTHON_BIN) ./scripts/s3-tests/test_report_compat.py
 	bash -n ./scripts/validate_object_data_cache_cold_stampede.sh
-	python3 ./scripts/check_object_data_cache_follower_samples.py --self-test
+	$(RUSTFS_PYTHON_BIN) ./scripts/check_object_data_cache_follower_samples.py --self-test
 	./scripts/validate_object_data_cache_cold_stampede.sh --self-test
 
 .PHONY: test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,14 @@ make pre-pr
 
 > `make test` requires [cargo-nextest](https://nexte.st) (CI runs it and only nextest honours `.config/nextest.toml` test-groups). Install it with `cargo install cargo-nextest --locked` or a prebuilt binary (see https://nexte.st/docs/installation/). To run the plain `cargo test` fallback anyway (results not authoritative — serialization semantics differ from CI), set `RUSTFS_ALLOW_CARGO_TEST_FALLBACK=1`.
 
+> Some guard checks are Python (`test-wiring-check` in `make pre-commit`, plus the
+> security-coverage and scheduled-validation self-tests in `make test`) and import
+> `tomllib`, so they need **Python 3.11+**. Make resolves the interpreter through
+> `scripts/python_bin.sh`, which prefers a `python3.11`+ on `PATH` and otherwise falls
+> back to `uv run --python 3.12`. macOS ships `/usr/bin/python3` at 3.9, so install a
+> newer one (`brew install python@3.12`) or [uv](https://docs.astral.sh/uv/); pin a
+> specific interpreter with `RUSTFS_PYTHON=/path/to/python3.12`.
+
 > For the full test-layer taxonomy (unit / ecstore black-box / e2e / s3s-e2e / S3 compatibility / chaos / fuzz / bench), each layer's entry command, the naming conventions the migration gate depends on, and the serial/nextest rules, see [docs/testing/README.md](docs/testing/README.md).
 
 > For the event, timeout, required-status, and local reproduction matrix, see [docs/testing/ci-gates.md](docs/testing/ci-gates.md).

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ SHELL := $(shell which bash)
 .SHELLFLAGS = -eu -o pipefail -c
 
 DOCKER_CLI ?= docker
+# Python interpreter for the repository's helper scripts. They import tomllib
+# (Python 3.11+), while macOS still ships /usr/bin/python3 at 3.9, so calls go
+# through a resolver that picks a new-enough interpreter (or falls back to uv).
+# Override with RUSTFS_PYTHON=/path/to/python3.12, or replace the resolver via
+# RUSTFS_PYTHON_BIN=<command>.
+RUSTFS_PYTHON_BIN ?= ./scripts/python_bin.sh
 IMAGE_NAME ?= rustfs:v1.0.0
 CONTAINER_NAME ?= rustfs-dev
 # Docker build configurations

--- a/scripts/python_bin.sh
+++ b/scripts/python_bin.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Resolve a Python interpreter new enough for this repository's helper scripts
+# and exec it with the given arguments.
+#
+# Why this exists: scripts/check_test_wiring.py and
+# scripts/check_security_coverage.py import `tomllib`, which only landed in
+# Python 3.11. macOS ships /usr/bin/python3 at 3.9, so a plain
+# `python3 ./scripts/check_test_wiring.py` makes `make pre-commit` fail on a
+# clean machine with `ModuleNotFoundError: No module named 'tomllib'` even
+# though the checker itself is fine. Make targets go through this wrapper so
+# the gate works wherever a new-enough interpreter (or `uv`) is reachable.
+#
+# CI runners already provide Python 3.11+ as `python3`, so .github/workflows
+# keeps calling `python3` directly.
+#
+# Resolution order:
+#   1. $RUSTFS_PYTHON, if set (must itself be >= the minimum version)
+#   2. python3.14 / python3.13 / python3.12 / python3.11 / python3 / python
+#   3. `uv run --python <spec> --no-project python`
+#
+# Usage:
+#   ./scripts/python_bin.sh ./scripts/check_test_wiring.py --self-test
+#   ./scripts/python_bin.sh --print-interpreter   # report what would be used
+
+set -euo pipefail
+
+MIN_MAJOR=3
+MIN_MINOR=11
+UV_PYTHON_SPEC="${RUSTFS_UV_PYTHON:-3.12}"
+
+version_ok() {
+    "$1" -c "import sys; raise SystemExit(0 if sys.version_info >= (${MIN_MAJOR}, ${MIN_MINOR}) else 1)" \
+        >/dev/null 2>&1
+}
+
+if [ "${1:---help}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    cat <<USAGE
+Usage: scripts/python_bin.sh [--print-interpreter] [python arguments...]
+
+Execs a Python >= ${MIN_MAJOR}.${MIN_MINOR} interpreter (the repository's checkers import
+tomllib) with the given arguments. Resolution order:
+  1. \$RUSTFS_PYTHON, if set
+  2. python3.14 / python3.13 / python3.12 / python3.11 / python3 / python
+  3. uv run --python \${RUSTFS_UV_PYTHON:-3.12} --no-project python
+
+  --print-interpreter   Print the interpreter that would be used and exit.
+USAGE
+    exit 0
+fi
+
+print_only=0
+if [ "${1:-}" = "--print-interpreter" ]; then
+    print_only=1
+    shift
+fi
+
+if [ -n "${RUSTFS_PYTHON:-}" ]; then
+    if ! command -v "${RUSTFS_PYTHON}" >/dev/null 2>&1; then
+        echo >&2 "❌ RUSTFS_PYTHON='${RUSTFS_PYTHON}' is not an executable command."
+        exit 1
+    fi
+    if ! version_ok "${RUSTFS_PYTHON}"; then
+        echo >&2 "❌ RUSTFS_PYTHON='${RUSTFS_PYTHON}' is older than Python ${MIN_MAJOR}.${MIN_MINOR}."
+        echo >&2 "   The repository's checkers import tomllib (Python ${MIN_MAJOR}.${MIN_MINOR}+)."
+        exit 1
+    fi
+    if [ "${print_only}" = "1" ]; then
+        command -v "${RUSTFS_PYTHON}"
+        exit 0
+    fi
+    exec "${RUSTFS_PYTHON}" "$@"
+fi
+
+for candidate in python3.14 python3.13 python3.12 python3.11 python3 python; do
+    if command -v "${candidate}" >/dev/null 2>&1 && version_ok "${candidate}"; then
+        if [ "${print_only}" = "1" ]; then
+            command -v "${candidate}"
+            exit 0
+        fi
+        exec "${candidate}" "$@"
+    fi
+done
+
+if command -v uv >/dev/null 2>&1; then
+    echo >&2 "ℹ️  No Python ${MIN_MAJOR}.${MIN_MINOR}+ on PATH; using 'uv run --python ${UV_PYTHON_SPEC}'."
+    if [ "${print_only}" = "1" ]; then
+        echo "uv run --python ${UV_PYTHON_SPEC} --no-project python"
+        exit 0
+    fi
+    exec uv run --python "${UV_PYTHON_SPEC}" --no-project python "$@"
+fi
+
+echo >&2 "❌ No Python ${MIN_MAJOR}.${MIN_MINOR}+ interpreter found."
+echo >&2 "   The repository's checkers import tomllib, added in Python ${MIN_MAJOR}.${MIN_MINOR}."
+echo >&2 "   Fix it with any of:"
+echo >&2 "     brew install python@3.12          # macOS: /usr/bin/python3 is 3.9"
+echo >&2 "     curl -LsSf https://astral.sh/uv/install.sh | sh   # then re-run"
+echo >&2 "     make ... RUSTFS_PYTHON=/path/to/python3.12"
+exit 1

--- a/scripts/test_python_bin.sh
+++ b/scripts/test_python_bin.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+# Tests for scripts/python_bin.sh: the interpreter resolver that keeps
+# `make pre-commit` working on machines whose `python3` is older than 3.11
+# (notably macOS, which ships /usr/bin/python3 at 3.9).
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+RESOLVER="$REPO_ROOT/scripts/python_bin.sh"
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+
+fail() {
+    echo "❌ $1" >&2
+    exit 1
+}
+
+# A resolved interpreter must be able to import tomllib, which is the module
+# the repository's checkers need and the reason the resolver exists.
+"$RESOLVER" -c 'import tomllib, sys; assert sys.version_info >= (3, 11)' \
+    || fail "resolver produced an interpreter without tomllib"
+
+"$RESOLVER" --print-interpreter >/dev/null \
+    || fail "--print-interpreter failed"
+
+# An explicit RUSTFS_PYTHON override wins over PATH discovery.
+selected=$("$RESOLVER" --print-interpreter)
+RUSTFS_PYTHON="$selected" "$RESOLVER" -c 'import tomllib' \
+    || fail "RUSTFS_PYTHON override rejected a valid interpreter"
+
+# A too-old RUSTFS_PYTHON must fail loudly instead of silently falling back to
+# a newer interpreter, so the operator learns their override is unusable.
+mkdir -p "$TMP_ROOT/bin"
+cat > "$TMP_ROOT/bin/fake-old-python" <<'STUB'
+#!/bin/sh
+# Pretends to be Python 3.9: the version probe exits non-zero.
+exit 1
+STUB
+chmod +x "$TMP_ROOT/bin/fake-old-python"
+
+if RUSTFS_PYTHON="$TMP_ROOT/bin/fake-old-python" "$RESOLVER" -c 'pass' \
+    >"$TMP_ROOT/old.out" 2>"$TMP_ROOT/old.err"; then
+    fail "resolver accepted a too-old RUSTFS_PYTHON"
+fi
+grep -q 'older than Python' "$TMP_ROOT/old.err" \
+    || fail "too-old RUSTFS_PYTHON did not explain the version requirement"
+
+# A missing RUSTFS_PYTHON must be reported as such.
+if RUSTFS_PYTHON="$TMP_ROOT/bin/definitely-absent" "$RESOLVER" -c 'pass' \
+    >"$TMP_ROOT/absent.out" 2>"$TMP_ROOT/absent.err"; then
+    fail "resolver accepted a nonexistent RUSTFS_PYTHON"
+fi
+grep -q 'is not an executable command' "$TMP_ROOT/absent.err" \
+    || fail "nonexistent RUSTFS_PYTHON did not explain what was wrong"
+
+# With no usable interpreter and no uv on PATH, the failure must name the fix
+# rather than surfacing a bare ModuleNotFoundError from a 3.9 interpreter.
+cat > "$TMP_ROOT/bin/python3" <<'STUB'
+#!/bin/sh
+exit 1
+STUB
+chmod +x "$TMP_ROOT/bin/python3"
+
+SANDBOX_PATH="$TMP_ROOT/bin:/usr/bin:/bin"
+if PATH="$SANDBOX_PATH" command -v uv >/dev/null 2>&1; then
+    # uv is reachable even from the sandbox PATH, so the resolver would
+    # legitimately fall back to it instead of failing. Skip this case.
+    echo "ℹ️  uv is on the sandbox PATH; skipping the no-interpreter case"
+else
+    if PATH="$SANDBOX_PATH" "$RESOLVER" -c 'pass' \
+        >"$TMP_ROOT/none.out" 2>"$TMP_ROOT/none.err"; then
+        fail "resolver succeeded with no usable interpreter on PATH"
+    fi
+    grep -q 'No Python 3.11+ interpreter found' "$TMP_ROOT/none.err" \
+        || fail "missing-interpreter failure did not name the requirement"
+    grep -q 'RUSTFS_PYTHON=' "$TMP_ROOT/none.err" \
+        || fail "missing-interpreter failure did not point at the override"
+fi
+
+echo "✅ scripts/python_bin.sh resolver checks passed"


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

`make pre-commit` failed on a clean macOS machine: its `test-wiring-check` step ran `python3 ./scripts/check_test_wiring.py`, and `scripts/check_test_wiring.py` (like `scripts/check_security_coverage.py`) imports `tomllib`, which only landed in Python 3.11. macOS ships `/usr/bin/python3` at 3.9, so the gate died with `ModuleNotFoundError: No module named 'tomllib'` even though the checkers themselves are correct. The same trap applied to the Python self-tests in `make test` and to `make coverage`.

This adds `scripts/python_bin.sh`, a resolver that execs a Python >= 3.11 interpreter: an explicit `$RUSTFS_PYTHON` first (rejected with an explicit reason if it is missing or too old, rather than silently falling back), then `python3.14`/`python3.13`/`python3.12`/`python3.11`/`python3`/`python` on `PATH` with a real version probe per candidate, then `uv run --python 3.12 --no-project python`. When nothing usable exists it fails with the concrete remediation (`brew install python@3.12`, install `uv`, or `RUSTFS_PYTHON=...`) instead of a bare `ModuleNotFoundError`.

The Make call sites in `.config/make/lint-fmt.mak`, `.config/make/tests.mak`, and `.config/make/coverage.mak` now go through the `RUSTFS_PYTHON_BIN` variable defined in `Makefile`. The variable is deliberately not named `PYTHON`: the Makefile sets `.EXPORT_ALL_VARIABLES:`, so a `PYTHON` export would leak into the `cargo check` environment where some `-sys` build scripts honour it; it is also not named `RUSTFS_PYTHON`, which would make the resolver recurse into itself. `.github/workflows/` keeps calling `python3` directly because the runners already provide 3.11+, and `scripts/check_test_wiring.py` asserts on the literal `python3 scripts/check_scheduled_validation_freshness.py` invocation inside the workflow files.

`scripts/test_python_bin.sh` covers the resolver behaviour and is registered in the `script-tests` target. `CONTRIBUTING.md` records the Python 3.11+ prerequisite next to the existing cargo-nextest note.

## Verification

- `make pre-commit` — passed (exit 0, includes `test-wiring-check` and `quick-check`).
- `make test-wiring-check RUSTFS_PYTHON=/opt/homebrew/bin/python3.12` — passed, confirming the explicit override path.
- `env -i PATH="/usr/bin:/bin:<uv dir>" ./scripts/python_bin.sh ./scripts/check_test_wiring.py` — passed, confirming the uv fallback on a machine whose only `python3` is the macOS 3.9 build.
- `./scripts/test_python_bin.sh` — passed (resolver provides `tomllib`; too-old and nonexistent `RUSTFS_PYTHON` fail with an explanatory message; the no-interpreter case names the requirement and the override).
- `./scripts/python_bin.sh` runs of `check_test_wiring.py --self-test`, `check_security_coverage.py --self-test`, `check_scheduled_validation_freshness.py --self-test`, `s3-tests/test_report_compat.py`, and `check_object_data_cache_follower_samples.py --self-test` — all passed.
- `./scripts/check_doc_paths.sh` and `./scripts/check_embedded_secrets.sh` — passed.

## Impact

Local developer tooling only. No runtime, API, or on-disk behaviour changes. Contributors with Python 3.11+ or `uv` available see no difference; contributors on stock macOS Python now get a working gate instead of a `tomllib` import failure. CI workflow invocations are unchanged, so no CI behaviour changes.

## Additional Notes

`scripts/validate_object_data_cache_cold_stampede.sh` still calls `python3` directly for its inline snippets and for `scripts/check_object_data_cache_follower_samples.py`; those run fine on Python 3.9, so they were left alone. The no-usable-interpreter assertion in `scripts/test_python_bin.sh` is skipped when `uv` is reachable from the sandbox `PATH`, because the resolver would then legitimately take the uv fallback.
