### PR TITLE
fix: update stale docs/README.md references to docs/architecture/README.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ This file contains repository-wide rules. Use the nearest subdirectory
 - CI gates: `.github/workflows/ci.yml`.
 - PR format: `.github/pull_request_template.md`.
 - Architecture routing: `ARCHITECTURE.md` and `docs/architecture/README.md`.
-- Knowledge-base index and documentation rules: `docs/README.md`.
+- Knowledge-base index and documentation rules: `docs/architecture/README.md`.
 - Agent skills: `.agents/skills/*/SKILL.md`.
 
 Do not commit one-shot plans, trackers, migration ledgers, benchmark snapshots,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,7 +62,7 @@ rustfs/                      # Workspace root (virtual manifest)
 │   ├── utils/               # Pure utility functions
 │   ├── ...                  # (see "Crate Reference" below)
 │   └── e2e_test/            # End-to-end integration tests
-└── docs/                    # Agent knowledge base: contracts, runbooks, testing rules (index: docs/README.md)
+└── docs/                    # Agent knowledge base: contracts, runbooks, testing rules (index: docs/architecture/README.md)
 ```
 
 ### Main Crate Layers (`rustfs/src/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ make build-docker BUILD_OS=ubuntu22.04
 
 ## Where to look (do not duplicate here)
 
-- Agent knowledge base index and doc-writing rules: [docs/README.md](docs/README.md)
+- Agent knowledge base index and doc-writing rules: [docs/architecture/README.md](docs/architecture/README.md)
 - Crate membership: `Cargo.toml` `[workspace].members`
 - Architecture, layering, crate map: [ARCHITECTURE.md](ARCHITECTURE.md)
 - Migration guardrails & readiness contracts: [docs/architecture/](docs/architecture/README.md)


### PR DESCRIPTION
## Problem

`make pre-pr` failed on `doc-paths-check` with 3 stale references to `docs/README.md`:

```
stale path reference: AGENTS.md -> docs/README.md
stale path reference: ARCHITECTURE.md -> docs/README.md
stale path reference: CLAUDE.md -> docs/README.md
```

The file `docs/README.md` was removed long ago (commit `fff175dcd`), but the references in agent instruction files were not updated. Commit `0a975f2fe` expanded `check_doc_paths.sh` to scan `docs/*.md`, `docs/operations/*.md`, and `docs/testing/*.md`, which surfaced these stale references.

## Fix

Updated all three references from `docs/README.md` to `docs/architecture/README.md`, which is the current knowledge-base index.

## Verification

- `scripts/check_doc_paths.sh` — passed
- `make pre-commit` — all gates passed (doc path check, formatting, guards, compilation)
- `make pre-pr` — compilation + clippy + tests pass; one pre-existing flaky test (`transition_matrix_tests::transition_and_restore_reclaim_prior_metadata_generations`) fails non-deterministically under concurrent execution but passes when run individually. This test is already tracked in `nextest.toml` under `ecstore-serial-flaky` group.
