### PR TITLE
fix(ci): enable test utilities in migration gate

### DIFF
--- a/.config/migration-gate-floor.txt
+++ b/.config/migration-gate-floor.txt
@@ -1,10 +1,11 @@
 # Committed floor for the number of tests selected by the migration-critical
 # CI gate (see scripts/check_migration_gate_count.sh, backlog#1153 infra-12).
 #
-# The floor equals the exact count of rustfs-ecstore --lib tests matching the
-# gate filter (name substrings: data_movement, rebalance, decommission,
-# source_cleanup, delete_marker) at the time this file was last updated.
+# The floor equals the exact count of rustfs-ecstore --lib tests, with the
+# test-util feature enabled, matching the gate filter (name substrings:
+# data_movement, rebalance, decommission, source_cleanup, delete_marker) at
+# the time this file was last updated.
 # CI fails if the selected count drops below this number, so renames or
 # removals that thin the gate must update this file in the same PR.
 # Adding tests does not require a bump, but bumping keeps the guard tight.
-571
+946

--- a/scripts/check_migration_gate_count.sh
+++ b/scripts/check_migration_gate_count.sh
@@ -33,8 +33,11 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-# Single source of truth for the migration-gate filter. ci.yml must invoke
-# this script instead of inlining the expression.
+# Single source of truth for the migration-gate target and filter. The
+# test-util feature activates migration-critical tests that otherwise leave
+# their shared fixtures compiled but unused. ci.yml must invoke this script
+# instead of inlining either selection.
+MIGRATION_GATE_TARGET_ARGS=(-p rustfs-ecstore --lib --features test-util)
 MIGRATION_GATE_FILTER='test(data_movement) or test(rebalance) or test(decommission) or test(source_cleanup) or test(delete_marker)'
 FLOOR_FILE=".config/migration-gate-floor.txt"
 
@@ -60,7 +63,7 @@ if [[ "$mode" == "all" || "$mode" == "check" ]]; then
     # count to 0 and failing every PR). A nextest failure aborts via set -e
     # with its stderr visible; a JSON schema change makes jq fail loudly
     # rather than silently passing.
-    count="$(cargo nextest list -p rustfs-ecstore --lib -E "$MIGRATION_GATE_FILTER" --message-format json \
+    count="$(cargo nextest list "${MIGRATION_GATE_TARGET_ARGS[@]}" -E "$MIGRATION_GATE_FILTER" --message-format json \
         | jq '[."rust-suites"[].testcases[] | select(."filter-match".status == "matches")] | length')"
     if ! [[ "$count" =~ ^[0-9]+$ ]]; then
         echo "error: could not parse nextest JSON listing (got count: '$count')" >&2
@@ -81,5 +84,5 @@ if [[ "$mode" == "all" || "$mode" == "check" ]]; then
 fi
 
 if [[ "$mode" == "all" || "$mode" == "run" ]]; then
-    cargo nextest run -p rustfs-ecstore --lib -E "$MIGRATION_GATE_FILTER"
+    cargo nextest run "${MIGRATION_GATE_TARGET_ARGS[@]}" -E "$MIGRATION_GATE_FILTER"
 fi


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

When the focused migration gate compiled `rustfs-ecstore --lib` without `test-util`, feature-gated migration tests were absent while their shared fixtures were still compiled, producing 25 dead-code warnings and silently narrowing the gate. This change centralizes the package, target, and feature arguments, enables `test-util` for both test listing and execution, and raises the exact selected-test floor from 571 to 946.

## Verification

- Before the change, the reported `Test and Lint` job generated the same 25 `rustfs-ecstore` dead-code warnings twice because the gate runs both `nextest list` and `nextest run`.
- `./scripts/check_migration_gate_count.sh` on base `e2a921bc` plus this task diff completed with 946 tests passed, 4515 skipped, and no Rust source warnings.
- `bash -n scripts/check_migration_gate_count.sh`, `shellcheck scripts/check_migration_gate_count.sh`, and `git diff --check` passed on the final diff based on `081a8b61`.

The full gate was not repeated locally after the final fast-forward because the workspace disk had only 1.3 GiB free. The intervening main changes added no test names matching the migration filter, and PR CI will run the exact final script on Linux.

## Impact

No runtime, public API, deployment, configuration, or production artifact impact. CI now includes 62 additional feature-gated migration tests in the focused rerun, removes the existing warning noise, and may spend slightly longer in that step.

## Additional Notes

Rollback is a revert of this commit; no persisted state or compatibility migration is involved.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
