### PR TITLE
fix(ecstore): missing HashMap import in sealed_credentials test

### DIFF
--- a/crates/ecstore/src/bucket/sealed_credentials.rs
+++ b/crates/ecstore/src/bucket/sealed_credentials.rs
@@ -203,9 +203,8 @@ mod tests {
     use parking_lot::Mutex;
     use std::collections::BTreeMap;
 
-    fn encode_context(context: &HashMap<String, String>) -> String {
-        let ordered = context.iter().collect::<BTreeMap<_, _>>();
-        serde_json::to_string(&ordered).expect("context serializes")
+    fn encode_context(context: &BTreeMap<String, String>) -> String {
+        serde_json::to_string(context).expect("context serializes")
     }
 
     /// Stands in for the KMS-backed sealer: records the context it was called


### PR DESCRIPTION
## Problem

`make clippy-check` fails on main (e648f683b) because `sealed_credentials.rs` test module references `HashMap` without importing it, and calls `encode_context(&HashMap)` where the caller passes a `BTreeMap`.

## Error

```
error[E0425]: cannot find type `HashMap` in this scope
   --> crates/ecstore/src/bucket/sealed_credentials.rs:206:33
```

## Fix

Changed `encode_context()` to accept `&BTreeMap<String, String>` (matching the return type of `SealScope::encryption_context()`) and removed the redundant inner `BTreeMap` conversion. This also eliminates the unused `HashMap` import.

**File changed:** `crates/ecstore/src/bucket/sealed_credentials.rs` (test module only, no production code affected)

## Verification

- `cargo fmt --all --check` — passed
- All guard checks (unsafe-code, architecture-migration, logging-guardrails, etc.) — passed
- `cargo clippy -D warnings` (full workspace) — passed
- `cargo check -p rustfs-ecstore --tests` — passed
- Flaky test `complete_multipart_waits_for_tail_before_releasing_guards_and_marking_capacity` — pre-existing timing issue, passes when run in isolation, unrelated to this change
