### PR TITLE
fix(admin): preserve decommission readiness error

### DIFF
--- a/crates/ecstore/src/api/mod.rs
+++ b/crates/ecstore/src/api/mod.rs
@@ -293,7 +293,7 @@ pub mod cache {
 pub mod capacity {
     pub use crate::core::pools::{
         DecommissionUnresolvedEntry, PoolDecommissionInfo, PoolStatus, get_total_usable_capacity, get_total_usable_capacity_free,
-        path2_bucket_object, path2_bucket_object_with_base_path,
+        is_pool_activation_fleet_proof_error, path2_bucket_object, path2_bucket_object_with_base_path,
     };
     pub use crate::store::utils::is_reserved_or_invalid_bucket;
 }

--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -3385,7 +3385,7 @@ pub(crate) async fn acquire_pool_activation_fleet_proof(
         .ok_or_else(|| Error::other(POOL_ACTIVATION_FLEET_PROOF_REQUIRED))
 }
 
-pub(crate) fn is_pool_activation_fleet_proof_error(err: &Error) -> bool {
+pub fn is_pool_activation_fleet_proof_error(err: &Error) -> bool {
     // Save-stage helpers add context by formatting the original error, so the
     // marker may be nested in the display string. Restrict matching to the
     // `Error::other` I/O shape used by this activation path.

--- a/rustfs/src/admin/handlers/pools.rs
+++ b/rustfs/src/admin/handlers/pools.rs
@@ -63,6 +63,7 @@ const EVENT_ADMIN_REQUEST_STATE: &str = "admin_request_state";
 const EVENT_ADMIN_REQUEST_REJECTED: &str = "admin_request_rejected";
 const EVENT_ADMIN_REQUEST_FAILED: &str = "admin_request_failed";
 const EVENT_ADMIN_RESPONSE_EMITTED: &str = "admin_response_emitted";
+const POOL_ACTIVATION_FLEET_PROOF_REQUIRED: &str = "pool activation requires a live fleet capability proof";
 
 fn admin_request_id(headers: &HeaderMap) -> Option<&str> {
     headers
@@ -319,6 +320,17 @@ fn contextualize_admin_pool_api_error(
         message: format!("admin {operation} failed for {pool_context}: {}", err.message),
         source: err.source,
     }
+}
+
+fn decommission_start_api_error(err: crate::storage_api::error::StorageError) -> ApiError {
+    if crate::storage_api::capacity::is_pool_activation_fleet_proof_error(&err) {
+        return ApiError {
+            code: S3ErrorCode::InternalError,
+            message: POOL_ACTIVATION_FLEET_PROOF_REQUIRED.to_string(),
+            source: Some(Box::new(err)),
+        };
+    }
+    ApiError::from(err)
 }
 
 fn decommission_admin_not_initialized_error_with_audit(operation: &str, audit: PoolAuditContext<'_>) -> S3Error {
@@ -790,7 +802,24 @@ impl Operation for StartDecommission {
                 store
                     .decommission(ctx.clone(), pools_indices.clone())
                     .await
-                    .map_err(ApiError::from)
+                    .map_err(|err| {
+                        error!(
+                            event = EVENT_ADMIN_REQUEST_FAILED,
+                            component = LOG_COMPONENT_ADMIN_API,
+                            subsystem = LOG_SUBSYSTEM_POOL_ADMIN,
+                            operation = "start_decommission",
+                            action = "start_decommission",
+                            result = "failed",
+                            reason = "storage_decommission_failed",
+                            request_id = %request_id,
+                            actor = %actor,
+                            remote_addr = %remote_addr,
+                            pool_indices = ?pools_indices,
+                            error = %err,
+                            "admin request failed"
+                        );
+                        decommission_start_api_error(err)
+                    })
                     .map_err(|err| contextualize_admin_pool_api_error(err, "start decommission", &pool_context))?;
             }
         }
@@ -1018,9 +1047,10 @@ impl Operation for ClearDecommission {
 #[cfg(test)]
 mod pools_handler_tests {
     use super::{
-        AdminPoolStatus, Body, CancelDecommission, ClearDecommission, HeaderMap, ListPools, Method, Operation, Params,
-        PoolAuditContext, S3ErrorCode, S3Request, StartDecommission, StatusDecommission, StatusPool, Uri,
-        contextualize_admin_pool_api_error, decommission_admin_not_initialized_error_with_audit, decommission_peer_target,
+        AdminPoolStatus, Body, CancelDecommission, ClearDecommission, HeaderMap, ListPools, Method, Operation,
+        POOL_ACTIVATION_FLEET_PROOF_REQUIRED, Params, PoolAuditContext, S3ErrorCode, S3Request, StartDecommission,
+        StatusDecommission, StatusPool, Uri, contextualize_admin_pool_api_error,
+        decommission_admin_not_initialized_error_with_audit, decommission_peer_target, decommission_start_api_error,
         has_duplicate_indices, parse_mutation_pool_query, parse_pool_idx_by_id, parse_status_pool_query,
         pool_admin_missing_credentials_error, pool_admin_missing_credentials_error_with_request,
         pool_admin_pool_index_error_with_audit, pool_admin_pool_not_found_error_with_audit,
@@ -1207,6 +1237,21 @@ mod pools_handler_tests {
             err.message,
             "admin start decommission failed for pools [1, 3]: decommission already running"
         );
+    }
+
+    #[test]
+    fn test_decommission_start_api_error_preserves_fleet_proof_retry_marker() {
+        let err = crate::storage_api::error::StorageError::other(POOL_ACTIVATION_FLEET_PROOF_REQUIRED);
+
+        let err = decommission_start_api_error(err);
+
+        assert_eq!(err.code, s3s::S3ErrorCode::InternalError);
+        assert_eq!(err.message, POOL_ACTIVATION_FLEET_PROOF_REQUIRED);
+        assert!(err.source.is_some());
+
+        let unrelated = decommission_start_api_error(crate::storage_api::error::StorageError::other("disk read failed"));
+        assert_eq!(unrelated.code, s3s::S3ErrorCode::InternalError);
+        assert_eq!(unrelated.message, "We encountered an internal error, please try again.");
     }
 
     #[test]

--- a/rustfs/src/storage/storage_api.rs
+++ b/rustfs/src/storage/storage_api.rs
@@ -417,7 +417,7 @@ pub(crate) mod ecstore_bucket {
 pub(crate) mod ecstore_capacity {
     pub(crate) use rustfs_ecstore::api::capacity::{
         DecommissionUnresolvedEntry, PoolDecommissionInfo, PoolStatus, get_total_usable_capacity, get_total_usable_capacity_free,
-        is_reserved_or_invalid_bucket,
+        is_pool_activation_fleet_proof_error, is_reserved_or_invalid_bucket,
     };
 }
 

--- a/rustfs/src/storage_api.rs
+++ b/rustfs/src/storage_api.rs
@@ -18,6 +18,8 @@
 use rustfs_storage_api as storage_contracts;
 
 pub(crate) mod capacity {
+    pub(crate) use crate::storage::storage_api::ecstore_capacity::is_pool_activation_fleet_proof_error;
+
     pub(crate) mod service {
         pub(crate) use crate::storage::storage_api::{all_local_disk, disk_drive_path, disk_endpoint};
     }


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Preserve the existing fail-closed pool activation behavior while exposing the specific fleet capability proof readiness marker from the decommission start endpoint. This lets distributed clients retry the temporary readiness window without leaking unrelated storage I/O errors. Add a structured admin failure event and focused regression coverage for the classifier and API mapping.

## Verification

- `cargo test -p rustfs admin::handlers::pools::pools_handler_tests::test_decommission_start_api_error_preserves_fleet_proof_retry_marker` — passed on the final diff before the no-conflict rebase; verifies the safe retry marker and retained source error.
- `cargo test -p rustfs-ecstore pool_activation_fleet_proof_error_classifier_matches_only_retryable_proof_failures` — passed on the final diff before the no-conflict rebase; verifies only the two fleet-proof readiness errors are classified.
- `./scripts/check_logging_guardrails.sh` and `git diff --check` — passed. The real distributed rerun is pending because the workflow is currently disabled manually.

## Impact

Decommission start may return the existing `InternalError` code with a specific readiness message while the live fleet capability proof is unavailable. No activation is allowed without the proof, and unrelated I/O errors retain the generic response.

## Additional Notes

The distributed workflow run for this head was cancelled during setup when the workflow was disabled manually. Merge should wait for a successful real distributed run after the workflow is restored.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
