### PR TITLE
fix: use BTreeMap for deterministic encryption context serialization

### DIFF
--- a/crates/ecstore/src/bucket/sealed_credentials.rs
+++ b/crates/ecstore/src/bucket/sealed_credentials.rs
@@ -28,7 +28,7 @@
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::{Arc, OnceLock};
 
@@ -81,8 +81,8 @@ impl SealScope {
     /// The encryption context handed to the sealer. Keys are stable: they are
     /// part of the on-disk contract, because a ciphertext only decrypts under
     /// the same context.
-    pub fn encryption_context(&self) -> HashMap<String, String> {
-        HashMap::from([
+    pub fn encryption_context(&self) -> BTreeMap<String, String> {
+        BTreeMap::from([
             ("rustfs:store".to_string(), self.store.as_str().to_string()),
             ("rustfs:owner".to_string(), self.owner.clone()),
             ("rustfs:field".to_string(), self.field.to_string()),
@@ -206,7 +206,7 @@ mod tests {
     /// with, and refuses a ciphertext presented under a different one.
     #[derive(Default)]
     struct FakeSealer {
-        sealed_contexts: Mutex<Vec<HashMap<String, String>>>,
+        sealed_contexts: Mutex<Vec<BTreeMap<String, String>>>,
     }
 
     #[async_trait]


### PR DESCRIPTION
## Problem

`seal_round_trips_and_binds_the_scope` test in `sealed_credentials.rs` intermittently fails with:

```
unseal: Kms("encryption context mismatch")
```

## Root Cause

`SealScope::encryption_context()` returned `HashMap<String, String>`. The `FakeSealer` test round-trips the encryption context through JSON serialization during both `seal()` and `unseal()`. `HashMap` has non-deterministic iteration order, so the JSON key ordering can differ between the seal and unseal calls, causing the prefix comparison to fail.

## Fix

Changed `encryption_context()` return type from `HashMap<String, String>` to `BTreeMap<String, String>`, which guarantees stable key ordering across all calls.

## Changes

- `crates/ecstore/src/bucket/sealed_credentials.rs`: `HashMap` -> `BTreeMap` in `encryption_context()` return type and `FakeSealer` test struct.

## Verification

- Targeted test `seal_round_trips_and_binds_the_scope`: PASS
- `cargo check -p rustfs-ecstore`: PASS
- `cargo fmt --all --check`: PASS

## Detected by

Hourly automated verification (`make pre-pr`) on commit `146003a42`.

Note: This failure was flaky (non-deterministic HashMap ordering) — the test may pass most runs but fail intermittently.
