### PR TITLE
fix(deps): update mysql_async to 0.37.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6650,10 +6650,11 @@ dependencies = [
 
 [[package]]
 name = "mysql_async"
-version = "0.37.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3519e91b0d254ac1ffa495bc42053286cb2172ad7241d5b3b1b9f8a891f21ee2"
+checksum = "40d11da0e2d9fad4640c9f9198ee431c6d68444568f83ef1f10f3367270071e4"
 dependencies = [
+ "arc-swap",
  "bytes",
  "crossbeam-queue",
  "crossbeam-utils",
@@ -7013,7 +7014,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.5.0",
@@ -8240,7 +8241,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -8260,7 +8261,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ rustfs-zip = { path = "./crates/zip", version = "1.0.0-rc.5" }
 # Async Runtime and Networking
 async-channel = "2.5.0"
 async_zip = { default-features = false, version = "0.0.19" }
-mysql_async = { default-features = false, version = "0.37" }
+mysql_async = { default-features = false, version = "0.37.1" }
 async-compression = { version = "0.4.43" }
 async-recursion = "1.1.1"
 async-trait = "0.1.92"


### PR DESCRIPTION
## Related Issues

N/A.

## Summary of Changes

- Raise the workspace `mysql_async` minimum from `0.37` to `0.37.1` and refresh `Cargo.lock`.
- Replace the yanked `0.37.0` release so the Security Audit `Cargo Deny` job passes again.
- Pick up the upstream statement-cache data-race fix included in `0.37.1`.

## Verification

- `cargo-deny 0.20.2 check --hide-inclusion-graph advisories sources bans licenses` — pass; advisories, sources, bans, and licenses are all OK.
- `cargo check --locked -p rustfs-targets` — pass.
- `git diff --check` — pass.
- `make pre-pr` — not run per maintainer direction for this urgent dependency-only fix.

## Impact

The MySQL notification target now uses the non-yanked patch release. This is a patch-level dependency update with no RustFS API, configuration, or persisted-format changes. Rollback should select another non-yanked compatible release rather than restore `0.37.0`.

## Additional Notes

Upstream release: https://github.com/blackbeam/mysql_async/releases/tag/v0.37.1. Cargo also normalized three existing lockfile dependency-edge references without changing those packages' resolved versions.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
