### PR TITLE
test(odm): provide the source region in access fixture

### DIFF
--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -4034,7 +4034,7 @@ mod tests {
             let enabled_before = sys.is_module_enabled();
             sys.set_module_enabled(true);
             let bucket = format!("odm-capture-failure-{}", uuid::Uuid::new_v4());
-            let mut config: crate::on_demand_migration::OnDemandMigrationConfig = serde_json::from_str(r#"{"source":{"provider":"minio","endpoint":"https://source.example.com","bucket":"source","credentials":{"access_key":"test","secret_key":"test"}}}"#).expect("source config");
+            let mut config: crate::on_demand_migration::OnDemandMigrationConfig = serde_json::from_str(r#"{"source":{"provider":"minio","endpoint":"https://source.example.com","region":"us-east-1","bucket":"source","credentials":{"access_key":"test","secret_key":"test"}}}"#).expect("source config");
             config.policy.list_through = true;
             sys.apply_for_incarnation(&bucket, uuid::Uuid::new_v4(), Some(&config)).await;
             let mut get = build_request(


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#2315.

## Summary of Changes

Supply the required source region in the access regression fixture so the test reaches its intended local-hit and source-failure assertions.

## Verification

The preceding nextest run passed 252 cases and failed this fixture during JSON decoding, before its behavior assertions. Formatting and diff checks pass; the complete selected suite is rerunning with this corrected input and retries disabled.

## Impact

Test fixture only.

## Additional Notes

N/A
