### PR TITLE
fix: resolve clippy warnings in bucket_list_through.rs

### DIFF
--- a/rustfs/src/app/bucket_list_through.rs
+++ b/rustfs/src/app/bucket_list_through.rs
@@ -336,7 +336,7 @@ async fn fetch_source_page(
             delimiter: params.delimiter.as_deref(),
             // S3 ignores start-after once a continuation token is present, so
             // the client's own start-after only applies to the first page.
-            start_after: token.is_none().then(|| params.start_after_for_query.as_deref()).flatten(),
+            start_after: token.is_none().then_some(params.start_after_for_query.as_deref()).flatten(),
             continuation_token: token,
             max_keys: params.max_keys,
         },
@@ -363,9 +363,11 @@ async fn fetch_source_page(
         SourceListPlan::Folded { common_prefix, .. } => {
             let exists = !page.objects.is_empty() || !page.common_prefixes.is_empty();
             Ok((
-                exists
-                    .then(|| vec![SideEntry::Prefix(common_prefix.clone())])
-                    .unwrap_or_default(),
+                if exists {
+                    vec![SideEntry::Prefix(common_prefix.clone())]
+                } else {
+                    Vec::new()
+                },
                 false,
                 None,
             ))


### PR DESCRIPTION
## Summary

Auto-detected and fixed 2 clippy errors introduced in the latest batch of commits on `main` (`9d10d69a6`).

## Problem

`make pre-pr` failed at the clippy stage with 2 errors in `rustfs/src/app/bucket_list_through.rs`:

1. **`unnecessary_lazy_evaluations`** (line 339): `then(|| ...)` should be `then_some(...)` when the closure just wraps an already-computed value
2. **`obfuscated_if_else`** (line 366): `bool.then(|| expr).unwrap_or_default()` is clearer as `if bool { expr } else { Default::default() }`

These were introduced in commit `9d10d69a6` (test(odm): add the scheduled provider interop lane #7114) which added `bucket_list_through.rs`.

## Fix

Minimal 2-line fix:
- `then(|| params.start_after_for_query.as_deref())` → `then_some(params.start_after_for_query.as_deref())`
- `.then(|| vec![...]).unwrap_or_default()` → `if exists { vec![...] } else { Vec::new() }`

## Verification

- `cargo fmt --all --check` — passed
- `cargo clippy -p rustfs --lib -- -D warnings` — passed

## Note

One unrelated test (`prepared_snapshot_transition_duplicate_and_late_get_use_committed_remote_generation`) fails in the full `make pre-pr` suite but passes when run in isolation. This is a pre-existing flaky test caused by shared state between serial tests, not related to these changes.
