### PR TITLE
fix(admin): compile metadata test helper only in tests

### DIFF
--- a/rustfs/src/admin/storage_api.rs
+++ b/rustfs/src/admin/storage_api.rs
@@ -314,6 +314,7 @@ pub(crate) mod metadata_sys {
         super::ecstore_bucket::metadata_sys::get(bucket).await
     }
 
+    #[cfg(test)]
     pub(crate) async fn update(bucket: &str, config_file: &str, data: Vec<u8>) -> Result<OffsetDateTime> {
         crate::storage::storage_api::update_bucket_metadata_config(bucket, config_file, data).await
     }


### PR DESCRIPTION
## Related Issues

Follow-up to #7262. Refs rustfs/backlog#2315.

## Summary of Changes

After ordinary target writes moved to metadata transactions, the admin `metadata_sys::update` forwarding function was used only by tests. A normal server build now reports it as dead code. Compile this test helper only for tests.

## Verification

- Audited all RustFS consumers, including aliases and optional-feature paths: the nine remaining calls are inside admin test modules. The app/storage and ECStore update functions remain unchanged.
- Independent mechanical review, file formatting, `git diff --check`, and `scripts/check_architecture_migration_rules.sh` passed at `7298f2c458de8d6ffaa4c1cad6b35eb39379566b`.
- No Cargo run on this one-line commit before merge; the shared CI follow-up will verify compilation. The warning was observed during the normal server build containing #7262.

## Impact

No runtime behavior changes. Unit tests retain the same helper; no lint allowance is added.

## Additional Notes

Part of the requested CI cleanup after merging the behavior fixes.
