### PR TITLE
fix(list): satisfy clippy in the source listing merge

### DIFF
--- a/rustfs/src/app/bucket_list_through.rs
+++ b/rustfs/src/app/bucket_list_through.rs
@@ -336,7 +336,7 @@ async fn fetch_source_page(
             delimiter: params.delimiter.as_deref(),
             // S3 ignores start-after once a continuation token is present, so
             // the client's own start-after only applies to the first page.
-            start_after: token.is_none().then(|| params.start_after_for_query.as_deref()).flatten(),
+            start_after: token.is_none().then_some(params.start_after_for_query.as_deref()).flatten(),
             continuation_token: token,
             max_keys: params.max_keys,
         },
@@ -363,9 +363,11 @@ async fn fetch_source_page(
         SourceListPlan::Folded { common_prefix, .. } => {
             let exists = !page.objects.is_empty() || !page.common_prefixes.is_empty();
             Ok((
-                exists
-                    .then(|| vec![SideEntry::Prefix(common_prefix.clone())])
-                    .unwrap_or_default(),
+                if exists {
+                    vec![SideEntry::Prefix(common_prefix.clone())]
+                } else {
+                    Vec::new()
+                },
                 false,
                 None,
             ))


### PR DESCRIPTION
## Related Issues

N/A — unbreaks `main`.

## Summary of Changes

`cargo clippy --all-targets -- -D warnings` fails on `main` since #7112, so every open PR shows a red "Test and Lint". Two mechanical rewrites in `rustfs/src/app/bucket_list_through.rs`:

- `unnecessary_lazy_evaluations`: `token.is_none().then(|| params.start_after_for_query.as_deref())` becomes `then_some(...)`. The argument is a borrow with no side effects, so eager evaluation is equivalent.
- `obfuscated_if_else`: `exists.then(|| vec![...]).unwrap_or_default()` becomes a plain `if`/`else`.

No behaviour change.

## Verification

- `cargo +1.98.0 clippy -p rustfs --lib --all-targets` — clean
- `cargo +1.98.0 fmt --all --check`

## Impact

None at runtime; this only restores the lint gate.

## Additional Notes

N/A
