### PR TITLE
test(ecstore): fix sealed context fixture map type

### DIFF
--- a/crates/ecstore/src/bucket/sealed_credentials.rs
+++ b/crates/ecstore/src/bucket/sealed_credentials.rs
@@ -203,7 +203,7 @@ mod tests {
     use parking_lot::Mutex;
     use std::collections::BTreeMap;
 
-    fn encode_context(context: &HashMap<String, String>) -> String {
+    fn encode_context(context: &BTreeMap<String, String>) -> String {
         let ordered = context.iter().collect::<BTreeMap<_, _>>();
         serde_json::to_string(&ordered).expect("context serializes")
     }


### PR DESCRIPTION
## Related Issues

Follow-up to #7154. Found while validating rustfs/backlog#2248.

## Summary of Changes

The sealed-credential test helper still accepted `HashMap` after its callers switched to `BTreeMap`, preventing ECStore unit tests from compiling. Match the helper argument to the actual encryption-context type. Serialization and assertions are unchanged.

## Verification

- ECStore lib-test target compiled in the integrated validation build.
- Ran `bucket::sealed_credentials::tests::seal_round_trips_and_binds_the_scope` directly in that binary: 1 passed, 0 failed.
- `cargo fmt --all --check` and `git diff --check` passed.
- Independent review confirmed both callers pass `BTreeMap`.

## Impact

Test-only signature correction. No production behavior or format change.

## Additional Notes

The separate storage fixes remain under validation.
