### PR TITLE
test(admin): validate repair futures with the default stack

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -69,7 +69,7 @@ filter = 'package(rustfs-ecstore) & test(/^(bucket::lifecycle::bucket_lifecycle_
 setup = 'ecstore-large-stack'
 
 [[profile.default.scripts]]
-filter = 'package(rustfs-ecstore) | package(rustfs-s3select-api) | package(rustfs-scanner) | (package(rustfs) & test(/^(admin::handlers::replication::target_repair_tests::.*|app::multipart_usecase::tests::concurrent_completions_share_durable_bucket_quota_reservations|app::object::delete::tests::compressed_delete_requests_update_observed_usage_without_releasing_quota_floor|app::object::internal_put::tests::internal_multipart_roundtrip_completes_and_abort_leaves_nothing|app::object::restore::tests::execute_restore_object_maps_failures_to_typed_s3_errors|storage::access::tests::(delete_object_access_captures_authorized_bucket_incarnation|copy_operations_reject_recreated_source_bucket_after_authorization|request_slot_keeps_bucket_policy_bound_to_its_store))$/))'
+filter = 'package(rustfs-ecstore) | package(rustfs-s3select-api) | package(rustfs-scanner) | (package(rustfs) & test(/^(app::multipart_usecase::tests::concurrent_completions_share_durable_bucket_quota_reservations|app::object::delete::tests::compressed_delete_requests_update_observed_usage_without_releasing_quota_floor|app::object::internal_put::tests::internal_multipart_roundtrip_completes_and_abort_leaves_nothing|app::object::restore::tests::execute_restore_object_maps_failures_to_typed_s3_errors|storage::access::tests::(delete_object_access_captures_authorized_bucket_incarnation|copy_operations_reject_recreated_source_bucket_after_authorization|request_slot_keeps_bucket_policy_bound_to_its_store))$/))'
 setup = 'ecstore-base-stack'
 
 [[profile.default.scripts]]
@@ -217,7 +217,7 @@ filter = 'package(rustfs-ecstore) & test(/^(bucket::lifecycle::bucket_lifecycle_
 setup = 'ecstore-large-stack'
 
 [[profile.ci.scripts]]
-filter = 'package(rustfs-ecstore) | package(rustfs-s3select-api) | package(rustfs-scanner) | (package(rustfs) & test(/^(admin::handlers::replication::target_repair_tests::.*|app::multipart_usecase::tests::concurrent_completions_share_durable_bucket_quota_reservations|app::object::delete::tests::compressed_delete_requests_update_observed_usage_without_releasing_quota_floor|app::object::internal_put::tests::internal_multipart_roundtrip_completes_and_abort_leaves_nothing|app::object::restore::tests::execute_restore_object_maps_failures_to_typed_s3_errors|storage::access::tests::(delete_object_access_captures_authorized_bucket_incarnation|copy_operations_reject_recreated_source_bucket_after_authorization|request_slot_keeps_bucket_policy_bound_to_its_store))$/))'
+filter = 'package(rustfs-ecstore) | package(rustfs-s3select-api) | package(rustfs-scanner) | (package(rustfs) & test(/^(app::multipart_usecase::tests::concurrent_completions_share_durable_bucket_quota_reservations|app::object::delete::tests::compressed_delete_requests_update_observed_usage_without_releasing_quota_floor|app::object::internal_put::tests::internal_multipart_roundtrip_completes_and_abort_leaves_nothing|app::object::restore::tests::execute_restore_object_maps_failures_to_typed_s3_errors|storage::access::tests::(delete_object_access_captures_authorized_bucket_incarnation|copy_operations_reject_recreated_source_bucket_after_authorization|request_slot_keeps_bucket_policy_bound_to_its_store))$/))'
 setup = 'ecstore-base-stack'
 
 [[profile.ci.scripts]]


### PR DESCRIPTION
## Related Issues

Refs #7272 and #7277.

## Summary of Changes

#7277 boxes the three repair scenarios that overflowed on Linux. #7272 subsequently increased the stack for the entire repair test module, so a green run would no longer show whether the smaller futures solve the original failure.

Remove only those two new module-wide stack selectors from the default and CI profiles. Keep every existing stack rule for other tests. This restores the exact configuration used by the passing integrated tests and lets Linux verify the boxed scenarios with the original stack.

## Verification

- The complete resulting source tree is identical to main a40ec8a6, before #7272. The restored configuration was already used by the integrated 0952f964f run: 155/155 tests passed with zero retries, including all 18 repair tests. `cargo clippy -p rustfs --lib --tests -- -D warnings` passed on the same integrated source. These were macOS checks, not Linux confirmation.
- `cargo nextest show-config version --profile ci`, `cargo nextest show-config version --profile default` and `git diff --check` passed. No test membership, assertion, retry or timeout changes.
- The a40ec8a6 Linux run was canceled before the repair tests ran. The independent Linux run below uses the restored stack configuration.

Linux verification at d7b7d1835 in [run 34019914704](https://github.com/rustfs/rustfs/actions/runs/34019914704): [Swift](https://github.com/rustfs/rustfs/actions/runs/34019914704/job/101451145426) passed 5134/5134 tests (58 skipped); [SFTP](https://github.com/rustfs/rustfs/actions/runs/34019914704/job/101451145428) passed 4934/4934 (40 skipped). Both Clippy checks passed, with no test retries or SIGABRT. All three formerly overflowing repair scenarios directly passed with the original stack; the module-wide stack override from #7272 was removed by #7280. Other jobs in the workflow are still running.

## Impact

Test configuration only. The repair tests again use the original libtest stack. The production implementation and the three boxed futures remain unchanged.

## Additional Notes

If a boxed scenario still overflows, retain that failure and investigate its future layout instead of increasing the whole module's stack.
