### PR TITLE
test(odm): run multipart race on large stack

### DIFF
--- a/rustfs/src/app/object/on_demand_migration_put.rs
+++ b/rustfs/src/app/object/on_demand_migration_put.rs
@@ -692,9 +692,16 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test]
     #[serial_test::serial]
-    async fn write_back_multipart_completion_preserves_a_client_put_after_staging() {
+    fn write_back_multipart_completion_preserves_a_client_put_after_staging() {
+        crate::app::gating_test_env::run_large_stack_test(
+            "odm-write-back-multipart-client-put-race",
+            write_back_multipart_completion_preserves_a_client_put_after_staging_inner,
+        );
+    }
+
+    async fn write_back_multipart_completion_preserves_a_client_put_after_staging_inner() {
         let (store, bucket) = write_back_test_bucket("odm-mpu-race", false).await;
         let write_back = OnDemandMigrationWriteBack::new();
         let req = request(


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Run the multipart write-back race regression through the existing large-stack test harness. The default test thread overflows its stack in CI before the assertion completes.

## Verification

- Failing before: GitHub Actions jobs on PRs #7232 and #7167 aborted this test with a stack overflow.
- `cargo fmt --all --check`
- `cargo test -p rustfs write_back_multipart_completion_preserves_a_client_put_after_staging --lib -- --nocapture` — 1 passed.

## Impact

Test-only change. Runtime behavior and public APIs are unchanged.

## Additional Notes

Two independent reviews confirmed that the wrapper preserves the serial lock, current-thread runtime, panic propagation, complete scenario, and every assertion. The larger stack applies only to this test thread. Linux verification remains pending in main CI; this change does not establish production stack safety.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.

