### PR TITLE
test(ecstore): count injected faults across retry restarts

### DIFF
--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -2979,6 +2979,33 @@ mod tests {
     #[cfg(feature = "test-util")]
     const DECOMMISSION_TEST_FAULT_STAGE_TIERED: &str = "decommission_tiered_object";
 
+    fn decommission_retry_fault_hook(
+        bucket: &str,
+        object: &str,
+        faults: Arc<AtomicUsize>,
+    ) -> crate::core::pools::DecommissionTestFaultDecision {
+        let target_bucket = bucket.to_string();
+        let target_object = object.to_string();
+        Arc::new(move |stage, bucket, object, _attempt, succeeded| {
+            if !succeeded
+                || stage != DECOMMISSION_TEST_FAULT_STAGE_MIGRATE_OBJECT
+                || bucket != target_bucket
+                || object != target_object
+            {
+                return false;
+            }
+
+            // Entry retries reset the local attempt; real copy errors can skip
+            // successful attempts. Only injected faults spend this global budget.
+            faults
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |faults| {
+                    (faults < crate::core::pools::DECOMMISSION_VERSION_COPY_ATTEMPTS.saturating_sub(1))
+                        .then_some(faults.saturating_add(1))
+                })
+                .is_ok()
+        })
+    }
+
     async fn seed_decommission_source(
         store: &Arc<crate::store::ECStore>,
         bucket: &str,
@@ -5121,6 +5148,33 @@ mod tests {
     }
 
     #[test]
+    fn decommission_retry_fault_budget_counts_successes_across_attempt_changes() {
+        for attempts in [[1, 2, 3], [1, 1, 2], [1, 3, 3]] {
+            let faults = Arc::new(AtomicUsize::new(0));
+            let hook = decommission_retry_fault_hook("bucket", "object", Arc::clone(&faults));
+
+            for (stage, bucket, object, succeeded) in [
+                ("other-stage", "bucket", "object", true),
+                (DECOMMISSION_TEST_FAULT_STAGE_MIGRATE_OBJECT, "other-bucket", "object", true),
+                (DECOMMISSION_TEST_FAULT_STAGE_MIGRATE_OBJECT, "bucket", "other-object", true),
+                (DECOMMISSION_TEST_FAULT_STAGE_MIGRATE_OBJECT, "bucket", "object", false),
+            ] {
+                assert!(!hook(stage, bucket, object, 1, succeeded));
+            }
+            assert_eq!(faults.load(Ordering::SeqCst), 0, "unrelated or failed copies must not consume faults");
+
+            for (index, attempt) in attempts.into_iter().enumerate() {
+                assert_eq!(
+                    hook(DECOMMISSION_TEST_FAULT_STAGE_MIGRATE_OBJECT, "bucket", "object", attempt, true),
+                    index < 2,
+                    "attempts={attempts:?}, index={index}"
+                );
+            }
+            assert_eq!(faults.load(Ordering::SeqCst), 2, "attempts={attempts:?}");
+        }
+    }
+
+    #[test]
     #[serial_test::serial(storage_class_env)]
     fn decommission_entry_retries_source_changed_without_canceling_other_bucket() {
         let handle = std::thread::Builder::new()
@@ -5214,31 +5268,8 @@ mod tests {
                     ));
 
                     let ordinary_faults = Arc::new(AtomicUsize::new(0));
-                    let ordinary_faults_for_hook = Arc::clone(&ordinary_faults);
-                    let fault_bucket = other_bucket.clone();
-                    let _fault_guard = crate::core::pools::DecommissionTestFaultGuard::install(Arc::new(
-                        move |stage, bucket, object, attempt, succeeded| {
-                            let candidate = succeeded
-                                && stage == DECOMMISSION_TEST_FAULT_STAGE_MIGRATE_OBJECT
-                                && bucket == fault_bucket.as_str()
-                                && object == other_object;
-                            if !candidate {
-                                return false;
-                            }
-
-                            // Keep the fault budget global across any
-                            // entry-level re-list; its inner attempt counter
-                            // restarts after SourceChanged.
-                            ordinary_faults_for_hook
-                                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |faults| {
-                                    let next_fault = faults.saturating_add(1);
-                                    (faults < crate::core::pools::DECOMMISSION_VERSION_COPY_ATTEMPTS.saturating_sub(1)
-                                        && attempt == next_fault)
-                                        .then_some(next_fault)
-                                })
-                                .is_ok()
-                        },
-                    ));
+                    let fault_hook = decommission_retry_fault_hook(&other_bucket, other_object, Arc::clone(&ordinary_faults));
+                    let _fault_guard = crate::core::pools::DecommissionTestFaultGuard::install(fault_hook);
 
                     let rx = CancellationToken::new();
                     let source_changed_exhaustions = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
## Related Issues

Refs #7165. Diagnosed from its [rio-v2 test failure](https://github.com/rustfs/rustfs/actions/runs/33938393212/job/101230943581).

## Summary of Changes

The decommission retry fixture expects two injected copy failures, but tied its global injection count to a local attempt number. Entry retries can restart that number, while real copy errors can advance it without spending the injection budget. A later successful copy could therefore bypass the remaining injected fault. CI observed one injection instead of two even though both entries returned successfully; that run did not capture the inner attempt sequence.

The fixture now spends its bounded global budget on matching successful copies, independently of the local attempt number. Its existing hook is shared with a deterministic regression covering normal, restarted, and skipped attempt sequences: `[1,2,3]`, `[1,1,2]`, and `[1,3,3]`. Unrelated stages, buckets, objects, and failed copies leave the budget untouched.

The original two-bucket test still requires exactly two injected faults, the source-change retry, an uncancelled shared token, source cleanup, and complete target bodies for both generations and the other bucket.

## Verification

- Default native selection on macOS: **23 passed**, including the new budget regression and the original two-bucket integration test. Both native runs used integrated head `0b8ccae25`, whose two tested functions and shared hook are byte-identical to this branch. The PR still requires its own CI.
- `CARGO_BUILD_JOBS=2 cargo nextest run -p rustfs-ecstore --lib --features test-util,rio-v2 -j 2 --profile ci --no-tests=fail --no-fail-fast -E 'test(decommission_retry_fault_budget) | test(decommission_entry_retries_source_changed_without_canceling_other_bucket)'`: **2 passed**, no retries.
- The helper and regression extracted directly from the source passed a standalone Rust test. Restoring the old attempt-equality condition made it fail at `[1,1,2]`, index 1.
- `cargo fmt --all --check` and `git diff --check` passed.
- Final-diff correctness and simplicity review passed: only test code changed; the original integration assertions and production retry logic are unchanged.

## Impact

No production behavior, retry limits, locking, storage formats, or timeout changes. The new regression calls the same private hook directly and does not install process-global fault state or require sleeps.

Validation is on macOS. A `rio-v2` feature build there does not establish Linux io_uring behavior; the original Linux CI lane still needs to pass.

## Additional Notes

Real copy errors can still exhaust the production retry budget. This change does not hide those errors, increase retries, lower the expected injection count, or quarantine the integration test.
