### PR TITLE
docs: request concrete behavior evidence in pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,16 +10,16 @@ Use N/A when there is no related issue.
 
 ## Summary of Changes
 <!--
-Briefly explain what changed and why reviewers should accept it.
-Focus on behavior, compatibility, and review-relevant context.
+Describe the concrete problem and resulting behavior. For a behavior change, name the input or state that triggers it and the expected outcome. Explain any new dependency or abstraction that the change needs.
 -->
 
 ## Verification
 <!--
-List the commands or checks you ran, for example:
-- `make pre-commit`
+Give 1–3 concrete pieces of evidence for the changed behavior: the test or command, its observed result, and the regression it catches. For a bug fix, record a failing-before/passing-after check or explain why it was unavailable.
 
-Use N/A only when verification is not applicable.
+Identify the tested commit and any local changes. When testing a prebuilt binary or external service, include its source/version and artifact identity; a successful run against a different build is not evidence for this change.
+
+List relevant checks not run and the remaining risk. Use the validation tier in AGENTS.md; do not run broader checks solely to fill this section. For documentation-only changes, list the applicable documentation checks. Use N/A only when verification is not applicable.
 -->
 
 ## Impact


### PR DESCRIPTION
## Related Issues

Part of rustfs/backlog#2297.

## Summary of Changes

Ask PR authors for 1–3 concrete behavioral checks, their observed results, and the regression each detects. Record the tested commit or prebuilt artifact identity and any untested risk so reviewers can distinguish evidence for this change from a green run against another build.

Keep the existing template headings and use the repository's risk-based validation tier rather than prescribing broader checks.

## Verification

Documentation-only change at base `7ba5cd6888b367423357ef3e5211798c87bab3be`, with only the PR template comments modified. `git diff --check` and `./scripts/check_no_planning_docs.sh` passed. Inspected the final diff to confirm that all template headings are preserved.

Cargo formatting, compilation, Clippy, tests, and adversarial code validation were skipped under the documentation/instruction-only exemption.

## Impact

Changes the author guidance shown in new PR descriptions. No runtime, build, workflow, or test behavior changes. The template prompts do not replace enforced CI or independent review.

## Additional Notes

N/A
