### PR TITLE
test(ecstore): stabilize sealed context encoding

### DIFF
--- a/crates/ecstore/src/bucket/sealed_credentials.rs
+++ b/crates/ecstore/src/bucket/sealed_credentials.rs
@@ -201,6 +201,12 @@ pub async fn unseal_secret(sealed: &SealedCredential, scope: &SealScope) -> Resu
 mod tests {
     use super::*;
     use parking_lot::Mutex;
+    use std::collections::BTreeMap;
+
+    fn encode_context(context: &HashMap<String, String>) -> String {
+        let ordered = context.iter().collect::<BTreeMap<_, _>>();
+        serde_json::to_string(&ordered).expect("context serializes")
+    }
 
     /// Stands in for the KMS-backed sealer: records the context it was called
     /// with, and refuses a ciphertext presented under a different one.
@@ -214,7 +220,7 @@ mod tests {
         async fn seal(&self, plaintext: &str, scope: &SealScope) -> Result<SealedCredential, SealedCredentialError> {
             let context = scope.encryption_context();
             self.sealed_contexts.lock().push(context.clone());
-            let mut bound = serde_json::to_string(&context).expect("context serializes");
+            let mut bound = encode_context(&context);
             bound.push('|');
             bound.push_str(plaintext);
             Ok(SealedCredential {
@@ -231,7 +237,7 @@ mod tests {
                 .decode_to_vec(sealed.ct.as_bytes())
                 .map_err(|err| SealedCredentialError::Malformed(err.to_string()))?;
             let bound = String::from_utf8(raw).map_err(|err| SealedCredentialError::Malformed(err.to_string()))?;
-            let expected = serde_json::to_string(&scope.encryption_context()).expect("context serializes");
+            let expected = encode_context(&scope.encryption_context());
             bound
                 .strip_prefix(&expected)
                 .and_then(|rest| rest.strip_prefix('|'))


### PR DESCRIPTION
## Related Issues

- rustfs/backlog#2241

## Summary of Changes

- Canonicalize the test KMS encryption context through an ordered map before JSON encoding.
- Preserve the existing negative checks that reject ciphertext replay across owners and fields.
- Keep the production sealing API and persisted credential format unchanged.

## Verification

- `cargo fmt --all -- --check`
- `for iteration in {1..20}; do cargo test -p rustfs-ecstore --lib bucket::sealed_credentials::tests::seal_round_trips_and_binds_the_scope || exit $?; done` (20/20 passed)
- `cargo test -p rustfs-ecstore --lib --features rio-v2 bucket::sealed_credentials::tests::seal_round_trips_and_binds_the_scope` (1/1 passed)
- `git diff --check origin/main...HEAD`

## Impact

Test-only change. It removes a nondeterministic `HashMap` iteration-order dependency from the fake sealer without changing runtime behavior, public APIs, or on-disk formats.

## Additional Notes

This addresses the baseline failure also observed in rustfs/rustfs#7144. `make pre-pr` was intentionally not run per the batch verification policy.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
