### PR TITLE
fix(admin): gate the s3 facade auth re-export to tests

### DIFF
--- a/rustfs/src/admin/storage_api.rs
+++ b/rustfs/src/admin/storage_api.rs
@@ -1001,7 +1001,9 @@ pub(crate) mod runtime {
 }
 
 pub(crate) mod s3 {
-    pub(crate) use s3s::{Body, S3Error, S3ErrorCode, S3Request, S3Response, S3Result, auth, header};
+    #[cfg(test)]
+    pub(crate) use s3s::auth;
+    pub(crate) use s3s::{Body, S3Error, S3ErrorCode, S3Request, S3Response, S3Result, header};
 
     /// Build an `S3Error` without reaching for the `s3s` error macro.
     ///


### PR DESCRIPTION
## Related Issues

Follow-up to rustfs/rustfs#7076 (rustfs/backlog#2154).

## Summary of Changes

The `auth` re-export added to the admin `s3` facade in #7076 is only consumed by the on-demand migration handler tests, so the non-test library build reports it as an unused import under `-D warnings`. Gate the re-export with `#[cfg(test)]`.

## Verification

- `cargo clippy -p rustfs --all-targets -- -D warnings`
- `cargo nextest run -p rustfs --lib -E 'test(on_demand_migration)'`

## Impact

N/A

## Additional Notes

N/A
