### PR TITLE
fix(ci): route v1 listing test types through application bridge

### DIFF
--- a/rustfs/src/app/bucket_list_through.rs
+++ b/rustfs/src/app/bucket_list_through.rs
@@ -443,7 +443,9 @@ mod tests {
     use super::*;
     use crate::app::bucket_usecase::DefaultBucketUsecase;
     use crate::app::gating_test_env::{run_large_stack_test, shared_gating_ecstore};
-    use crate::app::storage_api::bucket_usecase::s3::{ListObjectsV2Input, ListObjectsV2Output, S3Request, S3Response};
+    use crate::app::storage_api::bucket_usecase::s3::{
+        ListObjectsInput, ListObjectsV2Input, ListObjectsV2Output, S3Request, S3Response, XmlSerialize, XmlSerializer,
+    };
     use crate::app::storage_api::test::StoragePutObjReader;
     use crate::app::storage_api::test::contract::bucket::{BucketOperations as _, MakeBucketOptions};
     use crate::app::storage_api::test::contract::object::ObjectIO as _;
@@ -451,7 +453,6 @@ mod tests {
         FilterConfig, MAX_LIST_NO_PROGRESS_PAGES, OnDemandMigrationConfig, PathStyle, PolicyConfig, Provider, SourceConfig,
         SourceCredentials, TlsConfig,
     };
-    use s3s::dto::ListObjectsInput;
     use std::time::Duration;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -864,7 +865,7 @@ mod tests {
                             assert_eq!(output.next_marker.as_deref(), (index == 0).then_some(expected_key));
 
                             let mut xml = Vec::new();
-                            s3s::xml::Serialize::serialize(&output, &mut s3s::xml::Serializer::new(&mut xml))
+                            XmlSerialize::serialize(&output, &mut XmlSerializer::new(&mut xml))
                                 .expect("serialize the real v1 response");
                             assert!(!xml.contains(&0), "XML 1.0 forbids NUL in NextMarker");
                             let mut reader = quick_xml::Reader::from_reader(xml.as_slice());

--- a/rustfs/src/app/storage_api.rs
+++ b/rustfs/src/app/storage_api.rs
@@ -28,11 +28,15 @@ pub(crate) fn EndpointServerPools(
 /// the direct s3s surface (s3s footprint ratchet, `scripts/check_s3s_footprint.sh`).
 pub(crate) mod s3 {
     #[cfg(test)]
+    pub(crate) use s3s::dto::ListObjectsInput;
+    #[cfg(test)]
     pub(crate) use s3s::dto::{
         BucketVersioningStatus, DeleteMarkerReplication, DeleteMarkerReplicationStatus, Destination, ListObjectsV2Input,
         ListObjectsV2Output, ReplicationConfiguration, ReplicationRule, ReplicationRuleFilter, ReplicationRuleStatus,
         ServerSideEncryptionByDefault, ServerSideEncryptionConfiguration, ServerSideEncryptionRule, Tag, VersioningConfiguration,
     };
+    #[cfg(test)]
+    pub(crate) use s3s::xml::{Serialize as XmlSerialize, Serializer as XmlSerializer};
     pub(crate) use s3s::{S3Error, S3ErrorCode, S3Result};
     #[cfg(test)]
     pub(crate) use s3s::{S3Request, S3Response};


### PR DESCRIPTION
## Related Issues
Follow-up to #7220 and #7226. Refs rustfs/backlog#2315.

## Summary of Changes
Route the v1 regression test's DTO and XML serializer imports through the existing application bridge. Direct imports added one file to the S3 dependency surface and stopped Quick Checks before compilation.

## Verification
The observed main-branch Quick Checks failure was the 214-file S3 footprint against the existing 213-file limit. `scripts/check_s3s_footprint.sh` now passes at 213 without changing its baseline. The changed Rust files are formatted and `git diff --check` passes. Static review confirms the same test types and serializer are used, with all assertions retained.

## Impact
Test imports only; no production behavior change. Remaining compilation and runtime checks continue on the integrated ODM tree.

## Additional Notes
No guard, allowance or test assertion was relaxed.
