### PR TITLE
ci(e2e): install network fault-injection tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -850,6 +850,11 @@ jobs:
           cache-save-if: 'false'
           install-build-packaging-tools: 'false'
 
+      - name: Install network fault-injection tools
+        run: |
+          sudo apt-get install -y iptables
+          sudo -n iptables --version
+
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

The full E2E gate fails to inject the endpoint blackhole on its custom runner because `iptables` is missing. Install it in that lane and verify it is available through the same non-interactive sudo path used by the test.

## Verification

- [The previous full E2E run](https://github.com/rustfs/rustfs/actions/runs/33986262998/job/101368530181) failed `test_cluster_root_heal_recovers_after_target_endpoint_blackhole` with `sudo: iptables: command not found`.
- `actionlint` and `git diff --check` passed on `2f8c0bd79`.
- The injection test will verify the Linux runner's network permissions in main CI. It was not run locally on macOS.

## Impact

Only the full E2E lane installs the package. Fault injection, cleanup, assertions, and test selection are unchanged.

## Additional Notes

The shared setup step already refreshes the apt package index. Other heal and tier failures from that run are being investigated separately.
