### PR TITLE
fix(scanner): make reset cleanup safely reentrant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ dependencies = [
  "arrow-select",
  "chrono",
  "half",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "itoa",
  "lexical-core",
  "memchr",
@@ -809,7 +809,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -891,9 +891,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a767267da9e2c2e189b2f9df8b5657e850ecf5352644734ba130d4a57095cf1b"
+checksum = "b8d7b388a9fc3a6db15a5ec778c38b354eff1364882c94d08e0252f7a47dcaa4"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -958,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
+checksum = "ef47857a1d4488b528f4a5d5715fa7c3300820897824152234d3fa22b1426657"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.117.0"
+version = "1.118.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b602641be84ebe5f96606cfefe4b96efaae1fd947c1b34ea8513b8ac0d2d8d"
+checksum = "c243864bc3754be9f0001414e0162fdf1370fa62c70b0cfbe1da6a6221d553c7"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1012,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.144.0"
+version = "1.145.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30dc8bf6baaf7d46336a0ca2c69f223d9b90d7a801fb3e28f7ea17b00dc6b1de"
+checksum = "f0e6320417a37c8a62f78b443d0b4cf628b57cd340a09b0eb56173d47cc94e93"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1049,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.108.0"
+version = "1.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15301b04372832947916607983b114b3374b9db0be058a00fb7513800de1f05"
+checksum = "c3cfe74df5d9ad2fedd691973ad3521ebf4f27a3c68c792556686aedb5519bab"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1075,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.110.0"
+version = "1.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cc2c205cb27108183cf1856333f7d584c2ba0f505421b4209ca5828f9ea899"
+checksum = "81b0ec31ed6191bd11350aae4b2004198f2db21350cb0a20c57e0a92e55dd161"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.113.0"
+version = "1.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68182ecb449f7537db0f4d5d25917789cf41e32074a9fe47b6a0b847fe1d2032"
+checksum = "ef45745026107ec30c4ef86bd8ae4b002e7e5f6a86e4225240bdf6b06a0b944a"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1235,7 +1235,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "pin-project-lite",
  "rustls",
  "rustls-native-certs",
@@ -1406,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
+checksum = "209f3a6d82a6e9e5f94abbed94c7a26e1c052341002bf57a5fb5481f625896fc"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -1660,7 +1660,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1679,7 +1679,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1734,7 +1734,7 @@ dependencies = [
  "prettyplease 0.3.0",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1951,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2061,7 +2061,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "inout 0.1.4",
 ]
 
@@ -2108,7 +2108,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2531,7 +2531,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -2556,11 +2556,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
  "typenum",
 ]
 
@@ -2759,7 +2759,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2803,7 +2803,7 @@ checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core 0.24.1",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2868,7 +2868,7 @@ dependencies = [
  "datafusion-session",
  "datafusion-sql",
  "futures",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "itertools 0.15.0",
  "log",
  "object_store",
@@ -2943,7 +2943,7 @@ dependencies = [
  "foldhash 0.2.0",
  "half",
  "hashbrown 0.17.1",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "itertools 0.15.0",
  "libc",
  "log",
@@ -3148,7 +3148,7 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "itertools 0.15.0",
  "recursive",
  "serde_json",
@@ -3163,7 +3163,7 @@ checksum = "2604994999d5aeca1d1df645ffc98bc787447aaff05dde27aad0342b48fc1fe0"
 dependencies = [
  "arrow",
  "datafusion-common",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "itertools 0.15.0",
 ]
 
@@ -3304,7 +3304,7 @@ checksum = "15192effab05d38cce10e92a6fb48c967b5f166b27b7195a165a72b232569c58"
 dependencies = [
  "datafusion-doc",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3319,7 +3319,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-physical-expr",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "itertools 0.15.0",
  "log",
  "recursive",
@@ -3341,7 +3341,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "half",
  "hashbrown 0.17.1",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "itertools 0.15.0",
  "parking_lot",
  "petgraph 0.8.3",
@@ -3375,7 +3375,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr-common",
  "hashbrown 0.17.1",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "itertools 0.15.0",
  "parking_lot",
  "pin-project",
@@ -3426,7 +3426,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.17.1",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "itertools 0.15.0",
  "log",
  "num-traits",
@@ -3479,7 +3479,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-functions-nested",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "log",
  "recursive",
  "regex",
@@ -3852,7 +3852,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -3929,7 +3929,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4117,7 +4117,7 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff 0.13.1",
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
  "group 0.13.0",
  "hkdf 0.12.4",
  "pem-rfc7468 0.7.0",
@@ -4341,9 +4341,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "findshlibs"
@@ -4517,7 +4517,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4562,9 +4562,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -4577,7 +4577,7 @@ version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "337d46834ee672ab3e48caca2cb0c78cc174fb12b3a68d0d88f99a0519a5e36e"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
  "rustversion",
  "typenum",
 ]
@@ -4656,7 +4656,7 @@ checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "stable_deref_trait",
 ]
 
@@ -4934,7 +4934,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.5.0",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -5583,9 +5583,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.1"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -5600,7 +5600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding 0.3.3",
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -5847,9 +5847,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5885,7 +5885,7 @@ dependencies = [
  "crc",
  "crc32c",
  "flate2",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "lz4",
  "snap",
  "uuid",
@@ -5918,7 +5918,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee7893dab2e44ae5f9d0173f26ff4aa327c10b01b06a72b52dd9405b628640d"
 dependencies = [
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
 ]
 
 [[package]]
@@ -6398,7 +6398,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "metrics",
  "ordered-float 5.5.0",
  "quanta",
@@ -7027,7 +7027,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.5.0",
@@ -7703,7 +7703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
 ]
 
 [[package]]
@@ -7714,7 +7714,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "serde",
 ]
 
@@ -7989,9 +7989,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
 dependencies = [
  "portable-atomic",
 ]
@@ -8095,7 +8095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
 dependencies = [
  "proc-macro2",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -8943,7 +8943,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -9662,6 +9662,7 @@ dependencies = [
  "async-trait",
  "aws-credential-types",
  "aws-sdk-s3",
+ "aws-smithy-async",
  "aws-smithy-http-client",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -9956,7 +9957,7 @@ dependencies = [
  "bytes",
  "fnv",
  "hmac 0.13.0",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "kafka-protocol",
  "metrics",
  "pbkdf2 0.13.0",
@@ -11293,7 +11294,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct 0.2.0",
  "der 0.7.10",
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
  "pkcs8 0.10.2",
  "subtle",
  "zeroize",
@@ -11405,7 +11406,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -11424,7 +11425,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "itoa",
  "memchr",
  "serde",
@@ -11469,7 +11470,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -11495,7 +11496,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
@@ -11549,7 +11550,7 @@ checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -12146,9 +12147,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12271,7 +12272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -12367,7 +12368,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -12513,7 +12514,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -12558,9 +12559,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -12642,7 +12643,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -12736,7 +12737,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -13239,9 +13240,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -13252,9 +13253,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -13262,9 +13263,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -13272,22 +13273,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -13307,9 +13308,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -13856,7 +13857,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -13873,7 +13874,7 @@ dependencies = [
  "flate2",
  "getrandom 0.4.3",
  "hmac 0.13.0",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "lzma-rust2",
  "memchr",
  "pbkdf2 0.13.0",
@@ -13921,18 +13922,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.4"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+checksum = "64d80649ab6db9d9f6f9c80a40becd948eda4714a0a5ac8c4d157a32231c7882"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
+version = "2.1.0+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+checksum = "0ef0a8027ec3ee71300ab3bcbcd0393f434aa72b91ca6d635a39941deae8eea0"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ reqwest = "0.13.4"
 rustfs-kafka-async = { version = "1.3.1" }
 socket2 = { version = "0.6.5" }
 tokio = { version = "1.53.1" }
-tokio-rustls = { default-features = false, version = "0.26.4" }
+tokio-rustls = { default-features = false, version = "0.26.5" }
 tokio-stream = { version = "0.1.19" }
 tokio-test = "0.4.5"
 tokio-util = { version = "0.7.19" }
@@ -238,11 +238,12 @@ arc-swap = "1.9.2"
 astral-tokio-tar = { git = "https://github.com/cxymds/tokio-tar.git", rev = "603756478b7668436e464519c77ccac22a99ba96" }
 atoi = "3.1.0"
 atomic_enum = "0.3.0"
-aws-config = { version = "1.11.0" }
+aws-config = { version = "1.12.0" }
 aws-credential-types = { version = "1.3.0" }
-aws-sdk-kms = { default-features = false, version = "1.117.0" }
-aws-sdk-s3 = { default-features = false, version = "1.144.0" }
-aws-sdk-sts = { default-features = false, version = "1.113.0" }
+aws-sdk-kms = { default-features = false, version = "1.118.0" }
+aws-sdk-s3 = { default-features = false, version = "1.145.0" }
+aws-sdk-sts = { default-features = false, version = "1.114.0" }
+aws-smithy-async = { version = "1.3.0" }
 aws-smithy-http-client = { default-features = false, version = "1.4.0" }
 aws-smithy-runtime-api = { version = "1.16.0" }
 aws-smithy-types = { version = "1.6.3" }

--- a/crates/ecstore/Cargo.toml
+++ b/crates/ecstore/Cargo.toml
@@ -244,6 +244,7 @@ windows-sys = { workspace = true, features = [
 windows-sys = { workspace = true, features = ["Win32_System_Ioctl"] }
 
 [dev-dependencies]
+aws-smithy-async.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util", "fs"] }
 criterion = { workspace = true, features = ["html_reports"] }
 temp-env = { workspace = true, features = ["async_closure"] }

--- a/crates/ecstore/src/bucket/remote_s3_client.rs
+++ b/crates/ecstore/src/bucket/remote_s3_client.rs
@@ -652,9 +652,10 @@ async fn build_aws_s3_http_client_from_tls_path() -> Option<SharedHttpClient> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aws_smithy_async::time::TimeSource;
     use aws_smithy_runtime_api::http::StatusCode as SmithyStatusCode;
     use std::sync::Mutex;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
     fn spec(endpoint: &str, secure: bool) -> RemoteS3EndpointSpec {
         RemoteS3EndpointSpec {
@@ -822,6 +823,174 @@ mod tests {
             1,
             "a zero attempt budget is clamped to the initial request"
         );
+    }
+
+    #[derive(Clone, Debug)]
+    struct ClockSkewTimeSource(Arc<AtomicU64>);
+
+    impl TimeSource for ClockSkewTimeSource {
+        fn now(&self) -> SystemTime {
+            SystemTime::UNIX_EPOCH + Duration::from_secs(self.0.load(Ordering::SeqCst))
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct ClockSkewConnector {
+        request_headers: RecordedHeaders,
+        error_code: &'static str,
+        skew_seconds: i64,
+        clock: ClockSkewTimeSource,
+    }
+
+    fn recorded_header<'a>(headers: &'a [(String, String)], name: &str) -> &'a str {
+        headers
+            .iter()
+            .find(|(key, _)| key.eq_ignore_ascii_case(name))
+            .map(|(_, value)| value.as_str())
+            .unwrap_or_else(|| panic!("signed request must contain {name}"))
+    }
+
+    fn signing_time(headers: &[(String, String)]) -> chrono::NaiveDateTime {
+        chrono::NaiveDateTime::parse_from_str(recorded_header(headers, "x-amz-date"), "%Y%m%dT%H%M%SZ")
+            .expect("SDK signing timestamp must use the SigV4 format")
+    }
+
+    impl SmithyHttpConnector for ClockSkewConnector {
+        fn call(&self, request: HttpRequest) -> HttpConnectorFuture {
+            let mut headers = self.request_headers.lock().expect("clock skew request capture lock");
+            assert!(headers.len() < 3, "clock skew fixture must not exceed two GET attempts and one HEAD");
+            headers.push(
+                request
+                    .headers()
+                    .iter()
+                    .map(|(key, value)| (key.to_string(), value.to_string()))
+                    .collect(),
+            );
+            let server_time = chrono::DateTime::<chrono::Utc>::from(self.clock.now()).naive_utc()
+                + chrono::Duration::seconds(self.skew_seconds);
+            let (status, body) = if headers.len() == 1 {
+                (
+                    403,
+                    format!("<Error><Code>{}</Code><Message>Clock skew fixture</Message></Error>", self.error_code),
+                )
+            } else {
+                (200, String::new())
+            };
+            let response = http::Response::builder()
+                .status(status)
+                .header("date", server_time.format("%a, %d %b %Y %H:%M:%S GMT").to_string())
+                .header("content-type", "application/xml")
+                .header("content-length", body.len())
+                .body(SdkBody::from(body))
+                .expect("clock skew fixture response");
+            HttpConnectorFuture::ready(Ok(HttpResponse::try_from(response).expect("Smithy fixture response")))
+        }
+    }
+
+    async fn clock_skew_client(
+        error_code: &'static str,
+        skew_seconds: i64,
+        retry: RemoteS3RetryPolicy,
+    ) -> (S3Client, RecordedHeaders, ClockSkewTimeSource) {
+        let headers: RecordedHeaders = Arc::new(Mutex::new(Vec::new()));
+        let clock = ClockSkewTimeSource(Arc::new(AtomicU64::new(1_700_000_000)));
+        let connector = SharedHttpConnector::new(ClockSkewConnector {
+            request_headers: Arc::clone(&headers),
+            error_code,
+            skew_seconds,
+            clock: clock.clone(),
+        });
+        let mut spec = spec("s3.example.com", true);
+        spec.retry = retry;
+        let config = build_remote_s3_config(&spec)
+            .await
+            .expect("clock skew fixture uses the production outbound configuration")
+            .http_client(http_client_fn(move |_settings, _components| connector.clone()))
+            .time_source(clock.clone())
+            .build();
+        (S3Client::from_conf(config), headers, clock)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn remote_s3_clock_skew_retries_resign_and_seed_next_operation() {
+        for error_code in ["RequestTimeTooSkewed", "SignatureDoesNotMatch"] {
+            for skew_seconds in [-600, 600] {
+                let (client, headers, clock) = clock_skew_client(error_code, skew_seconds, REPLICATION_TARGET_RETRY_POLICY).await;
+                let initial = chrono::DateTime::<chrono::Utc>::from(clock.now()).naive_utc();
+                client
+                    .get_object()
+                    .bucket("bucket")
+                    .key("object")
+                    .send()
+                    .await
+                    .expect("clock skew GET must retry successfully");
+                assert_eq!(
+                    headers.lock().expect("captured requests").len(),
+                    2,
+                    "{error_code}: GET needs exactly one retry"
+                );
+                clock.0.fetch_add(17, Ordering::SeqCst);
+                // SDK signing time is independent of Tokio's retry/scheduler clock.
+                tokio::time::advance(Duration::from_secs(61)).await;
+                client
+                    .head_bucket()
+                    .bucket("bucket")
+                    .send()
+                    .await
+                    .expect("subsequent HEAD must use the client's cached skew");
+                let headers = headers.lock().expect("captured signed requests");
+                assert_eq!(headers.len(), 3, "subsequent operation must succeed on its first attempt");
+                assert_eq!(signing_time(&headers[0]), initial, "the first attempt must use the injected clock");
+                assert_eq!(
+                    signing_time(&headers[1]),
+                    initial + chrono::Duration::seconds(skew_seconds),
+                    "{error_code}: retry must apply the measured offset exactly"
+                );
+                assert_eq!(
+                    signing_time(&headers[2]),
+                    initial + chrono::Duration::seconds(skew_seconds + 17),
+                    "{error_code}: the next operation must apply cached skew to the advanced signing clock"
+                );
+                let signature = |index: usize| {
+                    recorded_header(&headers[index], "authorization")
+                        .rsplit_once("Signature=")
+                        .expect("SigV4 authorization contains a signature")
+                        .1
+                };
+                assert_ne!(
+                    signature(0),
+                    signature(1),
+                    "{error_code}: retry must be signed again after adjusting its date"
+                );
+            }
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn remote_s3_clock_skew_respects_one_attempt_policy() {
+        use aws_smithy_types::error::metadata::ProvideErrorMetadata;
+
+        for error_code in ["RequestTimeTooSkewed", "SignatureDoesNotMatch"] {
+            for retry in [
+                RemoteS3RetryPolicy::Disabled,
+                RemoteS3RetryPolicy::Standard { max_attempts: 1 },
+            ] {
+                let (client, headers, _clock) = clock_skew_client(error_code, 600, retry).await;
+                let error = client
+                    .get_object()
+                    .bucket("bucket")
+                    .key("object")
+                    .send()
+                    .await
+                    .expect_err("clock skew must not override the caller's one-attempt budget");
+                assert_eq!(error.as_service_error().and_then(ProvideErrorMetadata::code), Some(error_code));
+                assert_eq!(
+                    headers.lock().expect("captured requests").len(),
+                    1,
+                    "{error_code}: {retry:?} must send exactly one request"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/scanner/src/scanner/cycle_state.rs
+++ b/crates/scanner/src/scanner/cycle_state.rs
@@ -379,6 +379,12 @@ pub(super) fn decode_recovery_marker_for_reset(
     if !matches!(marker_revision, DataUsageCacheRevision::Etag(_)) {
         return Err(ScannerError::Other("cycle recovery marker has no object revision".to_string()));
     }
+    if let Ok(value) = serde_json::from_slice::<serde_json::Value>(data)
+        && let Some(state) = value.get("state")
+        && !matches!(state.as_str(), Some("blocked" | "cleanup-pending"))
+    {
+        return Err(ScannerError::Other("cycle recovery marker state is unsupported".to_string()));
+    }
     let compat = serde_json::from_slice::<ScannerCycleRecoveryMarkerCompat>(data).ok();
     let _schema_version = compat.as_ref().and_then(|marker| marker.schema_version);
     let primary_revision = compat
@@ -406,7 +412,10 @@ pub(super) fn decode_recovery_marker_for_reset(
     };
     let state = match compat.as_ref().and_then(|marker| marker.state.as_deref()) {
         Some("cleanup-pending") => "cleanup-pending",
-        _ => "blocked",
+        Some("blocked") | None => "blocked",
+        Some(_) => {
+            return Err(ScannerError::Other("cycle recovery marker state is unsupported".to_string()));
+        }
     };
     let now = unix_now_secs();
     Ok(ScannerCycleRecoveryMarker {
@@ -721,17 +730,19 @@ async fn mark_cycle_recovery_cleanup_pending(
     mut marker: ScannerCycleRecoveryMarker,
     marker_revision: &DataUsageCacheRevision,
     expected_epoch: u64,
+    owns_reset: &(impl Fn() -> bool + Sync),
 ) -> Result<(ScannerCycleRecoveryMarker, DataUsageCacheRevision), ScannerError> {
     marker.state = "cleanup-pending".to_string();
     marker.last_attempt_at_unix_secs = unix_now_secs();
     let bytes = serde_json::to_vec(&marker)
         .map_err(|err| ScannerError::Other(format!("failed to encode cycle recovery marker: {err}")))?;
-    let info = save_config_with_publication_admission_for_epoch(
+    let info = save_reset_config(
         storeapi.clone(),
         DATA_USAGE_BLOOM_RECOVERY_PATH.as_str(),
         bytes,
         marker_revision.preconditions(),
         expected_epoch,
+        owns_reset,
     )
     .await
     .map_err(|err| ScannerError::Other(format!("failed to mark cycle recovery cleanup pending: {err}")))?;
@@ -933,6 +944,7 @@ pub async fn reset_scanner_cycle_recovery(ctx: CancellationToken, storeapi: Arc<
         .get_write_lock_quiet(Duration::from_secs(5))
         .await
         .map_err(|err| ScannerError::Other(format!("scanner leader lock is busy: {err}")))?;
+    let owns_reset = || !guard.is_lock_lost() && !ctx.is_cancelled();
 
     if guard.is_lock_lost() {
         return Err(ScannerError::Other("scanner leader lock was lost before recovery reset".to_string()));
@@ -952,7 +964,27 @@ pub async fn reset_scanner_cycle_recovery(ctx: CancellationToken, storeapi: Arc<
         }
         Err(err) => return Err(ScannerError::Other(format!("failed to read cycle recovery marker: {err}"))),
     };
-    let marker_data = marker_data.ok_or_else(|| ScannerError::Other("scanner cycle recovery marker is absent".to_string()))?;
+    let Some(marker_data) = marker_data else {
+        // A delete may commit before its reply is lost. Confirm both durable
+        // fences before treating a retry without its marker as completed.
+        let (cycle, epoch, revision) = read_cycle_state_for_usage_reset(storeapi.clone()).await?;
+        let floor = persisted_usage_floor(storeapi.clone()).await?;
+        if !matches!(revision, DataUsageCacheRevision::Etag(_))
+            || epoch < floor.leader_epoch
+            || cycle.next < floor.next_cycle
+            || !owns_reset()
+            || scanner_publication_admission_for_epoch(storeapi.clone(), reset_epoch)
+                .await
+                .is_none()
+        {
+            return Err(ScannerError::Other(
+                "scanner cycle recovery marker is absent without a completed reset fence".to_string(),
+            ));
+        }
+        set_scanner_cycle_recovery_status(recovery_status("healthy", None, false));
+        super::notify_scanner_cycle_recovery_wake();
+        return Ok(());
+    };
     let (marker, force_full_rescan) = match serde_json::from_slice::<ScannerCycleRecoveryMarker>(&marker_data) {
         Ok(marker) if validate_recovery_marker(&marker).is_ok() => (marker, false),
         _ => (decode_recovery_marker_for_reset(&marker_data, &marker_revision)?, true),
@@ -1026,8 +1058,10 @@ pub async fn reset_scanner_cycle_recovery(ctx: CancellationToken, storeapi: Arc<
             }
         };
         if let Some((primary_cycle, primary_epoch)) = primary_state {
+            verify_cycle_reset_intent(storeapi.clone(), &marker_revision, &owns_reset).await?;
             let (cleanup_marker, cleanup_marker_revision) =
-                mark_cycle_recovery_cleanup_pending(storeapi.clone(), marker.clone(), &marker_revision, reset_epoch).await?;
+                mark_cycle_recovery_cleanup_pending(storeapi.clone(), marker.clone(), &marker_revision, reset_epoch, &owns_reset)
+                    .await?;
             set_scanner_cycle_recovery_status(recovery_status_from_marker(&cleanup_marker, "cleanup-pending"));
             let usage_floor = persisted_usage_floor(storeapi.clone()).await?;
             let fence_epoch = primary_epoch
@@ -1047,12 +1081,14 @@ pub async fn reset_scanner_cycle_recovery(ctx: CancellationToken, storeapi: Arc<
                     "preserved scanner cycle state exceeds the bounded object size".to_string(),
                 ));
             }
-            let preserved_info = save_config_with_publication_admission_for_epoch(
+            verify_cycle_reset_intent(storeapi.clone(), &cleanup_marker_revision, &owns_reset).await?;
+            let preserved_info = save_reset_config(
                 storeapi.clone(),
                 DATA_USAGE_BLOOM_NAME_PATH.as_str(),
                 preserved_data,
                 primary_revision.preconditions(),
                 reset_epoch,
+                &owns_reset,
             )
             .await
             .map_err(|err| {
@@ -1072,9 +1108,17 @@ pub async fn reset_scanner_cycle_recovery(ctx: CancellationToken, storeapi: Arc<
                     "scanner leader lock was lost after fencing newer cycle state".to_string(),
                 ));
             }
-            fence_scanner_usage_epoch_with_expected_epoch(&ctx, storeapi.clone(), fence_epoch, Some(reset_epoch), false)
-                .await
-                .map_err(|err| ScannerError::Other(format!("failed to fence preserved scanner usage epoch: {err}")))?;
+            verify_cycle_reset_intent(storeapi.clone(), &cleanup_marker_revision, &owns_reset).await?;
+            fence_scanner_usage_epoch_with_expected_epoch(
+                &ctx,
+                storeapi.clone(),
+                fence_epoch,
+                Some(reset_epoch),
+                false,
+                &owns_reset,
+            )
+            .await
+            .map_err(|err| ScannerError::Other(format!("failed to fence preserved scanner usage epoch: {err}")))?;
             if guard.is_lock_lost() {
                 return Err(ScannerError::Other(
                     "scanner leader lock was lost after fencing newer cycle state".to_string(),
@@ -1088,7 +1132,8 @@ pub async fn reset_scanner_cycle_recovery(ctx: CancellationToken, storeapi: Arc<
                     "scanner cycle state changed before recovery marker cleanup".to_string(),
                 ));
             }
-            delete_config_with_publication_admission_for_epoch(
+            verify_cycle_reset_intent(storeapi.clone(), &cleanup_marker_revision, &owns_reset).await?;
+            delete_reset_config(
                 storeapi.clone(),
                 RUSTFS_META_BUCKET,
                 DATA_USAGE_BLOOM_RECOVERY_PATH.as_str(),
@@ -1100,6 +1145,7 @@ pub async fn reset_scanner_cycle_recovery(ctx: CancellationToken, storeapi: Arc<
                     ..Default::default()
                 },
                 reset_epoch,
+                &owns_reset,
             )
             .await
             .map_err(|err| {
@@ -1149,17 +1195,20 @@ pub async fn reset_scanner_cycle_recovery(ctx: CancellationToken, storeapi: Arc<
     // Persist the cleanup-pending phase before rewriting the primary. If the
     // process dies after the rewrite, startup still sees a durable fence and
     // cannot mistake the partially completed reset for a healthy state.
+    verify_cycle_reset_intent(storeapi.clone(), &marker_revision, &owns_reset).await?;
     let (marker, marker_revision) = if marker.state == "cleanup-pending" {
         (marker, marker_revision)
     } else {
-        mark_cycle_recovery_cleanup_pending(storeapi.clone(), marker, &marker_revision, reset_epoch).await?
+        mark_cycle_recovery_cleanup_pending(storeapi.clone(), marker, &marker_revision, reset_epoch, &owns_reset).await?
     };
-    let rebuilt_info = save_config_with_publication_admission_for_epoch(
+    verify_cycle_reset_intent(storeapi.clone(), &marker_revision, &owns_reset).await?;
+    let rebuilt_info = save_reset_config(
         storeapi.clone(),
         DATA_USAGE_BLOOM_NAME_PATH.as_str(),
         data,
         primary_revision.preconditions(),
         reset_epoch,
+        &owns_reset,
     )
     .await
     .map_err(|err| {
@@ -1178,8 +1227,10 @@ pub async fn reset_scanner_cycle_recovery(ctx: CancellationToken, storeapi: Arc<
             "scanner leader lock was lost after rebuilding cycle state".to_string(),
         ));
     }
+    verify_cycle_reset_intent(storeapi.clone(), &marker_revision, &owns_reset).await?;
     if let Err(err) =
-        fence_scanner_usage_epoch_with_expected_epoch(&ctx, storeapi.clone(), leader_epoch, Some(reset_epoch), false).await
+        fence_scanner_usage_epoch_with_expected_epoch(&ctx, storeapi.clone(), leader_epoch, Some(reset_epoch), false, &owns_reset)
+            .await
     {
         set_scanner_cycle_recovery_status(ScannerCycleRecoveryStatus {
             path: DATA_USAGE_BLOOM_NAME_PATH.clone(),
@@ -1249,7 +1300,8 @@ pub async fn reset_scanner_cycle_recovery(ctx: CancellationToken, storeapi: Arc<
         ));
     }
 
-    if let Err(err) = delete_config_with_publication_admission_for_epoch(
+    verify_cycle_reset_intent(storeapi.clone(), &marker_revision, &owns_reset).await?;
+    if let Err(err) = delete_reset_config(
         storeapi.clone(),
         RUSTFS_META_BUCKET,
         DATA_USAGE_BLOOM_RECOVERY_PATH.as_str(),
@@ -1261,6 +1313,7 @@ pub async fn reset_scanner_cycle_recovery(ctx: CancellationToken, storeapi: Arc<
             ..Default::default()
         },
         reset_epoch,
+        &owns_reset,
     )
     .await
     {
@@ -1310,6 +1363,57 @@ pub async fn reset_scanner_cycle_recovery(ctx: CancellationToken, storeapi: Arc<
     Ok(())
 }
 
+async fn verify_cycle_reset_intent(
+    storeapi: Arc<impl ScannerObjectIO>,
+    expected_revision: &DataUsageCacheRevision,
+    owns_reset: &(impl Fn() -> bool + Sync),
+) -> Result<(), ScannerError> {
+    let revision = read_config_revision(storeapi, DATA_USAGE_BLOOM_RECOVERY_PATH.as_str())
+        .await
+        .map_err(|err| ScannerError::Other(format!("failed to verify scanner cycle reset intent: {err}")))?;
+    if &revision != expected_revision {
+        return Err(ScannerError::Other("scanner cycle reset intent changed".to_string()));
+    }
+    if !owns_reset() {
+        return Err(ScannerError::Other("scanner cycle reset ownership was lost".to_string()));
+    }
+    Ok(())
+}
+
+async fn save_reset_config(
+    storeapi: Arc<impl ScannerObjectIO + ScannerConfigObjectDelete>,
+    path: &str,
+    data: Vec<u8>,
+    preconditions: crate::HTTPPreconditions,
+    expected_epoch: u64,
+    owns_reset: &(impl Fn() -> bool + Sync),
+) -> Result<crate::ScannerObjectInfo, EcstoreError> {
+    let Some(_admission) = scanner_publication_admission_for_epoch(storeapi.clone(), expected_epoch).await else {
+        return Err(EcstoreError::other(SCANNER_PUBLICATION_EPOCH_CHANGED));
+    };
+    if !owns_reset() {
+        return Err(EcstoreError::other("scanner reset ownership was lost before write"));
+    }
+    save_config_with_preconditions(storeapi, path, data, preconditions).await
+}
+
+async fn delete_reset_config(
+    storeapi: Arc<impl ScannerObjectIO + ScannerConfigObjectDelete>,
+    bucket: &str,
+    path: &str,
+    options: ScannerObjectOptions,
+    expected_epoch: u64,
+    owns_reset: &(impl Fn() -> bool + Sync),
+) -> Result<crate::ScannerObjectInfo, EcstoreError> {
+    let Some(_admission) = scanner_publication_admission_for_epoch(storeapi.clone(), expected_epoch).await else {
+        return Err(EcstoreError::other(SCANNER_PUBLICATION_EPOCH_CHANGED));
+    };
+    if !owns_reset() {
+        return Err(EcstoreError::other("scanner reset ownership was lost before delete"));
+    }
+    storeapi.delete_config_object(bucket, path, options).await
+}
+
 fn scanner_usage_state_reset_paths() -> Vec<String> {
     vec![
         DATA_USAGE_OBJ_NAME_PATH.as_str().to_string(),
@@ -1333,8 +1437,14 @@ pub(super) async fn read_usage_state_reset_slots(
     Ok(slots)
 }
 
-fn usage_state_reset_floor(slots: &[ScannerUsageStateResetSlot]) -> Result<PersistedUsageFloor, ScannerError> {
-    let mut floor = PersistedUsageFloor::default();
+enum ScannerUsageResetFloor {
+    Missing,
+    Trusted(PersistedUsageFloor),
+    Corrupt,
+}
+
+fn usage_state_reset_floor(slots: &[ScannerUsageStateResetSlot]) -> Result<ScannerUsageResetFloor, ScannerError> {
+    let mut floor = None;
     for slot in slots {
         let Some(data) = slot.data.as_deref() else {
             continue;
@@ -1342,9 +1452,21 @@ fn usage_state_reset_floor(slots: &[ScannerUsageStateResetSlot]) -> Result<Persi
         let Ok(usage) = serde_json::from_slice::<DataUsageInfo>(data) else {
             continue;
         };
-        update_persisted_usage_floor(&mut floor, &usage, &slot.path)?;
+        if !data_usage_info_has_persisted_baseline_identity(&usage)
+            && !(slot.path == DATA_USAGE_OBJ_NAME_PATH.as_str() && data_usage_info_is_bootstrap_pending(&usage))
+            && legacy_incomplete_usage_fence(data, &usage)
+                .and_then(|fence| fence.claimable_epoch())
+                .is_none()
+        {
+            continue;
+        }
+        update_persisted_usage_floor(floor.get_or_insert_with(PersistedUsageFloor::default), &usage, &slot.path)?;
     }
-    Ok(floor)
+    Ok(match floor {
+        Some(floor) => ScannerUsageResetFloor::Trusted(floor),
+        None if slots.iter().any(|slot| slot.data.is_some()) => ScannerUsageResetFloor::Corrupt,
+        None => ScannerUsageResetFloor::Missing,
+    })
 }
 
 async fn read_cycle_state_for_usage_reset(
@@ -1401,11 +1523,12 @@ async fn delete_usage_state_reset_slot(
     storeapi: Arc<impl ScannerObjectIO + ScannerConfigObjectDelete>,
     slot: &ScannerUsageStateResetSlot,
     expected_epoch: u64,
+    owns_reset: &(impl Fn() -> bool + Sync),
 ) -> Result<bool, ScannerError> {
     if matches!(slot.revision, DataUsageCacheRevision::Missing) {
         return Ok(false);
     }
-    let delete_result = delete_config_with_publication_admission_for_epoch(
+    let delete_result = delete_reset_config(
         storeapi.clone(),
         RUSTFS_META_BUCKET,
         &slot.path,
@@ -1415,6 +1538,7 @@ async fn delete_usage_state_reset_slot(
             ..Default::default()
         },
         expected_epoch,
+        owns_reset,
     )
     .await;
     match delete_result {
@@ -1486,21 +1610,24 @@ pub(super) async fn publish_scanner_usage_bootstrap_primary(
     expected_publication_epoch: u64,
     leader_epoch: Option<u64>,
     context: ScannerUsageBootstrapPublishContext,
+    owns_publication: impl Fn() -> bool + Sync,
 ) -> Result<(), ScannerError> {
     async fn inner(
         storeapi: Arc<impl ScannerObjectIO + ScannerConfigObjectDelete>,
         expected_revision: &DataUsageCacheRevision,
         expected_publication_epoch: u64,
         leader_epoch: Option<u64>,
+        owns_publication: &(impl Fn() -> bool + Sync),
     ) -> Result<(), ScannerUsageBootstrapPublishError> {
         let marker = scanner_usage_bootstrap_marker(std::time::SystemTime::now(), leader_epoch);
         let data = serde_json::to_vec(&marker).map_err(ScannerUsageBootstrapPublishError::Encode)?;
-        let save_result = save_config_with_publication_admission_for_epoch(
+        let save_result = save_reset_config(
             storeapi.clone(),
             DATA_USAGE_OBJ_NAME_PATH.as_str(),
             data.clone(),
             expected_revision.preconditions(),
             expected_publication_epoch,
+            owns_publication,
         )
         .await;
         if save_result
@@ -1524,7 +1651,7 @@ pub(super) async fn publish_scanner_usage_bootstrap_primary(
         })
     }
 
-    inner(storeapi, expected_revision, expected_publication_epoch, leader_epoch)
+    inner(storeapi, expected_revision, expected_publication_epoch, leader_epoch, &owns_publication)
         .await
         .map_err(|err| err.into_scanner_error(context))
 }
@@ -1534,30 +1661,106 @@ pub(super) async fn reset_scanner_usage_state_slots_for_full_rebuild(
     slots: &[ScannerUsageStateResetSlot],
     expected_epoch: u64,
     leader_epoch: u64,
+    owns_reset: impl Fn() -> bool + Sync,
 ) -> Result<Vec<String>, ScannerError> {
     let mut reset_paths = Vec::new();
     let primary = slots
         .iter()
         .find(|slot| slot.path == DATA_USAGE_OBJ_NAME_PATH.as_str())
         .ok_or_else(|| ScannerError::Other("scanner usage reset primary slot was not inspected".to_string()))?;
-    publish_scanner_usage_bootstrap_primary(
-        storeapi.clone(),
-        &primary.revision,
-        expected_epoch,
-        Some(leader_epoch),
-        ScannerUsageBootstrapPublishContext::Reset,
-    )
-    .await?;
+    if !owns_reset() {
+        return Err(ScannerError::Other("scanner usage reset ownership was lost".to_string()));
+    }
+    let resume_epoch = usage_state_reset_resume_epoch(slots)?;
+    match resume_epoch {
+        Some(epoch) if epoch == leader_epoch => {}
+        Some(_) => return Err(ScannerError::Other("scanner usage reset bootstrap epoch changed".to_string())),
+        None => {
+            publish_scanner_usage_bootstrap_primary(
+                storeapi.clone(),
+                &primary.revision,
+                expected_epoch,
+                Some(leader_epoch),
+                ScannerUsageBootstrapPublishContext::Reset,
+                &owns_reset,
+            )
+            .await?;
+        }
+    }
+    let (data, intent_revision) = read_config_with_revision(storeapi.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str())
+        .await
+        .map_err(|err| ScannerError::Other(format!("failed to inspect scanner usage reset intent: {err}")))?;
+    data.as_deref()
+        .and_then(|data| serde_json::from_slice::<DataUsageInfo>(data).ok())
+        .filter(|usage| data_usage_info_is_bootstrap_pending(usage) && usage.scanner_epoch == Some(leader_epoch))
+        .ok_or_else(|| ScannerError::Other("scanner usage reset intent changed before cleanup".to_string()))?;
+    if !matches!(intent_revision, DataUsageCacheRevision::Etag(_))
+        || (resume_epoch.is_some() && intent_revision != primary.revision)
+    {
+        return Err(ScannerError::Other("scanner usage reset intent revision changed".to_string()));
+    }
     reset_paths.push(DATA_USAGE_OBJ_NAME_PATH.as_str().to_string());
 
     for slot in slots.iter().filter(|slot| slot.path != DATA_USAGE_OBJ_NAME_PATH.as_str()) {
-        if delete_usage_state_reset_slot(storeapi.clone(), slot, expected_epoch).await? {
+        if let Some(usage) = slot
+            .data
+            .as_deref()
+            .and_then(|data| serde_json::from_slice::<DataUsageInfo>(data).ok())
+            && usage_epoch(&usage) >= leader_epoch
+        {
+            return Err(ScannerError::Other(format!(
+                "scanner usage reset slot is not older than its intent: {}",
+                slot.path
+            )));
+        }
+        let revision = read_config_revision(storeapi.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str())
+            .await
+            .map_err(|err| ScannerError::Other(format!("failed to verify scanner usage reset intent: {err}")))?;
+        if revision != intent_revision {
+            return Err(ScannerError::Other("scanner usage reset intent changed during cleanup".to_string()));
+        }
+        if !owns_reset() {
+            return Err(ScannerError::Other("scanner usage reset ownership was lost".to_string()));
+        }
+        if delete_usage_state_reset_slot(storeapi.clone(), slot, expected_epoch, &owns_reset).await? {
             reset_paths.push(slot.path.clone());
         }
+    }
+    let revision = read_config_revision(storeapi.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str())
+        .await
+        .map_err(|err| ScannerError::Other(format!("failed to confirm scanner usage reset intent: {err}")))?;
+    if revision != intent_revision || !owns_reset() {
+        return Err(ScannerError::Other(
+            "scanner usage reset intent or ownership changed before completion".to_string(),
+        ));
     }
     invalidate_admin_data_usage_snapshot_cache().await;
     invalidate_data_usage_snapshot_cache().await;
     Ok(reset_paths)
+}
+
+fn usage_state_reset_resume_epoch(slots: &[ScannerUsageStateResetSlot]) -> Result<Option<u64>, ScannerError> {
+    let primary = slots.iter().find(|slot| slot.path == DATA_USAGE_OBJ_NAME_PATH.as_str());
+    let usage = primary
+        .and_then(|slot| slot.data.as_deref())
+        .and_then(|data| serde_json::from_slice::<DataUsageInfo>(data).ok());
+    match usage {
+        Some(usage) if usage.usage_snapshot_bootstrap_pending => {
+            if !data_usage_info_is_bootstrap_pending(&usage) {
+                return Err(ScannerError::Other("scanner usage reset bootstrap is invalid".to_string()));
+            }
+            if usage.scanner_epoch.is_none() {
+                // Initial bootstrap has no reset owner yet.
+                return Ok(None);
+            }
+            usage
+                .scanner_epoch
+                .filter(|epoch| *epoch > 0 && *epoch < u64::MAX)
+                .map(Some)
+                .ok_or_else(|| ScannerError::Other("scanner usage reset bootstrap has no valid epoch".to_string()))
+        }
+        _ => Ok(None),
+    }
 }
 
 pub async fn reset_scanner_usage_state_for_full_rebuild(
@@ -1584,12 +1787,31 @@ pub async fn reset_scanner_usage_state_for_full_rebuild(
     };
     let (cycle, cycle_epoch, cycle_revision) = read_cycle_state_for_usage_reset(storeapi.clone()).await?;
     let slots = read_usage_state_reset_slots(storeapi.clone()).await?;
-    let usage_floor = usage_state_reset_floor(&slots)?;
-    let leader_epoch = cycle_epoch
-        .max(usage_floor.leader_epoch)
-        .checked_add(1)
-        .filter(|epoch| *epoch < u64::MAX)
-        .ok_or_else(|| ScannerError::Other("scanner leader epoch is exhausted".to_string()))?;
+    let usage_floor = match usage_state_reset_floor(&slots)? {
+        ScannerUsageResetFloor::Trusted(floor) => floor,
+        ScannerUsageResetFloor::Corrupt if matches!(cycle_revision, DataUsageCacheRevision::Missing) => {
+            return Err(ScannerError::Other("scanner usage reset has no trusted cycle or usage floor".to_string()));
+        }
+        ScannerUsageResetFloor::Missing | ScannerUsageResetFloor::Corrupt => PersistedUsageFloor {
+            next_cycle: cycle.next,
+            leader_epoch: cycle_epoch,
+        },
+    };
+    let resume_epoch = usage_state_reset_resume_epoch(&slots)?;
+    let leader_epoch = if let Some(epoch) = resume_epoch {
+        if epoch != cycle_epoch || usage_floor.leader_epoch > epoch || usage_floor.next_cycle > cycle.next {
+            return Err(ScannerError::Other(
+                "scanner usage reset bootstrap conflicts with the persisted cycle fence".to_string(),
+            ));
+        }
+        epoch
+    } else {
+        cycle_epoch
+            .max(usage_floor.leader_epoch)
+            .checked_add(1)
+            .filter(|epoch| *epoch < u64::MAX)
+            .ok_or_else(|| ScannerError::Other("scanner leader epoch is exhausted".to_string()))?
+    };
     let rebuilt_cycle = CurrentCycle {
         next: cycle.next.max(usage_floor.next_cycle),
         ..Default::default()
@@ -1602,21 +1824,24 @@ pub async fn reset_scanner_usage_state_for_full_rebuild(
             "scanner leader lock was lost before fencing usage reset cycle state".to_string(),
         ));
     }
-    save_config_with_publication_admission_for_epoch(
-        storeapi.clone(),
-        DATA_USAGE_BLOOM_NAME_PATH.as_str(),
-        cycle_data,
-        cycle_revision.preconditions(),
-        reset_epoch,
-    )
-    .await
-    .map_err(|err| {
-        if scanner_publication_epoch_changed(&err) {
-            ScannerError::Other("scanner usage reset deferred by a movement epoch change".to_string())
-        } else {
-            ScannerError::Other(format!("failed to fence scanner cycle state for usage reset: {err}"))
-        }
-    })?;
+    if resume_epoch.is_none() {
+        save_reset_config(
+            storeapi.clone(),
+            DATA_USAGE_BLOOM_NAME_PATH.as_str(),
+            cycle_data,
+            cycle_revision.preconditions(),
+            reset_epoch,
+            &|| !guard.is_lock_lost() && !ctx.is_cancelled(),
+        )
+        .await
+        .map_err(|err| {
+            if scanner_publication_epoch_changed(&err) {
+                ScannerError::Other("scanner usage reset deferred by a movement epoch change".to_string())
+            } else {
+                ScannerError::Other(format!("failed to fence scanner cycle state for usage reset: {err}"))
+            }
+        })?;
+    }
 
     if guard.is_lock_lost() {
         return Err(ScannerError::Other(
@@ -1624,7 +1849,10 @@ pub async fn reset_scanner_usage_state_for_full_rebuild(
         ));
     }
     let reset_paths =
-        reset_scanner_usage_state_slots_for_full_rebuild(storeapi.clone(), &slots, reset_epoch, leader_epoch).await?;
+        reset_scanner_usage_state_slots_for_full_rebuild(storeapi.clone(), &slots, reset_epoch, leader_epoch, || {
+            !guard.is_lock_lost() && !ctx.is_cancelled()
+        })
+        .await?;
     if guard.is_lock_lost() {
         return Err(ScannerError::Other(
             "scanner leader lock was lost after publishing usage reset marker".to_string(),
@@ -2135,6 +2363,7 @@ async fn recover_legacy_incomplete_usage_floor(
         expected_publication_epoch,
         Some(primary.epoch),
         ScannerUsageBootstrapPublishContext::Recovery,
+        || true,
     )
     .await?;
     warn!(

--- a/crates/scanner/src/scanner/leadership.rs
+++ b/crates/scanner/src/scanner/leadership.rs
@@ -191,6 +191,7 @@ pub(super) async fn initialize_usage_baseline_bootstrap(
         expected_epoch,
         None,
         ScannerUsageBootstrapPublishContext::Initial,
+        || true,
     )
     .await
 }
@@ -201,9 +202,10 @@ pub(super) async fn fence_scanner_usage_epoch_with_expected_epoch(
     claimed_epoch: u64,
     expected_publication_epoch: Option<u64>,
     allow_bootstrap_pending: bool,
+    owns_fence: impl Fn() -> bool,
 ) -> Result<(), ScannerError> {
     for retry in 0..=SCANNER_PERSIST_CAS_RETRIES {
-        if ctx.is_cancelled() {
+        if ctx.is_cancelled() || !owns_fence() {
             return Err(ScannerError::Other("scanner leadership was cancelled before usage fencing".to_string()));
         }
 
@@ -264,6 +266,9 @@ pub(super) async fn fence_scanner_usage_epoch_with_expected_epoch(
                     "scanner usage epoch fence changed while preparing its conditional write".to_string(),
                 ));
             };
+            if ctx.is_cancelled() || !owns_fence() {
+                return Err(ScannerError::Other("scanner leadership was lost before usage fencing".to_string()));
+            }
             save_config_with_preconditions(storeapi.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str(), data, revision.preconditions())
                 .await
         };
@@ -319,6 +324,7 @@ pub(super) async fn complete_scanner_leadership_claim(
         claimed_epoch,
         expected_publication_epoch,
         allow_bootstrap_pending,
+        || true,
     )
     .await
     {

--- a/crates/scanner/src/scanner/tests.rs
+++ b/crates/scanner/src/scanner/tests.rs
@@ -634,6 +634,8 @@ struct MemoryConfigStore {
     cancel_after_successful_puts: Mutex<HashMap<String, (usize, CancellationToken)>>,
     replace_after_successful_puts: Mutex<HashMap<String, (usize, Vec<u8>)>>,
     error_after_commit_deletes: Mutex<HashSet<String>>,
+    cancel_after_deletes: Mutex<HashMap<String, CancellationToken>>,
+    pause_next_publication_admission: Mutex<Option<(Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>)>>,
     put_counts: Mutex<HashMap<String, usize>>,
     publication_admission_blocked: AtomicBool,
     block_publication_after_admissions: AtomicUsize,
@@ -4081,6 +4083,9 @@ impl crate::ScannerConfigObjectDelete for MemoryConfigStore {
         revisions.remove(&key);
         drop(revisions);
         drop(objects);
+        if let Some(token) = self.cancel_after_deletes.lock().await.remove(&key) {
+            token.cancel();
+        }
         if self.error_after_commit_deletes.lock().await.remove(&key) {
             return Err(EcstoreError::other("injected delete error after commit"));
         }
@@ -4088,6 +4093,11 @@ impl crate::ScannerConfigObjectDelete for MemoryConfigStore {
     }
 
     async fn scanner_data_usage_publication_admission(&self) -> Option<crate::ScannerDataUsagePublicationAdmission> {
+        let pause = self.pause_next_publication_admission.lock().await.take();
+        if let Some((entered, resume)) = pause {
+            entered.notify_one();
+            resume.notified().await;
+        }
         if self.publication_admission_blocked.load(Ordering::Acquire) {
             return None;
         }
@@ -4589,7 +4599,7 @@ async fn scanner_legacy_usage_backup_survives_fencing_and_restart_after_real_met
         .expect("publication must also read the intact backup");
     assert_eq!(baseline.data.as_deref(), Some(data.as_slice()));
     assert_eq!(baseline.revision, DataUsageCacheRevision::Missing);
-    fence_scanner_usage_epoch_with_expected_epoch(&CancellationToken::new(), store.clone(), 7, None, false)
+    fence_scanner_usage_epoch_with_expected_epoch(&CancellationToken::new(), store.clone(), 7, None, false, || true)
         .await
         .expect("legacy backup must be fenced into v2");
     let fenced = read_config(store.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str())
@@ -4818,6 +4828,28 @@ async fn scanner_usage_state_reset_publishes_fenced_bootstrap_marker() {
         );
     }
 
+    let cycle_before_retry = read_config_with_revision(store.clone(), DATA_USAGE_BLOOM_NAME_PATH.as_str())
+        .await
+        .expect("cycle should remain before retry");
+    let marker_before_retry = read_config_with_revision(store.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str())
+        .await
+        .expect("bootstrap should remain before retry");
+    let retry = reset_scanner_usage_state_for_full_rebuild(CancellationToken::new(), store.clone())
+        .await
+        .expect("completed cleanup should be reentrant");
+    assert_eq!(retry.leader_epoch, result.leader_epoch);
+    assert_eq!(
+        read_config_with_revision(store.clone(), DATA_USAGE_BLOOM_NAME_PATH.as_str())
+            .await
+            .expect("cycle should remain"),
+        cycle_before_retry
+    );
+    assert_eq!(
+        read_config_with_revision(store.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str())
+            .await
+            .expect("bootstrap should remain"),
+        marker_before_retry
+    );
     let (floor, state) = persisted_usage_floor_for_startup(store, false)
         .await
         .expect("reset marker should be resumable");
@@ -4973,13 +5005,355 @@ async fn scanner_usage_state_reset_slots_reject_primary_aba() {
 
     store.objects.lock().await.insert(key.clone(), b"newer-json".to_vec());
     store.revisions.lock().await.insert(key, 2);
-    let err = reset_scanner_usage_state_slots_for_full_rebuild(store, &slots, 0, 3)
+    let err = reset_scanner_usage_state_slots_for_full_rebuild(store, &slots, 0, 3, || true)
         .await
         .expect_err("stale primary revision must not be overwritten");
     assert!(
         err.to_string()
             .contains("scanner usage reset primary slot changed before bootstrap publish"),
         "unexpected primary ABA error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn scanner_usage_state_reset_resumes_every_cleanup_boundary_without_rewriting_intent() {
+    for completed in 0..=4 {
+        let store = Arc::new(MemoryConfigStore::default());
+        let primary_path = DATA_USAGE_OBJ_NAME_PATH.as_str();
+        let cleanup_paths = [
+            format!("{primary_path}.bkp"),
+            LEGACY_DATA_USAGE_OBJ_NAME_PATH.as_str().to_string(),
+            format!("{}.bkp", LEGACY_DATA_USAGE_OBJ_NAME_PATH.as_str()),
+            DATA_USAGE_OBSERVED_OBJ_NAME_PATH.as_str().to_string(),
+        ];
+        for path in std::iter::once(primary_path).chain(cleanup_paths.iter().map(String::as_str)) {
+            let mut usage = complete_usage_with_bucket_count(Some(std::time::SystemTime::UNIX_EPOCH), 0);
+            usage.scanner_epoch = Some(1);
+            save_config(store.clone(), path, serde_json::to_vec(&usage).expect("fixture should encode"))
+                .await
+                .expect("fixture should persist");
+        }
+        // These objects belong to other owners, even when reset cleanup resumes.
+        for path in ["buckets/quota-reservations/ledger", "buckets/example/incarnation"] {
+            save_config(store.clone(), path, b"retain".to_vec())
+                .await
+                .expect("unrelated state should persist");
+        }
+        let slots = read_usage_state_reset_slots(store.clone()).await.expect("slots should load");
+        let cancelled = CancellationToken::new();
+        if completed == 0 {
+            store
+                .cancel_after_successful_puts
+                .lock()
+                .await
+                .insert(memory_config_key(RUSTFS_META_BUCKET, primary_path), (2, cancelled.clone()));
+        } else {
+            store
+                .cancel_after_deletes
+                .lock()
+                .await
+                .insert(memory_config_key(RUSTFS_META_BUCKET, &cleanup_paths[completed - 1]), cancelled.clone());
+        }
+        let err = reset_scanner_usage_state_slots_for_full_rebuild(store.clone(), &slots, 0, 3, || !cancelled.is_cancelled())
+            .await
+            .expect_err("interruption should stop cleanup");
+        assert!(err.to_string().contains("ownership"), "boundary {completed}: {err}");
+        for (index, path) in cleanup_paths.iter().enumerate() {
+            assert_eq!(
+                store
+                    .objects
+                    .lock()
+                    .await
+                    .contains_key(&memory_config_key(RUSTFS_META_BUCKET, path)),
+                index >= completed,
+                "boundary {completed}, slot {index}"
+            );
+        }
+        let intent = read_config_with_revision(store.clone(), primary_path)
+            .await
+            .expect("intent should persist");
+        let slots = read_usage_state_reset_slots(store.clone())
+            .await
+            .expect("restart should reload slots");
+        reset_scanner_usage_state_slots_for_full_rebuild(store.clone(), &slots, 0, 3, || true)
+            .await
+            .expect("restart should complete the same intent");
+        assert_eq!(
+            read_config_with_revision(store.clone(), primary_path)
+                .await
+                .expect("intent should remain"),
+            intent
+        );
+        assert_eq!(store.put_counts.lock().await[&memory_config_key(RUSTFS_META_BUCKET, primary_path)], 2);
+        for path in cleanup_paths {
+            assert!(
+                !store
+                    .objects
+                    .lock()
+                    .await
+                    .contains_key(&memory_config_key(RUSTFS_META_BUCKET, &path))
+            );
+        }
+        for path in ["buckets/quota-reservations/ledger", "buckets/example/incarnation"] {
+            assert_eq!(read_config(store.clone(), path).await.expect("unrelated state should remain"), b"retain");
+        }
+    }
+}
+
+#[tokio::test]
+async fn scanner_usage_state_reset_stops_usage_fence_after_owner_loss() {
+    let store = Arc::new(MemoryConfigStore::default());
+    let mut usage = complete_usage_with_bucket_count(Some(std::time::SystemTime::UNIX_EPOCH), 0);
+    usage.scanner_epoch = Some(1);
+    let bytes = serde_json::to_vec(&usage).expect("baseline should encode");
+    save_config(store.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str(), bytes.clone())
+        .await
+        .expect("baseline should persist");
+    let checks = AtomicUsize::new(0);
+    let err = fence_scanner_usage_epoch_with_expected_epoch(&CancellationToken::new(), store.clone(), 3, Some(0), false, || {
+        checks.fetch_add(1, Ordering::SeqCst) == 0
+    })
+    .await
+    .expect_err("ownership lost during reads must prevent the write");
+    assert!(err.to_string().contains("leadership was lost"), "{err}");
+    assert_eq!(
+        read_config(store, DATA_USAGE_OBJ_NAME_PATH.as_str())
+            .await
+            .expect("baseline should remain"),
+        bytes
+    );
+}
+
+#[tokio::test]
+async fn scanner_usage_state_reset_cancels_during_publication_admission() {
+    for resuming in [false, true] {
+        let store = Arc::new(MemoryConfigStore::default());
+        let usage = if resuming {
+            scanner_usage_bootstrap_marker(std::time::SystemTime::UNIX_EPOCH, Some(3))
+        } else {
+            complete_usage_with_bucket_count(Some(std::time::SystemTime::UNIX_EPOCH), 0)
+        };
+        save_config(
+            store.clone(),
+            DATA_USAGE_OBJ_NAME_PATH.as_str(),
+            serde_json::to_vec(&usage).expect("primary should encode"),
+        )
+        .await
+        .expect("primary should persist");
+        save_config(store.clone(), LEGACY_DATA_USAGE_OBJ_NAME_PATH.as_str(), b"corrupt".to_vec())
+            .await
+            .expect("cleanup target should persist");
+        let slots = read_usage_state_reset_slots(store.clone()).await.expect("slots should load");
+        let before = store.objects.lock().await.clone();
+        let revisions_before = store.revisions.lock().await.clone();
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let resume = Arc::new(tokio::sync::Notify::new());
+        *store.pause_next_publication_admission.lock().await = Some((entered.clone(), resume.clone()));
+        let cancelled = CancellationToken::new();
+        let (result, ()) = tokio::join!(
+            reset_scanner_usage_state_slots_for_full_rebuild(store.clone(), &slots, 0, 3, || !cancelled.is_cancelled()),
+            async {
+                entered.notified().await;
+                cancelled.cancel();
+                resume.notify_one();
+            }
+        );
+        let err = result.expect_err("losing ownership during admission must prevent mutation");
+        assert!(err.to_string().contains("ownership was lost"), "resuming={resuming}: {err}");
+        assert_eq!(*store.objects.lock().await, before);
+        assert_eq!(*store.revisions.lock().await, revisions_before);
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn scanner_usage_state_reset_rejects_corruption_without_a_trusted_floor() {
+    let (_temp_dir, store) = setup_scanner_cycle_store_with_usage_baseline(false).await;
+    save_config(store.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str(), b"{corrupt".to_vec())
+        .await
+        .expect("corrupt primary should persist");
+    let before = read_config_with_revision(store.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str())
+        .await
+        .expect("evidence should load");
+    let err = reset_scanner_usage_state_for_full_rebuild(CancellationToken::new(), store.clone())
+        .await
+        .expect_err("corruption must not become a zero floor");
+    assert!(err.to_string().contains("no trusted cycle or usage floor"), "{err}");
+    assert_eq!(
+        read_config_with_revision(store.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str())
+            .await
+            .expect("evidence should remain"),
+        before
+    );
+    assert!(matches!(
+        read_config(store.clone(), DATA_USAGE_BLOOM_NAME_PATH.as_str()).await,
+        Err(EcstoreError::ConfigNotFound)
+    ));
+    let mut backup = complete_usage_with_bucket_count(Some(std::time::SystemTime::UNIX_EPOCH), 0);
+    backup.scanner_epoch = Some(7);
+    backup.scanner_cycle = Some(40);
+    save_config(
+        store.clone(),
+        &format!("{}.bkp", DATA_USAGE_OBJ_NAME_PATH.as_str()),
+        serde_json::to_vec(&backup).expect("backup should encode"),
+    )
+    .await
+    .expect("valid backup should persist");
+    let result = reset_scanner_usage_state_for_full_rebuild(CancellationToken::new(), store)
+        .await
+        .expect("valid backup should supply the recovery floor");
+    assert_eq!(result.leader_epoch, 8);
+    assert_eq!(result.next_cycle, 41);
+}
+
+#[tokio::test]
+async fn scanner_usage_state_reset_rejects_replaced_intent_and_newer_cleanup_slot() {
+    let store = Arc::new(MemoryConfigStore::default());
+    let marker = scanner_usage_bootstrap_marker(std::time::SystemTime::UNIX_EPOCH, Some(3));
+    let bytes = serde_json::to_vec(&marker).expect("marker should encode");
+    save_config(store.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str(), bytes.clone())
+        .await
+        .expect("intent should persist");
+    let slots = read_usage_state_reset_slots(store.clone()).await.expect("slots should load");
+    save_config(store.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str(), bytes)
+        .await
+        .expect("another intent should persist");
+    let err = reset_scanner_usage_state_slots_for_full_rebuild(store.clone(), &slots, 0, 3, || true)
+        .await
+        .expect_err("same epoch cannot replace an intent revision");
+    assert!(err.to_string().contains("intent revision changed"), "{err}");
+
+    let mut newer = complete_usage_with_bucket_count(Some(std::time::SystemTime::UNIX_EPOCH), 0);
+    newer.scanner_epoch = Some(3);
+    let path = format!("{}.bkp", DATA_USAGE_OBJ_NAME_PATH.as_str());
+    let bytes = serde_json::to_vec(&newer).expect("newer snapshot should encode");
+    save_config(store.clone(), &path, bytes.clone())
+        .await
+        .expect("newer snapshot should persist");
+    let slots = read_usage_state_reset_slots(store.clone())
+        .await
+        .expect("slots should reload");
+    let err = reset_scanner_usage_state_slots_for_full_rebuild(store.clone(), &slots, 0, 3, || true)
+        .await
+        .expect_err("cleanup cannot delete same-epoch progress");
+    assert!(err.to_string().contains("not older than its intent"), "{err}");
+    assert_eq!(read_config(store, &path).await.expect("newer snapshot should remain"), bytes);
+}
+
+#[tokio::test]
+#[serial]
+async fn scanner_usage_state_reset_rejects_decodable_untrusted_floor() {
+    let (_temp_dir, store) = setup_scanner_cycle_store_with_usage_baseline(false).await;
+    let invalid_identity = DataUsageInfo {
+        usage_snapshot_complete: true,
+        buckets_count: 1,
+        last_update: Some(std::time::SystemTime::UNIX_EPOCH),
+        ..Default::default()
+    };
+    for usage in [DataUsageInfo::default(), invalid_identity] {
+        save_config(
+            store.clone(),
+            DATA_USAGE_OBJ_NAME_PATH.as_str(),
+            serde_json::to_vec(&usage).expect("fixture should encode"),
+        )
+        .await
+        .expect("untrusted primary should persist");
+        let before = read_config_with_revision(store.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str())
+            .await
+            .expect("primary should load");
+        let err = reset_scanner_usage_state_for_full_rebuild(CancellationToken::new(), store.clone())
+            .await
+            .expect_err("valid JSON alone cannot prove a usage floor");
+        assert!(err.to_string().contains("no trusted cycle or usage floor"), "{err}");
+        assert_eq!(
+            read_config_with_revision(store.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str())
+                .await
+                .expect("evidence should remain"),
+            before
+        );
+        assert!(matches!(
+            read_config(store.clone(), DATA_USAGE_BLOOM_NAME_PATH.as_str()).await,
+            Err(EcstoreError::ConfigNotFound)
+        ));
+    }
+}
+
+#[test]
+fn full_rescan_reset_rejects_unknown_marker_phase_even_with_invalid_compat_fields() {
+    for state in [serde_json::json!("rewrite-v2"), serde_json::json!(7), serde_json::Value::Null] {
+        let marker = serde_json::json!({"state": state, "retry_count": "future-type", "schema_version": 99});
+        let err = super::cycle_state::decode_recovery_marker_for_reset(
+            &serde_json::to_vec(&marker).expect("future marker should encode"),
+            &DataUsageCacheRevision::Etag("intent-1".to_string()),
+        )
+        .expect_err("unknown persistent phases must remain fenced");
+        assert!(err.to_string().contains("state is unsupported"), "{err}");
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn full_rescan_reset_preserves_unknown_phase_and_retries_completed_cleanup() {
+    let (_temp_dir, store) = setup_scanner_cycle_store().await;
+    save_config(store.clone(), DATA_USAGE_BLOOM_NAME_PATH.as_str(), b"corrupt".to_vec())
+        .await
+        .expect("corrupt primary should persist");
+    save_config(
+        store.clone(),
+        DATA_USAGE_BLOOM_RECOVERY_PATH.as_str(),
+        br#"{"state":"future-rewrite"}"#.to_vec(),
+    )
+    .await
+    .expect("future marker should persist");
+    let primary_before = read_config_with_revision(store.clone(), DATA_USAGE_BLOOM_NAME_PATH.as_str())
+        .await
+        .expect("primary should load");
+    let marker_before = read_config_with_revision(store.clone(), DATA_USAGE_BLOOM_RECOVERY_PATH.as_str())
+        .await
+        .expect("marker should load");
+    let err = reset_scanner_cycle_recovery(CancellationToken::new(), store.clone())
+        .await
+        .expect_err("unknown phase must block explicit reset");
+    assert!(err.to_string().contains("state is unsupported"), "{err}");
+    assert_eq!(
+        read_config_with_revision(store.clone(), DATA_USAGE_BLOOM_NAME_PATH.as_str())
+            .await
+            .expect("primary should remain"),
+        primary_before
+    );
+    assert_eq!(
+        read_config_with_revision(store.clone(), DATA_USAGE_BLOOM_RECOVERY_PATH.as_str())
+            .await
+            .expect("marker should remain"),
+        marker_before
+    );
+
+    save_config(store.clone(), DATA_USAGE_BLOOM_RECOVERY_PATH.as_str(), b"{malformed".to_vec())
+        .await
+        .expect("recoverable marker should persist");
+    reset_scanner_cycle_recovery(CancellationToken::new(), store.clone())
+        .await
+        .expect("reset should complete");
+    let primary = read_config_with_revision(store.clone(), DATA_USAGE_BLOOM_NAME_PATH.as_str())
+        .await
+        .expect("rebuilt primary should load");
+    let usage = read_config_with_revision(store.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str())
+        .await
+        .expect("fenced usage should load");
+    reset_scanner_cycle_recovery(CancellationToken::new(), store.clone())
+        .await
+        .expect("retry after marker deletion should complete");
+    assert_eq!(
+        read_config_with_revision(store.clone(), DATA_USAGE_BLOOM_NAME_PATH.as_str())
+            .await
+            .expect("rebuilt primary should remain"),
+        primary
+    );
+    assert_eq!(
+        read_config_with_revision(store.clone(), DATA_USAGE_OBJ_NAME_PATH.as_str())
+            .await
+            .expect("fenced usage should remain"),
+        usage
     );
 }
 
@@ -4993,7 +5367,7 @@ async fn scanner_usage_state_reset_slots_defer_when_publication_epoch_moves() {
         .expect("usage reset slots should be inspected");
     store.publication_admission_blocked.store(true, Ordering::Release);
 
-    let err = reset_scanner_usage_state_slots_for_full_rebuild(store, &slots, 0, 3)
+    let err = reset_scanner_usage_state_slots_for_full_rebuild(store, &slots, 0, 3, || true)
         .await
         .expect_err("movement admission loss must defer reset");
     assert!(


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#2264 and rustfs/backlog#2240. Shared prerequisite: [dependency PR #7174](https://github.com/rustfs/rustfs/pull/7174).

## Summary of Changes

Make the existing scanner reset/cleanup steps reentrant using current markers and revision/epoch fences. Recheck ownership after publication admission and before each mutation. Reject syntactically valid but identity-less usage values as trusted recovery floors.

## Verification

- `cargo test -p rustfs-scanner --lib reset -j4`: 41 passed, 0 ignored.
- Covers admission-wait cancellation, each cleanup interruption, unknown phase, identity-less floor and retry preservation.
- `cargo fmt --all --check` and cumulative `git diff --check`: passed.

## Impact

Preserve existing marker encoding and v3 synchronous routes. No forced unlock or new background executor. Quota reservation and bucket-incarnation artifacts are outside the reset delete allowlist. Real process-crash, distributed lock-loss and mixed-version binary tests remain pending.

Two independent implementation reviews: Correctness/concurrency/durability and simplicity/compatibility/performance/test-coverage reviews found no unresolved issue after fixing the admission-wait ownership gap and untrusted floor classification.

## Additional Notes

This PR targets main so the repository PR CI runs. It includes the shared dependency commits until the prerequisite is merged; merge that PR first. The task-only change can be reviewed against the dependency branch. Delivery integrates main at 123967e729c74903a7f3d6dcc0a388736acd4f6c; the affected dependency/metadata checks were rerun. CI and formal PR approval are separate from local verification. Do not close the backlog task before its required evidence and merge are confirmed.
