### PR TITLE
test(e2e): rename stall timing variable flagged by typos

### DIFF
--- a/crates/e2e_test/src/on_demand_migration/harness_self_test.rs
+++ b/crates/e2e_test/src/on_demand_migration/harness_self_test.rs
@@ -452,9 +452,9 @@ async fn fake_source_fault_actions_truncate_stall_and_status() -> TestResult {
     let stalled = client.head_object().bucket(SOURCE_BUCKET).key("faulty").send().await?;
     assert!(started.elapsed() >= Duration::from_millis(350), "stall must delay the first byte");
     assert_eq!(stalled.content_length(), Some(4096));
-    let unstalled_started = Instant::now();
+    let post_stall_started = Instant::now();
     client.head_object().bucket(SOURCE_BUCKET).key("faulty").send().await?;
-    assert!(unstalled_started.elapsed() < Duration::from_millis(350), "stall is consumed once");
+    assert!(post_stall_started.elapsed() < Duration::from_millis(350), "stall is consumed once");
 
     // The object is intact once the script is drained.
     let intact = client.get_object().bucket(SOURCE_BUCKET).key("faulty").send().await?;


### PR DESCRIPTION
## Related Issues

Follow-up to rustfs/rustfs#7068 (rustfs/backlog#2151).

## Summary of Changes

Renames a test-local variable (`unstalled_started` → `post_stall_started`) in `crates/e2e_test/src/on_demand_migration/harness_self_test.rs`. The `typos` CI gate flags `unstalled` as a misspelling, and #7068 merged before that check reported, so `main` currently fails the Typos job.

## Verification

- `typos` finding reproduced from the CI log of run 33638627053; the rename removes the only two occurrences.
- Test-only rename, no behavior change.

## Impact

N/A

## Additional Notes

N/A
