### PR TITLE
fix(scanner): visit compacted subtrees during deep scans

### DIFF
--- a/crates/scanner/src/scanner_folder.rs
+++ b/crates/scanner/src/scanner_folder.rs
@@ -1828,7 +1828,12 @@ impl FolderScanner {
                         }
                     }
                     FolderScanSource::Existing => {
-                        if !forward_sweep && !into.compacted && self.old_cache.is_compacted(&h) {
+                        // Usage sampling is not proof that a Deep check ran.
+                        if self.scan_mode != HealScanMode::Deep
+                            && !forward_sweep
+                            && !into.compacted
+                            && self.old_cache.is_compacted(&h)
+                        {
                             let next_cycle = self.old_cache.info.next_cycle as u32;
                             if !h.mod_(next_cycle, data_usage_update_dir_cycles()) {
                                 // Transfer and add as child...

--- a/crates/scanner/src/scanner_folder/tests/checkpoint_fixture.rs
+++ b/crates/scanner/src/scanner_folder/tests/checkpoint_fixture.rs
@@ -20,6 +20,7 @@ use crate::{DataUsageCacheSource, DataUsageScanPlanDigest};
 use std::io::Cursor;
 use tokio::io::AsyncReadExt;
 
+mod deep_compacted;
 mod segment_observation;
 
 const CACHE_NAME: &str = "bucket/checkpoint-fixture.bin";

--- a/crates/scanner/src/scanner_folder/tests/checkpoint_fixture/deep_compacted.rs
+++ b/crates/scanner/src/scanner_folder/tests/checkpoint_fixture/deep_compacted.rs
@@ -1,0 +1,204 @@
+// Copyright 2026 RustFS Team
+// Licensed under the Apache License, Version 2.0.
+
+use super::*;
+
+const PREFIX: &str = "bucket/prefix";
+const OBJECTS: u64 = 4;
+
+struct CompactedFixture {
+    disk: Arc<Disk>,
+    root: std::path::PathBuf,
+    cache: DataUsageCache,
+    identity: crate::DataUsageScanIdentity,
+    store: Arc<FixtureStore>,
+    _cleanup: TestGuard,
+}
+
+async fn scan(
+    disk: &Arc<Disk>,
+    cache: DataUsageCache,
+    mode: HealScanMode,
+    max_objects: u64,
+) -> (ScannerDiskScanOutcome, Arc<ScannerCycleBudget>) {
+    let budget = ScannerCycleBudget::new_with_progress_tracking(
+        &CancellationToken::new(),
+        ScannerCycleBudgetConfig {
+            max_objects: Some(max_objects),
+            ..Default::default()
+        },
+    );
+    let outcome = disk
+        .clone()
+        .nsscanner_disk(budget.token(), budget.clone(), vec![disk.clone()], cache, None, mode)
+        .await
+        .expect("bounded real disk scan");
+    (outcome, budget)
+}
+
+async fn save_reload(store: &Arc<FixtureStore>, cache: &DataUsageCache) -> DataUsageCache {
+    let revisions = DataUsageCache::default()
+        .load_with_revisions(store.clone(), CACHE_NAME)
+        .await
+        .expect("fixture save revisions");
+    cache
+        .save_with_revisions_for_epoch(store.clone(), CACHE_NAME, &revisions, 0)
+        .await
+        .expect("save compacted checkpoint through real codec and revision checks");
+    let loaded = store.strict_load().await;
+    assert_eq!(loaded.info.snapshot_complete, cache.info.snapshot_complete);
+    assert_eq!(loaded.info.scan_checkpoint, cache.info.scan_checkpoint);
+    assert_eq!(loaded.info.scan_identity, cache.info.scan_identity);
+    assert_eq!(loaded.info.scan_plan_digest, cache.info.scan_plan_digest);
+    assert_eq!(
+        loaded.checked_flatten("bucket").expect("reloaded root").size,
+        cache.checked_flatten("bucket").expect("returned root").size
+    );
+    loaded
+}
+
+impl CompactedFixture {
+    async fn new(mode: HealScanMode) -> Self {
+        let (scanner, root) = build_test_scanner().await;
+        let cleanup = TestGuard {
+            temp_dir: Some(root.clone()),
+        };
+        for index in 0..OBJECTS {
+            write_checkpoint_object(&root, &format!("prefix/{index:04}"), &[(None, 1)]).await;
+        }
+        let identity = crate::DataUsageScanIdentity {
+            scan_mode: mode,
+            tier_registry_generation: crate::runtime_tier_registry_for_cycle(11, 7).await.generation,
+            ..bound_checkpoint().1
+        };
+        let mut cache = DataUsageCache::default();
+        // The first real scan builds coverage; the second same-plan scan takes
+        // the normal compaction path. No synthetic compacted cache is injected.
+        for cycle in [11, 12] {
+            cache.prepare_bucket_checkpoint("bucket", cycle, 7, SOURCE, PLAN, identity);
+            cache.info.skip_healing = true;
+            let (outcome, budget) = scan(&scanner.local_disk, cache, mode, OBJECTS + 1).await;
+            let ScannerDiskScanOutcome::Complete(completed) = outcome else {
+                panic!("fixture baseline must complete")
+            };
+            assert_eq!(budget.progress().0, OBJECTS, "baseline must read every metadata object");
+            cache = completed;
+        }
+        let store = FixtureStore::new();
+        cache = save_reload(&store, &cache).await;
+        assert!(cache.find(PREFIX).expect("baseline prefix").compacted);
+        assert_eq!(cache.checked_flatten("bucket").expect("complete baseline").size, 4);
+        assert!(cache.info.scan_progress.is_none());
+        Self {
+            disk: scanner.local_disk,
+            root,
+            cache,
+            identity,
+            store,
+            _cleanup: cleanup,
+        }
+    }
+
+    fn next_cycle(&self, sampled: bool) -> u64 {
+        let first = self.cache.info.next_cycle + 1;
+        (first..first + 16)
+            .find(|cycle| hash_path(PREFIX).mod_(u32::try_from(*cycle).expect("bounded cycle"), 16) == sampled)
+            .expect("one selected cycle and non-selected cycles exist within the fixed rotation")
+    }
+
+    fn prepare(&mut self, cycle: u64) {
+        let state = crate::scanner_io::current_cache_root_or_prepare_with_generation(
+            &mut self.cache,
+            "bucket",
+            SOURCE,
+            cycle,
+            7,
+            PLAN,
+            crate::scanner_io::DataUsageCacheReuseOptions {
+                checkpoint_identity: Some(self.identity),
+                ..Default::default()
+            },
+        );
+        assert!(matches!(state, crate::scanner_io::DataUsageCacheScanState::Prepared { .. }));
+        assert_eq!(self.cache.info.scan_identity, Some(self.identity));
+        assert_eq!(self.cache.info.scan_plan_digest, Some(PLAN));
+        assert!(
+            self.cache.info.scan_progress.is_none(),
+            "same-strength complete baseline uses the existing tree"
+        );
+        assert!(self.cache.find(PREFIX).expect("prepared prefix").compacted);
+    }
+
+    async fn change_metadata_without_activity_event(&self) {
+        // This models a local metadata change not announced by a segment
+        // producer. Deep traversal must not depend on a usage-clean signal.
+        // Healing is disabled: the oracle proves metadata re-entry, not repair.
+        write_checkpoint_object(&self.root, "prefix/0000", &[(None, 7)]).await;
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn deep_compacted_same_plan_rechecks_unsampled_prefix() {
+    temp_env::async_with_vars([(ENV_DATA_USAGE_UPDATE_DIR_CYCLES, Some("16"))], async {
+        let mut fixture = CompactedFixture::new(HealScanMode::Deep).await;
+        fixture.change_metadata_without_activity_event().await;
+        fixture.prepare(fixture.next_cycle(false));
+        let (outcome, budget) = scan(&fixture.disk, fixture.cache.clone(), HealScanMode::Deep, OBJECTS + 1).await;
+        assert_eq!(
+            budget.progress().0,
+            OBJECTS,
+            "Deep must inspect compacted children even outside the usage sample cycle"
+        );
+        let ScannerDiskScanOutcome::Complete(cache) = outcome else {
+            panic!("bounded Deep scan must complete")
+        };
+        let loaded = save_reload(&fixture.store, &cache).await;
+        let root = loaded.checked_flatten("bucket").expect("Deep scan root");
+        assert_eq!((root.objects, root.size), (4, 10), "Deep must observe the changed metadata");
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn deep_compacted_normal_scan_preserves_periodic_sampling() {
+    temp_env::async_with_vars([(ENV_DATA_USAGE_UPDATE_DIR_CYCLES, Some("16"))], async {
+        let mut fixture = CompactedFixture::new(HealScanMode::Normal).await;
+        fixture.change_metadata_without_activity_event().await;
+        fixture.prepare(fixture.next_cycle(false));
+        let (outcome, budget) = scan(&fixture.disk, fixture.cache.clone(), HealScanMode::Normal, OBJECTS + 1).await;
+        assert_eq!(budget.progress().0, 0, "Normal retains its existing unsampled-subtree policy");
+        let ScannerDiskScanOutcome::Complete(cache) = outcome else { panic!("normal sampling completes") };
+        assert_eq!(cache.checked_flatten("bucket").expect("sampled root").size, 4);
+        fixture.cache = save_reload(&fixture.store, &cache).await;
+        fixture.prepare(fixture.next_cycle(true));
+        let (outcome, budget) = scan(&fixture.disk, fixture.cache.clone(), HealScanMode::Normal, OBJECTS + 1).await;
+        assert_eq!(budget.progress().0, OBJECTS);
+        let ScannerDiskScanOutcome::Complete(cache) = outcome else {
+            panic!("selected Normal rotation completes")
+        };
+        assert_eq!(cache.checked_flatten("bucket").expect("refreshed root").size, 10);
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn deep_compacted_budget_preserves_partial_checkpoint() {
+    temp_env::async_with_vars([(ENV_DATA_USAGE_UPDATE_DIR_CYCLES, Some("16"))], async {
+        let mut fixture = CompactedFixture::new(HealScanMode::Deep).await;
+        fixture.prepare(fixture.next_cycle(false));
+        let (outcome, budget) = scan(&fixture.disk, fixture.cache.clone(), HealScanMode::Deep, 2).await;
+        assert_eq!(budget.progress().0, 2);
+        assert_eq!(budget.reason(), Some(ScannerCycleBudgetReason::Objects));
+        let ScannerDiskScanOutcome::Partial(cache) = outcome else {
+            panic!("Deep must retain budget interruption as partial")
+        };
+        assert!(!cache.info.snapshot_complete);
+        let loaded = save_reload(&fixture.store, &cache).await;
+        assert!(!loaded.info.snapshot_complete);
+        assert!(loaded.checked_flatten("bucket").expect("partial root").objects > 0);
+    })
+    .await;
+}


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#2280 and rustfs/backlog#2240. This fixes a Deep-scan fallback defect within W24; it does not activate segment reuse or close its producer, durable-gap, identity and deployment-performance gates.

## Summary of Changes

An existing compacted subtree could be copied without traversal when its usage-sampling rotation was not selected, even during a Deep scan. This remains reachable after a complete Deep snapshot is reused for a later cycle with the same plan and scan identity: the stable-plan prepare path retains the tree without starting a coverage sweep.

Exclude Deep scans from that usage-sampling branch. Deep continues into the existing traversal and object-budget paths, while Normal retains its periodic sampling behavior. Validated partial-sweep resume logic is unchanged. No new selector, segment capability, cache format, dependency or shared scheduling API is introduced.

## Verification

### Latest Main Integration

Final head: `8fdfe1eaa78a661864db6c3f8f83bd04f16329f3`, one functional commit directly above main `d7b7d1835ff94a014f45f1709e90b9d9301f3928`. The complete tree is identical to the remote main-merge head `94ba96b0b1b56c896ed233754737c22677c6ab30`. Prior branches and backups were retained, and the update used an explicit expected-head lease.

All task-owned files, the complete crates tree, and Cargo files are byte-identical to `cdfaca169f05cfcbd79c22fb4d44ae9b532c6b0f`. The only upstream differences are five unrelated server/configuration/documentation files. Two independent reviewers verified the complete integration and retained the earlier scoped verdicts. Final formatting and diff checks passed. No Cargo test group was rerun merely for this history/mainline integration; the exact tested-head and evidence-reuse boundaries below remain in effect.

[Combined batch validation](https://github.com/rustfs/backlog/issues/2269#issuecomment-5557998944) is separately bound to combined head `d69ac1599` on the earlier main: Heal 20 tests passed cleanly; Scanner 23 assertions passed but two cases received LEAK labels. A same-configuration two-case recheck passed cleanly, but the initial cause remains unresolved. This is not an all-green combined release gate, distributed result, or a fresh run of the latest main.

The original CI scoped-maintenance failure also has an [evidence-backed W04 follow-up](https://github.com/rustfs/backlog/issues/2270#issuecomment-5557969907): one exact-head and one baseline check passed locally without reproducing the CI failure. No assertion, retry or stack policy was weakened.

### Earlier Focused Evidence


Verified the final source tree, committed unchanged as `cdfaca169f05cfcbd79c22fb4d44ae9b532c6b0f` over `1dddf357cda5ba5072068d8532895665936fb231`. Commands used `RUST_MIN_STACK=4194304`, localhost proxy bypass and `-j4`.

1. `cargo test -p rustfs-scanner --lib deep_compacted -j4 -- --nocapture`: the RED run used unmodified production code at main `1dddf357cda5ba5072068d8532895665936fb231` plus the regression fixtures only. `deep_compacted_same_plan_rechecks_unsampled_prefix` failed with zero inspected objects instead of four; `deep_compacted_budget_preserves_partial_checkpoint` failed with zero instead of two; `deep_compacted_normal_scan_preserves_periodic_sampling` passed. After the guard change, all three passed with zero ignored tests. Each fixture builds and compacts its baseline through two real `nsscanner_disk` calls, saves/reloads it, and selects a later non-sampled cycle without changing its plan or scan strength. The metadata-change oracle requires Deep to read all four objects and observe the updated aggregate; the two-object budget oracle requires a saved partial checkpoint, not false completion.
2. `cargo test -p rustfs-scanner --lib checkpoint_fixture_complete_sampling_partial_resumes_with_fixed_budget -j4 -- --nocapture` and `cargo test -p rustfs-scanner --lib checkpoint_fixture_normal_partial_reenters_prefix_for_deep_scan -j4 -- --nocapture`: one test passed per command. These retain the existing fixed-budget recovery and Normal-to-Deep identity coverage.
3. `cargo fmt --all --check` and `git diff --check` passed. Five unique focused tests passed in total.

The fixtures use valid local `xl.meta` metadata and the real scanner/cache codec with a bounded two-file revision-checking backend. They disable healing side effects, so the evidence proves Deep metadata re-entry and accounting, not actual bitrot repair, S3 body durability, distributed RPC or EC quorum persistence. Every fixture scan has an object budget; there is no final unbudgeted sweep.

## Impact

Deep scans now traverse compacted subtrees even when ordinary usage sampling would skip them. This intentionally increases work relative to the erroneous zero-inspection path; no performance improvement is claimed. Existing budget cancellation, partial checkpoints and pacing remain in force. The Normal control also verifies that a later selected rotation still observes the updated metadata.

The change is limited to one production condition and its dedicated tests. There are no wire/disk-format or deployment-configuration changes. Segment producer coverage, durable per-segment gap detection and identity, full invalidation matrices, release ABBA and front-end performance protection remain unverified, so segment reuse remains inactive and W24 remains open.

## Additional Notes

Two independent final-diff reviews passed on `cdfaca169f05cfcbd79c22fb4d44ae9b532c6b0f`, with no unresolved findings. Correctness/test coverage: real metadata re-entry, Normal positive controls and persisted Partial assertions cover the changed branch. Concurrency/durability: no new lock, await, commit or format path; existing scoped-frontier resume and budget cancellation remain intact. Compatibility/simplicity: Normal sampling and its heal divisor remain unchanged, with one local condition rather than another reuse mechanism. Performance: Deep performs the previously skipped work under existing budgets; no measured I/O or p99 improvement is claimed.

Parallel changes to the scanner's unrelated retry-ledger fields are not included here; their combined validation remains separate. Reverting this isolated guard needs no data migration, but would restore the Deep inspection gap and is not a correctness fix.

