### PR TITLE
fix(ci): repair chain handoff scripts broken by ${{VAR}} expressions

### DIFF
--- a/.github/workflows/rustfs-heal-test.yml
+++ b/.github/workflows/rustfs-heal-test.yml
@@ -293,7 +293,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PF_TESTING_GH_TOKEN }}
         run: |
           set -uo pipefail
-          if [ -z "${{GH_TOKEN:-}}" ]; then
+          if [ -z "${GH_TOKEN:-}" ]; then
             echo "PF_TESTING_GH_TOKEN is not configured; cannot dispatch the next suite" >&2
             exit 1
           fi
@@ -302,31 +302,31 @@ jobs:
             if gh api --method POST repos/rustfs/rustfs/dispatches \
               -f event_type='rustfs-chain-pool' \
               -F 'client_payload[from_suite]=heal'; then
-              echo "dispatched next suite Pool expansion (attempt ${{attempt}})"
+              echo "dispatched next suite Pool expansion (attempt ${attempt})"
               DISPATCHED=1
               break
             fi
-            echo "dispatch attempt ${{attempt}} failed; retrying in ${{attempt}}0s" >&2
-            sleep "${{attempt}}0"
+            echo "dispatch attempt ${attempt} failed; retrying in ${attempt}0s" >&2
+            sleep "${attempt}0"
           done
-          if [ "${{DISPATCHED:-0}}" -ne 1 ]; then
+          if [ "${DISPATCHED:-0}" -ne 1 ]; then
             echo "ERROR: functional chain stalled: could not dispatch Pool expansion after 3 attempts" >&2
-            TITLE="[functional][chain] stalled after heal (run ${{GITHUB_RUN_ID}})"
+            TITLE="[functional][chain] stalled after heal (run ${GITHUB_RUN_ID})"
             BODY_FILE="$(mktemp)"
             {
               echo "The functional chain could not hand off from **heal** to **Pool expansion** after 3 attempts."
               echo ""
-              echo "- Failed suite job: ${{GITHUB_SERVER_URL}}/${{GITHUB_REPOSITORY}}/actions/runs/${{GITHUB_RUN_ID}}"
-              echo "- Expected next event: `rustfs-chain-pool`"
+              echo "- Failed suite job: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+              echo "- Expected next event: 'rustfs-chain-pool'"
               echo "- Likely cause: PF_TESTING_GH_TOKEN lacks contents:write on rustfs/rustfs, or the GitHub API was unavailable."
               echo "- Recovery: re-dispatch manually with"
-              echo "  ```"
+              FENCE="$(printf "\x60\x60\x60")"; echo "  ${FENCE}"
               echo "  gh api --method POST repos/rustfs/rustfs/dispatches -f event_type='rustfs-chain-pool'"
-              echo "  ```"
-            } > "${{BODY_FILE}}"
-            gh issue create -R rustfs/backlog --title "${{TITLE}}" \
-              --body-file "${{BODY_FILE}}" --label functional-test \
-              || gh issue create -R rustfs/backlog --title "${{TITLE}}" --body-file "${{BODY_FILE}}" \
+              FENCE="$(printf "\x60\x60\x60")"; echo "  ${FENCE}"
+            } > "${BODY_FILE}"
+            gh issue create -R rustfs/backlog --title "${TITLE}" \
+              --body-file "${BODY_FILE}" --label functional-test \
+              || gh issue create -R rustfs/backlog --title "${TITLE}" --body-file "${BODY_FILE}" \
               || echo "could not file the stall alert issue either; check the token" >&2
             exit 1
           fi

--- a/.github/workflows/rustfs-kms-test.yml
+++ b/.github/workflows/rustfs-kms-test.yml
@@ -349,7 +349,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PF_TESTING_GH_TOKEN }}
         run: |
           set -uo pipefail
-          if [ -z "${{GH_TOKEN:-}}" ]; then
+          if [ -z "${GH_TOKEN:-}" ]; then
             echo "PF_TESTING_GH_TOKEN is not configured; cannot dispatch the next suite" >&2
             exit 1
           fi
@@ -358,31 +358,31 @@ jobs:
             if gh api --method POST repos/rustfs/rustfs/dispatches \
               -f event_type='rustfs-chain-tier' \
               -F 'client_payload[from_suite]=kms'; then
-              echo "dispatched next suite Tier (attempt ${{attempt}})"
+              echo "dispatched next suite Tier (attempt ${attempt})"
               DISPATCHED=1
               break
             fi
-            echo "dispatch attempt ${{attempt}} failed; retrying in ${{attempt}}0s" >&2
-            sleep "${{attempt}}0"
+            echo "dispatch attempt ${attempt} failed; retrying in ${attempt}0s" >&2
+            sleep "${attempt}0"
           done
-          if [ "${{DISPATCHED:-0}}" -ne 1 ]; then
+          if [ "${DISPATCHED:-0}" -ne 1 ]; then
             echo "ERROR: functional chain stalled: could not dispatch Tier after 3 attempts" >&2
-            TITLE="[functional][chain] stalled after kms (run ${{GITHUB_RUN_ID}})"
+            TITLE="[functional][chain] stalled after kms (run ${GITHUB_RUN_ID})"
             BODY_FILE="$(mktemp)"
             {
               echo "The functional chain could not hand off from **kms** to **Tier** after 3 attempts."
               echo ""
-              echo "- Failed suite job: ${{GITHUB_SERVER_URL}}/${{GITHUB_REPOSITORY}}/actions/runs/${{GITHUB_RUN_ID}}"
-              echo "- Expected next event: `rustfs-chain-tier`"
+              echo "- Failed suite job: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+              echo "- Expected next event: 'rustfs-chain-tier'"
               echo "- Likely cause: PF_TESTING_GH_TOKEN lacks contents:write on rustfs/rustfs, or the GitHub API was unavailable."
               echo "- Recovery: re-dispatch manually with"
-              echo "  ```"
+              FENCE="$(printf "\x60\x60\x60")"; echo "  ${FENCE}"
               echo "  gh api --method POST repos/rustfs/rustfs/dispatches -f event_type='rustfs-chain-tier'"
-              echo "  ```"
-            } > "${{BODY_FILE}}"
-            gh issue create -R rustfs/backlog --title "${{TITLE}}" \
-              --body-file "${{BODY_FILE}}" --label functional-test \
-              || gh issue create -R rustfs/backlog --title "${{TITLE}}" --body-file "${{BODY_FILE}}" \
+              FENCE="$(printf "\x60\x60\x60")"; echo "  ${FENCE}"
+            } > "${BODY_FILE}"
+            gh issue create -R rustfs/backlog --title "${TITLE}" \
+              --body-file "${BODY_FILE}" --label functional-test \
+              || gh issue create -R rustfs/backlog --title "${TITLE}" --body-file "${BODY_FILE}" \
               || echo "could not file the stall alert issue either; check the token" >&2
             exit 1
           fi

--- a/.github/workflows/rustfs-pool-expand-test.yml
+++ b/.github/workflows/rustfs-pool-expand-test.yml
@@ -605,7 +605,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PF_TESTING_GH_TOKEN }}
         run: |
           set -uo pipefail
-          if [ -z "${{GH_TOKEN:-}}" ]; then
+          if [ -z "${GH_TOKEN:-}" ]; then
             echo "PF_TESTING_GH_TOKEN is not configured; cannot dispatch the next suite" >&2
             exit 1
           fi
@@ -614,31 +614,31 @@ jobs:
             if gh api --method POST repos/rustfs/rustfs/dispatches \
               -f event_type='rustfs-chain-security' \
               -F 'client_payload[from_suite]=pool'; then
-              echo "dispatched next suite Security (attempt ${{attempt}})"
+              echo "dispatched next suite Security (attempt ${attempt})"
               DISPATCHED=1
               break
             fi
-            echo "dispatch attempt ${{attempt}} failed; retrying in ${{attempt}}0s" >&2
-            sleep "${{attempt}}0"
+            echo "dispatch attempt ${attempt} failed; retrying in ${attempt}0s" >&2
+            sleep "${attempt}0"
           done
-          if [ "${{DISPATCHED:-0}}" -ne 1 ]; then
+          if [ "${DISPATCHED:-0}" -ne 1 ]; then
             echo "ERROR: functional chain stalled: could not dispatch Security after 3 attempts" >&2
-            TITLE="[functional][chain] stalled after pool (run ${{GITHUB_RUN_ID}})"
+            TITLE="[functional][chain] stalled after pool (run ${GITHUB_RUN_ID})"
             BODY_FILE="$(mktemp)"
             {
               echo "The functional chain could not hand off from **pool** to **Security** after 3 attempts."
               echo ""
-              echo "- Failed suite job: ${{GITHUB_SERVER_URL}}/${{GITHUB_REPOSITORY}}/actions/runs/${{GITHUB_RUN_ID}}"
-              echo "- Expected next event: `rustfs-chain-security`"
+              echo "- Failed suite job: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+              echo "- Expected next event: 'rustfs-chain-security'"
               echo "- Likely cause: PF_TESTING_GH_TOKEN lacks contents:write on rustfs/rustfs, or the GitHub API was unavailable."
               echo "- Recovery: re-dispatch manually with"
-              echo "  ```"
+              FENCE="$(printf "\x60\x60\x60")"; echo "  ${FENCE}"
               echo "  gh api --method POST repos/rustfs/rustfs/dispatches -f event_type='rustfs-chain-security'"
-              echo "  ```"
-            } > "${{BODY_FILE}}"
-            gh issue create -R rustfs/backlog --title "${{TITLE}}" \
-              --body-file "${{BODY_FILE}}" --label functional-test \
-              || gh issue create -R rustfs/backlog --title "${{TITLE}}" --body-file "${{BODY_FILE}}" \
+              FENCE="$(printf "\x60\x60\x60")"; echo "  ${FENCE}"
+            } > "${BODY_FILE}"
+            gh issue create -R rustfs/backlog --title "${TITLE}" \
+              --body-file "${BODY_FILE}" --label functional-test \
+              || gh issue create -R rustfs/backlog --title "${TITLE}" --body-file "${BODY_FILE}" \
               || echo "could not file the stall alert issue either; check the token" >&2
             exit 1
           fi

--- a/.github/workflows/rustfs-s3-compat-test.yml
+++ b/.github/workflows/rustfs-s3-compat-test.yml
@@ -329,7 +329,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PF_TESTING_GH_TOKEN }}
         run: |
           set -uo pipefail
-          if [ -z "${{GH_TOKEN:-}}" ]; then
+          if [ -z "${GH_TOKEN:-}" ]; then
             echo "PF_TESTING_GH_TOKEN is not configured; cannot dispatch the next suite" >&2
             exit 1
           fi
@@ -338,31 +338,31 @@ jobs:
             if gh api --method POST repos/rustfs/rustfs/dispatches \
               -f event_type='rustfs-chain-kms' \
               -F 'client_payload[from_suite]=s3'; then
-              echo "dispatched next suite KMS (attempt ${{attempt}})"
+              echo "dispatched next suite KMS (attempt ${attempt})"
               DISPATCHED=1
               break
             fi
-            echo "dispatch attempt ${{attempt}} failed; retrying in ${{attempt}}0s" >&2
-            sleep "${{attempt}}0"
+            echo "dispatch attempt ${attempt} failed; retrying in ${attempt}0s" >&2
+            sleep "${attempt}0"
           done
-          if [ "${{DISPATCHED:-0}}" -ne 1 ]; then
+          if [ "${DISPATCHED:-0}" -ne 1 ]; then
             echo "ERROR: functional chain stalled: could not dispatch KMS after 3 attempts" >&2
-            TITLE="[functional][chain] stalled after s3 (run ${{GITHUB_RUN_ID}})"
+            TITLE="[functional][chain] stalled after s3 (run ${GITHUB_RUN_ID})"
             BODY_FILE="$(mktemp)"
             {
               echo "The functional chain could not hand off from **s3** to **KMS** after 3 attempts."
               echo ""
-              echo "- Failed suite job: ${{GITHUB_SERVER_URL}}/${{GITHUB_REPOSITORY}}/actions/runs/${{GITHUB_RUN_ID}}"
-              echo "- Expected next event: `rustfs-chain-kms`"
+              echo "- Failed suite job: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+              echo "- Expected next event: 'rustfs-chain-kms'"
               echo "- Likely cause: PF_TESTING_GH_TOKEN lacks contents:write on rustfs/rustfs, or the GitHub API was unavailable."
               echo "- Recovery: re-dispatch manually with"
-              echo "  ```"
+              FENCE="$(printf "\x60\x60\x60")"; echo "  ${FENCE}"
               echo "  gh api --method POST repos/rustfs/rustfs/dispatches -f event_type='rustfs-chain-kms'"
-              echo "  ```"
-            } > "${{BODY_FILE}}"
-            gh issue create -R rustfs/backlog --title "${{TITLE}}" \
-              --body-file "${{BODY_FILE}}" --label functional-test \
-              || gh issue create -R rustfs/backlog --title "${{TITLE}}" --body-file "${{BODY_FILE}}" \
+              FENCE="$(printf "\x60\x60\x60")"; echo "  ${FENCE}"
+            } > "${BODY_FILE}"
+            gh issue create -R rustfs/backlog --title "${TITLE}" \
+              --body-file "${BODY_FILE}" --label functional-test \
+              || gh issue create -R rustfs/backlog --title "${TITLE}" --body-file "${BODY_FILE}" \
               || echo "could not file the stall alert issue either; check the token" >&2
             exit 1
           fi

--- a/.github/workflows/rustfs-storage-test.yml
+++ b/.github/workflows/rustfs-storage-test.yml
@@ -344,7 +344,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PF_TESTING_GH_TOKEN }}
         run: |
           set -uo pipefail
-          if [ -z "${{GH_TOKEN:-}}" ]; then
+          if [ -z "${GH_TOKEN:-}" ]; then
             echo "PF_TESTING_GH_TOKEN is not configured; cannot dispatch the next suite" >&2
             exit 1
           fi
@@ -353,31 +353,31 @@ jobs:
             if gh api --method POST repos/rustfs/rustfs/dispatches \
               -f event_type='rustfs-chain-heal' \
               -F 'client_payload[from_suite]=storage'; then
-              echo "dispatched next suite Heal (attempt ${{attempt}})"
+              echo "dispatched next suite Heal (attempt ${attempt})"
               DISPATCHED=1
               break
             fi
-            echo "dispatch attempt ${{attempt}} failed; retrying in ${{attempt}}0s" >&2
-            sleep "${{attempt}}0"
+            echo "dispatch attempt ${attempt} failed; retrying in ${attempt}0s" >&2
+            sleep "${attempt}0"
           done
-          if [ "${{DISPATCHED:-0}}" -ne 1 ]; then
+          if [ "${DISPATCHED:-0}" -ne 1 ]; then
             echo "ERROR: functional chain stalled: could not dispatch Heal after 3 attempts" >&2
-            TITLE="[functional][chain] stalled after storage (run ${{GITHUB_RUN_ID}})"
+            TITLE="[functional][chain] stalled after storage (run ${GITHUB_RUN_ID})"
             BODY_FILE="$(mktemp)"
             {
               echo "The functional chain could not hand off from **storage** to **Heal** after 3 attempts."
               echo ""
-              echo "- Failed suite job: ${{GITHUB_SERVER_URL}}/${{GITHUB_REPOSITORY}}/actions/runs/${{GITHUB_RUN_ID}}"
-              echo "- Expected next event: `rustfs-chain-heal`"
+              echo "- Failed suite job: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+              echo "- Expected next event: 'rustfs-chain-heal'"
               echo "- Likely cause: PF_TESTING_GH_TOKEN lacks contents:write on rustfs/rustfs, or the GitHub API was unavailable."
               echo "- Recovery: re-dispatch manually with"
-              echo "  ```"
+              FENCE="$(printf "\x60\x60\x60")"; echo "  ${FENCE}"
               echo "  gh api --method POST repos/rustfs/rustfs/dispatches -f event_type='rustfs-chain-heal'"
-              echo "  ```"
-            } > "${{BODY_FILE}}"
-            gh issue create -R rustfs/backlog --title "${{TITLE}}" \
-              --body-file "${{BODY_FILE}}" --label functional-test \
-              || gh issue create -R rustfs/backlog --title "${{TITLE}}" --body-file "${{BODY_FILE}}" \
+              FENCE="$(printf "\x60\x60\x60")"; echo "  ${FENCE}"
+            } > "${BODY_FILE}"
+            gh issue create -R rustfs/backlog --title "${TITLE}" \
+              --body-file "${BODY_FILE}" --label functional-test \
+              || gh issue create -R rustfs/backlog --title "${TITLE}" --body-file "${BODY_FILE}" \
               || echo "could not file the stall alert issue either; check the token" >&2
             exit 1
           fi

--- a/.github/workflows/rustfs-tier-test.yml
+++ b/.github/workflows/rustfs-tier-test.yml
@@ -439,7 +439,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PF_TESTING_GH_TOKEN }}
         run: |
           set -uo pipefail
-          if [ -z "${{GH_TOKEN:-}}" ]; then
+          if [ -z "${GH_TOKEN:-}" ]; then
             echo "PF_TESTING_GH_TOKEN is not configured; cannot dispatch the next suite" >&2
             exit 1
           fi
@@ -448,31 +448,31 @@ jobs:
             if gh api --method POST repos/rustfs/rustfs/dispatches \
               -f event_type='rustfs-chain-storage' \
               -F 'client_payload[from_suite]=tier'; then
-              echo "dispatched next suite Storage engine (attempt ${{attempt}})"
+              echo "dispatched next suite Storage engine (attempt ${attempt})"
               DISPATCHED=1
               break
             fi
-            echo "dispatch attempt ${{attempt}} failed; retrying in ${{attempt}}0s" >&2
-            sleep "${{attempt}}0"
+            echo "dispatch attempt ${attempt} failed; retrying in ${attempt}0s" >&2
+            sleep "${attempt}0"
           done
-          if [ "${{DISPATCHED:-0}}" -ne 1 ]; then
+          if [ "${DISPATCHED:-0}" -ne 1 ]; then
             echo "ERROR: functional chain stalled: could not dispatch Storage engine after 3 attempts" >&2
-            TITLE="[functional][chain] stalled after tier (run ${{GITHUB_RUN_ID}})"
+            TITLE="[functional][chain] stalled after tier (run ${GITHUB_RUN_ID})"
             BODY_FILE="$(mktemp)"
             {
               echo "The functional chain could not hand off from **tier** to **Storage engine** after 3 attempts."
               echo ""
-              echo "- Failed suite job: ${{GITHUB_SERVER_URL}}/${{GITHUB_REPOSITORY}}/actions/runs/${{GITHUB_RUN_ID}}"
-              echo "- Expected next event: `rustfs-chain-storage`"
+              echo "- Failed suite job: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+              echo "- Expected next event: 'rustfs-chain-storage'"
               echo "- Likely cause: PF_TESTING_GH_TOKEN lacks contents:write on rustfs/rustfs, or the GitHub API was unavailable."
               echo "- Recovery: re-dispatch manually with"
-              echo "  ```"
+              FENCE="$(printf "\x60\x60\x60")"; echo "  ${FENCE}"
               echo "  gh api --method POST repos/rustfs/rustfs/dispatches -f event_type='rustfs-chain-storage'"
-              echo "  ```"
-            } > "${{BODY_FILE}}"
-            gh issue create -R rustfs/backlog --title "${{TITLE}}" \
-              --body-file "${{BODY_FILE}}" --label functional-test \
-              || gh issue create -R rustfs/backlog --title "${{TITLE}}" --body-file "${{BODY_FILE}}" \
+              FENCE="$(printf "\x60\x60\x60")"; echo "  ${FENCE}"
+            } > "${BODY_FILE}"
+            gh issue create -R rustfs/backlog --title "${TITLE}" \
+              --body-file "${BODY_FILE}" --label functional-test \
+              || gh issue create -R rustfs/backlog --title "${TITLE}" --body-file "${BODY_FILE}" \
               || echo "could not file the stall alert issue either; check the token" >&2
             exit 1
           fi

--- a/.github/workflows/rustfs-upgrade-test.yml
+++ b/.github/workflows/rustfs-upgrade-test.yml
@@ -397,7 +397,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PF_TESTING_GH_TOKEN }}
         run: |
           set -uo pipefail
-          if [ -z "${{GH_TOKEN:-}}" ]; then
+          if [ -z "${GH_TOKEN:-}" ]; then
             echo "PF_TESTING_GH_TOKEN is not configured; cannot dispatch the next suite" >&2
             exit 1
           fi
@@ -406,31 +406,31 @@ jobs:
             if gh api --method POST repos/rustfs/rustfs/dispatches \
               -f event_type='rustfs-chain-s3' \
               -F 'client_payload[from_suite]=upgrade'; then
-              echo "dispatched next suite S3 compatibility (attempt ${{attempt}})"
+              echo "dispatched next suite S3 compatibility (attempt ${attempt})"
               DISPATCHED=1
               break
             fi
-            echo "dispatch attempt ${{attempt}} failed; retrying in ${{attempt}}0s" >&2
-            sleep "${{attempt}}0"
+            echo "dispatch attempt ${attempt} failed; retrying in ${attempt}0s" >&2
+            sleep "${attempt}0"
           done
-          if [ "${{DISPATCHED:-0}}" -ne 1 ]; then
+          if [ "${DISPATCHED:-0}" -ne 1 ]; then
             echo "ERROR: functional chain stalled: could not dispatch S3 compatibility after 3 attempts" >&2
-            TITLE="[functional][chain] stalled after upgrade (run ${{GITHUB_RUN_ID}})"
+            TITLE="[functional][chain] stalled after upgrade (run ${GITHUB_RUN_ID})"
             BODY_FILE="$(mktemp)"
             {
               echo "The functional chain could not hand off from **upgrade** to **S3 compatibility** after 3 attempts."
               echo ""
-              echo "- Failed suite job: ${{GITHUB_SERVER_URL}}/${{GITHUB_REPOSITORY}}/actions/runs/${{GITHUB_RUN_ID}}"
-              echo "- Expected next event: `rustfs-chain-s3`"
+              echo "- Failed suite job: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+              echo "- Expected next event: 'rustfs-chain-s3'"
               echo "- Likely cause: PF_TESTING_GH_TOKEN lacks contents:write on rustfs/rustfs, or the GitHub API was unavailable."
               echo "- Recovery: re-dispatch manually with"
-              echo "  ```"
+              FENCE="$(printf "\x60\x60\x60")"; echo "  ${FENCE}"
               echo "  gh api --method POST repos/rustfs/rustfs/dispatches -f event_type='rustfs-chain-s3'"
-              echo "  ```"
-            } > "${{BODY_FILE}}"
-            gh issue create -R rustfs/backlog --title "${{TITLE}}" \
-              --body-file "${{BODY_FILE}}" --label functional-test \
-              || gh issue create -R rustfs/backlog --title "${{TITLE}}" --body-file "${{BODY_FILE}}" \
+              FENCE="$(printf "\x60\x60\x60")"; echo "  ${FENCE}"
+            } > "${BODY_FILE}"
+            gh issue create -R rustfs/backlog --title "${TITLE}" \
+              --body-file "${BODY_FILE}" --label functional-test \
+              || gh issue create -R rustfs/backlog --title "${TITLE}" --body-file "${BODY_FILE}" \
               || echo "could not file the stall alert issue either; check the token" >&2
             exit 1
           fi


### PR DESCRIPTION
## Incident

Last night's (9/1 → 9/2) nightly functional chain **did not run**: the Nightly GNU Build completed successfully at 16:41Z and the Functional Chain driver dispatched `rustfs-chain-upgrade` at 17:08Z, but **no shared-VM suite received the event**. Only performance ran (17:09Z, success — its workflow file was untouched).

## Root cause

PR #7023's handoff-retry patch wrote shell parameter expansions in Actions expression syntax: `${{GH_TOKEN:-}}`, `${{attempt}}`, `${{DISPATCHED:-0}}`, `${{TITLE}}`, `${{BODY_FILE}}` … GitHub parses `${{...}}` as workflow expressions; a bare identifier is invalid there, so GitHub **rejected the entire workflow file** for all seven suites touched by #7023 (upgrade, s3-compat, kms, tier, storage, heal, pool-expand).

Evidence:
- Every push to any branch since bba9347 (2026-09-01 23:11 +0800) produced `failure` runs with zero jobs — "This run likely failed because of a workflow file issue".
- The workflows API lists those seven by file path instead of `name:` — the signature of an unparseable workflow.
- `repository_dispatch` events are silently dropped for invalid workflows → the chain died at the first link.

## Fix (7 files, 98 lines)

- Restore the shell expansions: `${VAR}` / `${VAR:-default}` — exactly what #7023 intended.
- Quote the "Expected next event" name with single quotes instead of legacy backticks (shellcheck SC2288/SC1073).
- Render the markdown fence in the stall-alert issue body via `printf` so shellcheck can parse the block.
- Semantics of #7023 preserved: 3-attempt dispatch retry + backlog stall-alert issue.

## Validation

- `actionlint .github/workflows/rustfs-*.yml` → **0 findings** (was: parse errors + shellcheck errors)
- YAML validation passes on all 11 workflows
- `bash -n` + shellcheck clean on the embedded scripts

## After merge

The chain will self-heal tonight. To verify immediately after merging, dispatch once manually:
```
gh api --method POST repos/rustfs/rustfs/dispatches -f event_type='rustfs-chain-upgrade' -F 'client_payload[from_suite]=manual-recovery]'
```
and confirm a `repository_dispatch` run of RustFS Upgrade Test appears.