### PR TITLE
fix(object): route write-back test wire types through the s3 facade

### DIFF
--- a/rustfs/src/app/object/on_demand_migration_put.rs
+++ b/rustfs/src/app/object/on_demand_migration_put.rs
@@ -278,16 +278,16 @@ mod tests {
     use super::*;
     use crate::app::storage_api::multipart_usecase::contract::multipart::MultipartOperations as _;
     use crate::app::storage_api::object_usecase::on_demand_migration::{PullFailureReason, SourceSse};
+    use crate::app::storage_api::s3::{
+        BucketVersioningStatus, DeleteMarkerReplication, DeleteMarkerReplicationStatus, Destination, ReplicationConfiguration,
+        ReplicationRule, ReplicationRuleStatus, ServerSideEncryptionByDefault, ServerSideEncryptionConfiguration,
+        ServerSideEncryptionRule, VersioningConfiguration,
+    };
     use crate::app::storage_api::test::bucket::utils::serialize;
     use crate::app::storage_api::test::contract::bucket::{BucketOperations as _, MakeBucketOptions};
     use crate::app::storage_api::test::{get_global_bucket_metadata_sys, set_bucket_metadata};
     use http::Method;
     use rustfs_utils::http::{MINIO_INTERNAL_PREFIX, RUSTFS_INTERNAL_PREFIX, get_str};
-    use s3s::dto::{
-        BucketVersioningStatus, DeleteMarkerReplication, DeleteMarkerReplicationStatus, Destination, ReplicationConfiguration,
-        ReplicationRule, ReplicationRuleStatus, ServerSideEncryptionByDefault, ServerSideEncryptionConfiguration,
-        ServerSideEncryptionRule, VersioningConfiguration,
-    };
     use sha2::{Digest as Sha256Digest, Sha256};
     use std::time::SystemTime;
     use tokio::io::AsyncReadExt;

--- a/rustfs/src/app/storage_api.rs
+++ b/rustfs/src/app/storage_api.rs
@@ -24,6 +24,17 @@ pub(crate) fn EndpointServerPools(
     crate::storage::storage_api::EndpointServerPools::from(pools)
 }
 
+/// S3 wire types for app-layer modules, funneled here so new files stay off
+/// the direct s3s surface (s3s footprint ratchet, `scripts/check_s3s_footprint.sh`).
+pub(crate) mod s3 {
+    #[cfg(test)]
+    pub(crate) use s3s::dto::{
+        BucketVersioningStatus, DeleteMarkerReplication, DeleteMarkerReplicationStatus, Destination, ReplicationConfiguration,
+        ReplicationRule, ReplicationRuleStatus, ServerSideEncryptionByDefault, ServerSideEncryptionConfiguration,
+        ServerSideEncryptionRule, VersioningConfiguration,
+    };
+}
+
 pub(crate) mod admin {
     pub(crate) async fn get_server_info(get_pools: bool) -> rustfs_madmin::InfoMessage {
         crate::storage::storage_api::ecstore_admin::get_server_info(get_pools).await


### PR DESCRIPTION
## Related Issues

Follow-up to rustfs/rustfs#7079 (rustfs/backlog#2153).

## Summary of Changes

The write-back tests in `rustfs/src/app/object/on_demand_migration_put.rs` imported S3 wire types from `s3s::dto` directly, which grows the file counter of the s3s-footprint ratchet (`scripts/check_s3s_footprint.sh`) past its baseline and currently fails `make pre-commit` on `main`. Import them through a new test-only `app::storage_api::s3` facade module instead (the facade file is already inside the ratchet baseline).

## Verification

- `scripts/check_s3s_footprint.sh` — back at baseline (213 files)
- `cargo clippy -p rustfs --all-targets -- -D warnings`
- `cargo nextest run -p rustfs -E 'test(on_demand_migration_put)'` — 12 passed

## Impact

N/A

## Additional Notes

N/A
