### PR TITLE
fix(build): scope migration helpers to their features

### DIFF
--- a/rustfs/src/app/bucket_list_through.rs
+++ b/rustfs/src/app/bucket_list_through.rs
@@ -38,7 +38,6 @@ use crate::on_demand_migration::{
     SourceListRequest, SourceObject, SourcePage, decode_continuation_token, source_list_plan,
 };
 use futures::StreamExt;
-use http::HeaderMap;
 use rustfs_utils::http::{SUFFIX_SOURCE_PROXY_REQUEST, get_header};
 use std::sync::Arc;
 use std::time::Instant;
@@ -476,6 +475,7 @@ mod tests {
         FilterConfig, MAX_LIST_NO_PROGRESS_PAGES, OnDemandMigrationConfig, PathStyle, PolicyConfig, Provider, SourceConfig,
         SourceCredentials, TlsConfig,
     };
+    use http::HeaderMap;
     use std::time::Duration;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 

--- a/rustfs/src/on_demand_migration/native_http.rs
+++ b/rustfs/src/on_demand_migration/native_http.rs
@@ -133,6 +133,7 @@ impl NativeHttp {
         self.send_classified(request, error_code_header, false).await
     }
 
+    #[cfg(feature = "gcs")]
     pub(super) async fn send_object(
         &self,
         request: reqwest::Request,
@@ -210,6 +211,7 @@ pub(super) async fn read_text(response: reqwest::Response, max_bytes: usize) -> 
 /// Base64 digest (`Content-MD5`, `md5Hash`, `x-goog-hash`) as lowercase hex.
 /// `None` when the value is not a 16-byte digest, so a CRC32C never passes as
 /// an MD5.
+#[cfg(any(test, feature = "gcs"))]
 pub(super) fn base64_md5_to_hex(value: &str) -> Option<String> {
     let raw = base64_simd::STANDARD.decode_to_vec(value.trim().as_bytes()).ok()?;
     (raw.len() == 16).then(|| faster_hex::hex_string(&raw))


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#2315.

## Summary of Changes

Move the listing test's HeaderMap import into its test module. Compile the private GCS response helper only with GCS, and keep the MD5 decoder available for GCS and its unit tests. This resolves the unused-code warnings exposed by the migration changes and the build without Google dependencies.

## Verification

`cargo check -p rustfs --no-default-features --features ftps,webdav --lib` passed and exposed the three warnings addressed here. The same dependency graph contains zero Google SDK crates. `cargo fmt --all --check` and `git diff --check` pass on the final diff; final nextest and CI validation are ongoing.

## Impact

Existing callers retain the same behavior. The GCS-only response helper has no callers when that feature is disabled.

## Additional Notes

No lint suppression, baseline change or assertion change.
