### PR TITLE
fix(ci): pass repository to preview release cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1065,7 +1065,7 @@ jobs:
           while IFS= read -r preview_tag; do
             [[ -n "$preview_tag" ]] || continue
             echo "🧹 Deleting preview release $preview_tag (tag kept)"
-            gh release delete "$preview_tag" --yes
+            gh release delete "$preview_tag" --repo "${GITHUB_REPOSITORY}" --yes
             DELETED=$((DELETED + 1))
           done < <(
             jq -r --arg tag "$TAG" '

--- a/scripts/security/check_preview_release_workflow.sh
+++ b/scripts/security/check_preview_release_workflow.sh
@@ -144,7 +144,7 @@ require_line "$build_workflow" "    needs: [ build-check, publish-release ]" "la
 # Preview releases are internal validation artifacts: once the deliverable
 # release is published they are deleted, while their tags stay behind.
 require_job_if "$build_workflow" "cleanup-preview-releases" "    if: $latest_guard"
-require_line "$build_workflow" "            gh release delete \"\$preview_tag\" --yes" "preview release cleanup after publication"
+require_line "$build_workflow" "            gh release delete \"\$preview_tag\" --repo \"\${GITHUB_REPOSITORY}\" --yes" "preview release cleanup after publication"
 require_line "$build_workflow" "              | select(.tag_name | startswith(\$tag + \"-preview.\"))" "cleanup must match the target's own preview tags"
 require_line "$build_workflow" "              | select(.tag_name | ltrimstr(\$tag + \"-preview.\") | test(\"^[0-9]+\$\"))" "cleanup must match a numeric preview iteration"
 require_absent "$build_workflow" "--cleanup-tag" "preview tags must survive their release cleanup"


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Pass the explicit repository to `gh release delete` because the cleanup job does not check out the repository. Update the workflow contract check to keep this required argument from being removed again.

## Verification
- `./scripts/security/check_preview_release_workflow.sh`
- `actionlint`
- `git diff --check`

## Impact
Final releases can clean up their preview Releases while preserving the preview tags.

## Additional Notes
The `1.0.0-rc.5` cleanup failure was recovered by deleting the preview Releases manually and rerunning the failed job.
