### PR TITLE
ci: bump repo-visuals-action to v1.3.1

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: overtrue/repo-visuals-action@72f34d24769ff5d341956da2f23952594ef2f1e2 # v1.3.0
+      - uses: overtrue/repo-visuals-action@fd79cba437ecfac933d00a69add17eb95d3939c3 # v1.3.1
         with:
           github-token: ${{ github.token }}
           output-branch: star-history


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Bump `overtrue/repo-visuals-action` in `.github/workflows/star-history.yml` from v1.3.0 (`72f34d2`) to v1.3.1 (`fd79cba437ecfac933d00a69add17eb95d3939c3`), keeping the full-SHA pin with a version comment. v1.3.1 is a patch release that stops scheduled runs from failing after a repository rename (`history.json` ownership is now checked against the numeric repository id) and rebuilds `dist/index.cjs` so the bundle carries the undici 6.28.0 security bump. All inputs used by this workflow (`github-token`, `output-branch`, `output-path`, `chart-style`, `animate`, `contributors`) are unchanged in v1.3.1, so no parameter changes are needed.

## Verification
- `gh api repos/overtrue/repo-visuals-action/git/ref/tags/v1.3.1` resolves to commit `fd79cba437ecfac933d00a69add17eb95d3939c3`, matching the new pin.
- `gh api repos/overtrue/repo-visuals-action/contents/action.yml` at v1.3.1 lists every input this workflow passes.
- `git diff --check` clean; workflow-only change, no Rust code touched.

## Impact
CI-only. Affects the daily `star-history` scheduled workflow that publishes chart assets to the `star-history` branch. No user-facing, API, or deployment impact.

## Additional Notes
Release notes: https://github.com/overtrue/repo-visuals-action/releases/tag/v1.3.1
