### PR TITLE
fix(odm): compile relocated instance-bound backfill service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9503,6 +9503,7 @@ dependencies = [
  "clap",
  "const-str",
  "datafusion",
+ "faster-hex",
  "flatbuffers",
  "flate2",
  "futures",

--- a/crates/ecstore/src/bucket/metadata_sys.rs
+++ b/crates/ecstore/src/bucket/metadata_sys.rs
@@ -1043,11 +1043,8 @@ pub async fn get_on_demand_migration_config(bucket: &str) -> Result<Option<(Vec<
 }
 
 /// Resolve opaque configuration from the store's own metadata system.
-pub async fn get_on_demand_migration_config_in(
-    ctx: &crate::runtime::instance::InstanceContext,
-    bucket: &str,
-) -> Result<Option<(Vec<u8>, OffsetDateTime)>> {
-    let sys = bucket_metadata_sys_of(ctx)?;
+pub async fn get_on_demand_migration_config_in(api: &ECStore, bucket: &str) -> Result<Option<(Vec<u8>, OffsetDateTime)>> {
+    let sys = bucket_metadata_sys_of(&api.ctx)?;
     let lock = sys.read().await;
     lock.get_on_demand_migration_config(bucket).await
 }

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -353,6 +353,11 @@ async fn resume_rebalance_after_init(store: Arc<ECStore>, rx: CancellationToken)
 }
 
 impl ECStore {
+    /// Shutdown token owned by this store instance.
+    pub fn background_cancel_token(&self) -> Option<CancellationToken> {
+        self.ctx.background_cancel_token()
+    }
+
     /// Validate topology and process storage-class overrides before any disk is opened.
     pub fn validate_startup_storage_class(endpoint_pools: &EndpointServerPools) -> Result<()> {
         let drive_counts = startup_pool_drive_counts(endpoint_pools);

--- a/crates/madmin/src/on_demand_migration.rs
+++ b/crates/madmin/src/on_demand_migration.rs
@@ -17,7 +17,7 @@
 //! Wire types for `PUT`/`GET`/`DELETE /v3/on-demand-migration/{bucket}`,
 //! `GET .../status`, `POST .../backfill?op=start|cancel` and
 //! `GET .../backfill` (ODM-12), mirroring the server's config model
-//! (`crates/ecstore/src/bucket/on_demand_migration/config.rs`) and handler
+//! (`rustfs/src/on_demand_migration/config.rs`) and handler
 //! responses (`rustfs/src/admin/handlers/on_demand_migration.rs`). The SDK
 //! owns its own copies, madmin-go style; the fixtures under
 //! `fixtures/on_demand_migration/` are the contract both sides pin

--- a/rustfs/Cargo.toml
+++ b/rustfs/Cargo.toml
@@ -276,6 +276,7 @@ rcgen = { workspace = true }
 # Async Runtime and Networking
 async-trait = { workspace = true }
 axum.workspace = true
+faster-hex.workspace = true
 futures.workspace = true
 futures-lite.workspace = true
 futures-util.workspace = true

--- a/rustfs/src/on_demand_migration/backfill.rs
+++ b/rustfs/src/on_demand_migration/backfill.rs
@@ -471,7 +471,7 @@ impl BackfillContext for BucketBackfillContext {
 
     async fn config_updated_at(&self) -> Result<Option<OffsetDateTime>, StorageError> {
         Ok(
-            super::config::decode_stored_config(get_on_demand_migration_config_in(&self.api.ctx, self.state.bucket()).await?)?
+            super::config::decode_stored_config(get_on_demand_migration_config_in(&self.api, self.state.bucket()).await?)?
                 .map(|(_, updated_at)| updated_at),
         )
     }
@@ -1472,7 +1472,7 @@ impl Job {
 /// Spawns [`run_backfill_recovery_loop`] on the store's shutdown token;
 /// `false` (nothing spawned) when the store has no background token.
 pub fn spawn_backfill_recovery_loop(runner: Arc<BackfillRunner>) -> bool {
-    let Some(cancel) = runner.api.ctx.background_cancel_token() else {
+    let Some(cancel) = runner.api.background_cancel_token() else {
         return false;
     };
     tokio::spawn(run_backfill_recovery_loop(runner, cancel));


### PR DESCRIPTION
## Related Issues
Follow-up to #7226. Refs rustfs/backlog#2315.

## Summary of Changes
Keep relocated backfill tied to its own ECStore without accessing private context fields. The opaque configuration accessor now accepts the held store, and a narrow method exposes that instance's existing background cancellation token. Declare the existing faster-hex dependency used by the moved native response parser.

## Verification
The combined lib compile reported the private-field accesses and missing dependency. Formatting, platform-filtered Cargo metadata and diff checks pass. Static review confirms both accessors use the held instance rather than global state. The integrated test build is rerunning.

## Impact
No format or behavior change. Existing cancellation and per-instance configuration lookup are retained; the full context stays private.

## Additional Notes
Part of the post-merge compilation repair pass.
