### PR TITLE
test(ecstore): remove host and load dependencies from flaky suites

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -89,6 +89,29 @@ test-group = 'ecstore-serial-flaky'
 filter = 'package(rustfs-ecstore) & test(/^set_disk::ops::multipart::tests::crash_consistency::/)'
 test-group = 'ecstore-serial-flaky'
 
+# Serialize the heal result-report tests. Every test in the module builds a
+# real-disk (TempDir-backed) hermetic erasure set and drives MiB-scale writes
+# plus deep-scan heal — the same load-sensitive cross-disk IO shape as the
+# crash_consistency scenarios above. Under a heavily parallel run a single
+# disk's IO can fail while write quorum still holds, which flips per-disk
+# readback and aggregate-outcome assertions nondeterministically (different
+# tests each round; all pass standalone). Preventive serialization only, no
+# retries. The matching ci-profile override is after [profile.ci].
+[[profile.default.overrides]]
+filter = 'package(rustfs-ecstore) & test(/^set_disk::ops::heal::heal_result_report_tests::/)'
+test-group = 'ecstore-serial-flaky'
+
+# Serialize the metadata-cache generation-retirement pair. Both carry
+# #[serial(metadata_cache_invalidation_probe)] — a no-op across nextest's
+# process boundary — and assert get_object_metadata_cache generation
+# semantics on a 4-disk hermetic set, the same load-sensitive shape that
+# forced the transition matrix tests into this group. Preventive
+# serialization only, no retries. The matching ci-profile override is after
+# [profile.ci].
+[[profile.default.overrides]]
+filter = 'package(rustfs-ecstore) & test(retires_cached_snapshot)'
+test-group = 'ecstore-serial-flaky'
+
 # The production-handler relocation regression builds an isolated 8-disk,
 # 2-pool store and commits a 72 MiB multipart object. Keep that cross-disk IO
 # from overlapping the ecstore commit fixtures above.
@@ -248,6 +271,20 @@ test-group = 'e2e-reliability'
 # no retries, just serialized 4-disk cross-disk-commit IO.
 [[profile.ci.overrides]]
 filter = 'package(rustfs-ecstore) & test(/^set_disk::ops::multipart::tests::crash_consistency::/)'
+test-group = 'ecstore-serial-flaky'
+
+# Serialize the heal result-report tests under the ci profile too (see the
+# matching default-profile override near the top). Not a quarantine: no
+# retries, just serialized real-disk heal IO.
+[[profile.ci.overrides]]
+filter = 'package(rustfs-ecstore) & test(/^set_disk::ops::heal::heal_result_report_tests::/)'
+test-group = 'ecstore-serial-flaky'
+
+# Serialize the metadata-cache generation-retirement pair under the ci
+# profile too (see the matching default-profile override near the top). Not a
+# quarantine: no retries.
+[[profile.ci.overrides]]
+filter = 'package(rustfs-ecstore) & test(retires_cached_snapshot)'
 test-group = 'ecstore-serial-flaky'
 
 # Match the default-profile embedded test isolation without quarantining or

--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -7378,6 +7378,9 @@ type DecommissionCapacityInfoOverrides =
 #[cfg(test)]
 static DECOMMISSION_CAPACITY_INFO_OVERRIDES: std::sync::OnceLock<DecommissionCapacityInfoOverrides> = std::sync::OnceLock::new();
 
+/// Queues capacity snapshots consumed in order by `get_decommission_all_pool_capacity_infos`;
+/// the final snapshot is retained and replayed for every subsequent sample, so tests never
+/// fall back to the host's real disk statistics once an override is installed.
 #[cfg(test)]
 pub(crate) fn set_decommission_capacity_info_overrides_for_test(
     store_id: uuid::Uuid,
@@ -7396,11 +7399,15 @@ fn take_decommission_capacity_info_override_for_test(store_id: uuid::Uuid) -> Op
         .get_or_init(|| std::sync::Mutex::new(HashMap::new()))
         .lock()
         .expect("decommission capacity info override should not be poisoned");
-    let snapshot = overrides.get_mut(&store_id)?.pop_front();
-    if overrides.get(&store_id).is_some_and(std::collections::VecDeque::is_empty) {
-        overrides.remove(&store_id);
+    let queue = overrides.get_mut(&store_id)?;
+    if queue.len() > 1 {
+        queue.pop_front()
+    } else {
+        // The final snapshot is replayed forever: extra sampling points added to
+        // the decommission paths must keep observing injected capacity instead of
+        // silently falling back to the host's real statfs numbers (see #6989).
+        queue.front().cloned()
     }
-    snapshot
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Related Issues

N/A (follow-up hardening after #6989)

## Summary of Changes

Two test-stability fixes that remove host and load dependencies from the ecstore suite:

1. **Decommission capacity override hook retains its final snapshot** (`crates/ecstore/src/core/pools.rs`, `#[cfg(test)]` only). `take_decommission_capacity_info_override_for_test` used to pop its per-store queue to exhaustion, after which `get_decommission_all_pool_capacity_infos` silently fell back to the host's real statfs numbers. Any new sampling point added to the decommission start paths re-introduced that host dependency and broke tests on some dev machines (#6989 patched one instance by topping up snapshot counts, but the coupling remained). The hook now keeps the final queued snapshot and replays it for every subsequent sample, so tests always observe injected capacity once an override is installed. All existing injection patterns across `pools_test.rs`, `rebalance/control.rs`, `store/init.rs`, and `store/heal.rs` were audited: single-snapshot, repeated-identical, and decreasing-sequence injections all keep their semantics (the final snapshot in every decreasing sequence is the post-operation capacity state, so replaying it is correct).

2. **Serialize load-sensitive heal and cache-generation tests** (`.config/nextest.toml`). Under a heavily parallel run (~792 ecstore tests), `set_disk::ops::heal::heal_result_report_tests` failed 2 tests nondeterministically per round (different members each round; all 29 pass standalone). Every test in the module builds a TempDir-backed 4-disk hermetic erasure set and drives MiB-scale writes plus deep-scan heal: under load a single disk's IO can fail while write quorum still holds, flipping per-disk readback and aggregate-outcome assertions. The module's `#[serial]` markers do not serialize across nextest's process-per-test boundary (see the file-header note in `.config/nextest.toml`). Verification also caught `complete_multipart_generation_retires_cached_snapshot` failing once under the same load; it and its `object.rs` sibling carry `#[serial(metadata_cache_invalidation_probe)]` and assert `get_object_metadata_cache` generation semantics — the same shape that forced the transition matrix tests into the serial group. Both families join the existing `ecstore-serial-flaky` test-group in the default and ci profiles. Preventive serialization only, no retries — consistent with the `crash_consistency::` and `transition_matrix_tests::` precedents.

## Verification

- `cargo nextest run -p rustfs-ecstore -E 'test(decommission)'` — 329 passed, 0 failed (includes `real_rebalance_and_decommission_starts_commit_at_most_one_side`).
- `cargo nextest list -p rustfs-ecstore -E 'test(/^set_disk::ops::heal::heal_result_report_tests::/)'` — filter matches exactly the 29 module tests; the `retires_cached_snapshot` filter matches exactly the 2 cache-generation tests.
- Baseline reproduction: the parallel filter `-E 'test(rebalance) | test(capacity) | test(heal) | test(quota) | test(activation) | test(multipart)'` (792 tests) failed 2 random `heal_result_report_tests` members per round before the serialization change (also on an unmodified tree, confirming the flake predates the hook change).
- After both changes: three consecutive full parallel rounds of the same filter — 792/792 passed each round.
- On the final rebased head: `cargo nextest run -p rustfs-ecstore --no-fail-fast -E 'test(decommission) | test(rebalance) | test(capacity) | test(heal) | test(quota) | test(activation) | test(multipart)'` — 1067 passed, 0 failed.
- `make pre-commit` — all checks passed (the `test-wiring-check` step was run via Python 3.12 because the host default `python3` lacks `tomllib`; the check itself passes: "OK: e2e modules, runner selection, fuzz matrices, profiles, and scheduled alerts are wired").

## Impact

No production code changes: the pools.rs change is inside `#[cfg(test)]`, and the nextest.toml change only moves two test families into the existing `ecstore-serial-flaky` single-threaded group (adds roughly 30-60s of serialized wall-clock to that lane, which runs concurrently with the rest of the suite). Behavior contract for test authors: once a capacity override is installed for a store id, the final snapshot is replayed indefinitely — tests can no longer rely on queue exhaustion falling back to real disk statistics (no existing test did).

## Additional Notes

Rollback is a straight revert of either commit independently; they are functionally separate (hook semantics vs. nextest grouping).
