### PR TITLE
docs(readme): refresh feature and status matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,33 @@ Unlike other storage systems, RustFS is released under the permissible Apache 2.
 - **Open Source**: Licensed under Apache 2.0, encouraging unrestricted community contributions and commercial usage.
 - **User-Friendly**: Designed with simplicity in mind for easy deployment and management.
 
-| Feature                 | Status       | Feature                  | Status           |
-| :---------------------- | :----------- | :----------------------- | :--------------- |
-| **S3 Core Features**    | ✅ Available | **Bitrot Protection**    | ✅ Available     |
-| **Upload / Download**   | ✅ Available | **Single Node Mode**     | ✅ Available     |
-| **Versioning**          | ✅ Available | **Bucket Replication**   | ✅ Available     |
-| **Logging**             | ✅ Available | **Lifecycle Management** | 🚧 Under Testing |
-| **Event Notifications** | ✅ Available | **Distributed Mode**     | 🚧 Under Testing |
-| **K8s Helm Charts**     | ✅ Available | **RustFS KMS**           | 🚧 Under Testing |
-| **Keystone Auth**       | ✅ Available | **Multi-Tenancy**        | ✅ Available     |
-| **Swift API**           | ✅ Available | **Swift Metadata Ops**   | 🚧 Partial       |
+Status legend: ✅ Available — shipped and covered by CI gates; 🧪 Preview — shipped behind an opt-in flag or with a bounded compatibility claim.
+
+| Feature                          | Status       | Feature                            | Status       |
+| :------------------------------- | :----------- | :--------------------------------- | :----------- |
+| **S3 Core Features**             | ✅ Available | **Distributed Mode**               | ✅ Available |
+| **Upload / Download**            | ✅ Available | **Single Node Mode**               | ✅ Available |
+| **Versioning**                   | ✅ Available | **Bitrot Protection**              | ✅ Available |
+| **Object Lock (WORM)**           | ✅ Available | **Healing & Scanner**              | ✅ Available |
+| **Server-Side Encryption**       | ✅ Available | **Pool Expansion / Decommission**  | ✅ Available |
+| **RustFS KMS**                   | ✅ Available | **Bucket Replication**             | ✅ Available |
+| **Lifecycle Management (ILM)**   | ✅ Available | **Site Replication**               | ✅ Available |
+| **ILM Tiering (Remote S3)**      | ✅ Available | **Bucket Quota**                   | ✅ Available |
+| **S3 Select**                    | ✅ Available | **Event Notifications**            | ✅ Available |
+| **S3 Tables (Iceberg REST)**     | 🧪 Preview   | **Audit Logging**                  | ✅ Available |
+| **IAM / Policies**               | ✅ Available | **Logging & Observability**        | ✅ Available |
+| **OIDC / SSO**                   | ✅ Available | **Web Console**                    | ✅ Available |
+| **Keystone Auth**                | ✅ Available | **K8s Helm Charts**                | ✅ Available |
+| **Swift API**                    | ✅ Available | **FTPS / WebDAV**                  | ✅ Available |
+| **Multi-Tenancy**                | ✅ Available | **SFTP**                           | ✅ Available |
+| **MinIO On-Disk Compatibility**  | 🧪 Preview   |                                    |              |
+
+Notes:
+
+- **RustFS KMS**: Vault (KV2 / Transit) and AWS KMS backends are supported for production. The `Local` and `Static` backends are for development and testing only. See [KMS backend security properties](docs/operations/kms-backend-security.md).
+- **Swift API / SFTP**: opt-in cargo features (`--features swift`, `--features sftp`, or `full`). FTPS and WebDAV are enabled in the default build.
+- **S3 Tables**: ships as an Iceberg REST Catalog with automated PyIceberg and DuckDB coverage; other engines and vendor profiles carry bounded claims listed in the [S3 Tables support matrix](docs/architecture/s3-tables-support-matrix.md).
+- **MinIO On-Disk Compatibility**: gated behind the `rio-v2` feature and not part of the default build. Objects MinIO encrypted are not readable by RustFS. See [MinIO file-format interoperability](docs/architecture/minio-file-format-compat.md).
 
 ## RustFS vs MinIO Performance
 


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

The "Feature & Status" table in `README.md` still marked Lifecycle Management, Distributed Mode, and RustFS KMS as "Under Testing" and Swift metadata operations as "Partial". Those labels predate the CI gates that now cover these areas, and the table omitted a number of features that have shipped since.

- Lifecycle Management moves to Available: the PR lane runs `ILM Integration (serial)` and `S3 Lifecycle Behavior Tests`, and `rustfs-tier-test.yml` exercises transitions against a remote tier.
- Distributed Mode moves to Available: the weekly Ceph s3-tests sweep runs against a real four-node erasure-coded cluster and the nightly e2e lane runs cluster-fault tests.
- RustFS KMS moves to Available, with a note that Vault (KV2 / Transit) and AWS KMS are the production backends and `Local` / `Static` are development-only, matching `docs/operations/kms-backend-security.md`.
- The "Swift Metadata Ops" row is removed; account, container, and object metadata updates are implemented in `crates/protocols/src/swift/`.
- New rows for shipped features that were not listed: Object Lock, Server-Side Encryption, ILM Tiering, S3 Select, S3 Tables (Iceberg REST), IAM / Policies, OIDC / SSO, Site Replication, Healing & Scanner, Pool Expansion / Decommission, Bucket Quota, Audit Logging, Logging & Observability, Web Console, FTPS / WebDAV, SFTP, MinIO On-Disk Compatibility.
- S3 Tables and MinIO On-Disk Compatibility are labeled Preview rather than Available. S3 Tables only automates PyIceberg and DuckDB claims per `docs/architecture/s3-tables-support-matrix.md`; MinIO on-disk compatibility is behind the `rio-v2` feature and cannot read MinIO-encrypted objects per `docs/architecture/minio-file-format-compat.md`.
- A status legend and a notes list explain the Preview label and the opt-in cargo features (`swift`, `sftp`) versus the default-build protocols (FTPS, WebDAV).

## Verification

- `bash scripts/check_doc_paths.sh` — passed
- `git diff --check` — clean
- Confirmed each linked document exists: `docs/operations/kms-backend-security.md`, `docs/architecture/s3-tables-support-matrix.md`, `docs/architecture/minio-file-format-compat.md`, `docs/architecture/s3-compatibility-matrix.md`
- Confirmed feature flags against `rustfs/Cargo.toml` (`default = ["ftps", "webdav"]`; `swift`, `sftp`, `rio-v2` opt-in) and CI gate definitions in `.github/workflows/ci.yml`, `e2e-s3tests.yml`, `e2e-replication-nightly.yml`, `nightly-gnu.yml`

## Impact

Documentation only. No code, configuration, or API changes. The README now makes bounded compatibility claims for S3 Tables and MinIO on-disk interop instead of leaving them unlisted.

## Additional Notes

`crates/protocols/src/swift/README.md` still describes Swift as "Phase 1 (~25%)" and lists modules that now exist as unimplemented. That is being handled in a separate change.
