### PR TITLE
test(odm): bypass loopback proxies in native list fixtures

### DIFF
--- a/rustfs/src/app/bucket_list_through.rs
+++ b/rustfs/src/app/bucket_list_through.rs
@@ -1010,10 +1010,11 @@ mod tests {
     #[serial_test::serial]
     fn native_list_through_malformed_fields_follow_both_source_policies() {
         run_large_stack_test("native-list-through-fields", || async {
+            // The proxy matcher treats IP literals separately from the `*` domain wildcard.
             temp_env::async_with_vars(
                 [("RUSTFS_REPLICATION_ALLOW_LOOPBACK_TARGET", Some("true")), ("HTTP_PROXY", None), ("HTTPS_PROXY", None),
                  ("ALL_PROXY", None), ("http_proxy", None), ("https_proxy", None), ("all_proxy", None),
-                 ("NO_PROXY", Some("*")), ("no_proxy", Some("*"))],
+                 ("NO_PROXY", Some("127.0.0.1,localhost,::1")), ("no_proxy", Some("127.0.0.1,localhost,::1"))],
                 async {
                     #[cfg(feature = "gcs")]
                     let service_account = native_test_service_account();
@@ -1068,6 +1069,7 @@ mod tests {
     #[serial_test::serial]
     fn native_list_through_preserves_valid_empty_pages_and_zero_size_objects() {
         run_large_stack_test("native-list-through-valid", || async {
+            // The proxy matcher treats IP literals separately from the `*` domain wildcard.
             temp_env::async_with_vars(
                 [
                     ("RUSTFS_REPLICATION_ALLOW_LOOPBACK_TARGET", Some("true")),
@@ -1077,8 +1079,8 @@ mod tests {
                     ("http_proxy", None),
                     ("https_proxy", None),
                     ("all_proxy", None),
-                    ("NO_PROXY", Some("*")),
-                    ("no_proxy", Some("*")),
+                    ("NO_PROXY", Some("127.0.0.1,localhost,::1")),
+                    ("no_proxy", Some("127.0.0.1,localhost,::1")),
                 ],
                 async {
                     #[cfg(feature = "gcs")]


### PR DESCRIPTION
## Related Issues

Refs #7238 and rustfs/backlog#2315.

## Summary of Changes

The two native LIST handler fixtures can be sent through a macOS system proxy even after clearing proxy environment variables. In the locked HTTP dependency, the wildcard in NO_PROXY matches domain names but does not match IP addresses. Explicitly exclude the loopback addresses used by these fixtures.

## Verification

- Both tests failed before this change with SourceUnavailable/throttled and unconsumed fixture requests, including when all proxy variables were cleared at process launch. After the change both passed, including Azure and GCS scenarios, in the 155-test integrated run at 0952f964f with zero retries. That run selected all `app::bucket_list_through::tests::` tests and related merger, provider and target-repair tests using `cargo nextest run -p rustfs --lib`.
- `cargo fmt --all --check` and `git diff --check` passed. Independent review checked the locked reqwest 0.13.4/hyper-util 0.1.20 proxy path and confirmed this diff only changes the two fixture environments and explanatory comments.

`cargo clippy -p rustfs --lib --tests -- -D warnings` also passed on the integrated 0952f964f source.

## Impact

Test-only. Production proxy configuration, signing, requests and all test assertions remain unchanged. These local fixtures do not constitute acceptance against real Azure or GCS accounts.

## Additional Notes

The integrated run also contains the separately submitted disabled-pagination fix and target-test future boxing. Native source client behavior is unchanged.
