### PR TITLE
test(odm): use fixed-size Azure request chunks

### DIFF
--- a/rustfs/src/on_demand_migration/azure.rs
+++ b/rustfs/src/on_demand_migration/azure.rs
@@ -1074,7 +1074,7 @@ mod tests {
         }
         let recorded = recorded.lock().expect("recorder lock");
         assert_eq!(recorded.len(), 5);
-        for (requests, expected) in recorded[1..].chunks_exact(2).zip([
+        for (requests, expected) in recorded[1..].as_chunks::<2>().0.iter().zip([
             "/legacy/%EF%BF%BE/part%252F+%20&.txt",
             "/legacy/%25EF%25BF%25BE/part%25252F+%2520%2526.txt",
         ]) {


### PR DESCRIPTION
## Related Issues

Follow-up to #7251.

## Summary of Changes

The encoded-name Azure test trips `clippy::chunks_exact_to_as_chunks`, stopping all four Test and Lint jobs on main. Use fixed-size request pairs as suggested by Clippy; the five-request count and all HEAD/GET/path assertions stay the same.

## Verification

- `rustfmt --edition 2024 --check rustfs/src/on_demand_migration/azure.rs` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Checked that the two request pairs and all existing assertions are unchanged. Local Cargo was not run; compilation and Clippy remain for CI.

## Impact

Test code only. Production behavior is unchanged.

## Additional Notes

Original failure: [main CI](https://github.com/rustfs/rustfs/actions/runs/34008339213).
