### PR TITLE
test(rustfs): run RestoreObject generation-guard test on a large stack

### DIFF
--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -4277,9 +4277,16 @@ mod tests {
             .expect_err("the new-generation source object must not be copied");
     }
 
-    #[tokio::test]
+    #[test]
     #[serial]
-    async fn restore_object_access_keeps_authorized_bucket_incarnation_across_recreation() {
+    fn restore_object_access_keeps_authorized_bucket_incarnation_across_recreation() {
+        crate::app::gating_test_env::run_large_stack_test(
+            "restore-object-generation-guard",
+            restore_object_access_keeps_authorized_bucket_incarnation_across_recreation_inner,
+        );
+    }
+
+    async fn restore_object_access_keeps_authorized_bucket_incarnation_across_recreation_inner() {
         let store = crate::app::gating_test_env::shared_gating_ecstore().await;
         let server_ctx = ServerContextSlot::new();
         let app_context = Arc::new(AppContext::new(Arc::clone(&store), Arc::new(UnreadyIam), Arc::new(TestKms)));
@@ -4361,10 +4368,10 @@ mod tests {
         apply_bucket_generation_guard(&req, &bucket, &mut opts).expect("apply the RestoreObject authorization guard");
         assert_eq!(opts.expected_bucket_incarnation_id, Some(authorized_incarnation_id));
 
-        // The RestoreObject usecase future is large enough that, inlined into
-        // this test body, the test thread's 2 MiB stack sits within a few KiB
-        // of overflowing on Linux; heap-pin it so unrelated growth in bucket
-        // metadata futures cannot tip the test over.
+        // The RestoreObject usecase future is large enough that heap-pinning a
+        // single future was not enough on Linux: the whole scenario runs on a
+        // dedicated large stack (see the `#[test]` wrapper above) so unrelated
+        // growth in bucket metadata futures cannot tip the test over.
         let err = Box::pin(
             crate::app::object_usecase::DefaultObjectUsecase::with_context(Some(app_context)).execute_restore_object(req),
         )


### PR DESCRIPTION
## Related Issues

Follow-up of the CI debt batch tracked in rustfs/backlog#2147 (the three Linux lanes that fail on rustfs/rustfs#7061).

## Summary of Changes

`storage::access::tests::restore_object_access_keeps_authorized_bucket_incarnation_across_recreation` overflows the 2 MiB test-thread stack on Linux. The scenario keeps the shared gating `ECStore`, a live RestoreObject authorization hook and the RestoreObject usecase future alive at once, and heap-pinning the single usecase future (the previous mitigation) left only a few KiB of headroom, so unrelated growth in bucket-metadata futures tips it over again.

The test body now runs through the existing `gating_test_env::run_large_stack_test` helper, the same idiom already used by `internal_put.rs` and `head.rs`: a dedicated 32 MiB thread with its own current-thread runtime. No production code changes.

## Verification

- `cargo +1.98.0 test -p rustfs --lib storage::access::tests::restore_object_access_keeps_authorized_bucket_incarnation_across_recreation`
- `cargo fmt --all`

## Impact

Test-only. No behavior, API, configuration or documentation change.

## Additional Notes

The local default toolchain resolves to 1.97.1 while the workspace requires 1.98.0, hence the explicit `+1.98.0` in the commands above.
