### PR TITLE
chore(deps): refresh concurrency and protocol dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,18 +2527,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+checksum = "98b0cc327b5bc766e7fda9c9260cc0fa81b43a8e240440422dff70788e3f9ef1"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -2546,27 +2546,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+checksum = "03e8bd762f7479489c70ed6c768ddca99d7296857de437a68dcb2a94365b3fae"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crunchy"
@@ -3673,9 +3673,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
 dependencies = [
  "const-oid 0.10.2",
  "pem-rfc7468 1.0.0",
@@ -3946,7 +3946,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4090,7 +4090,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
- "der 0.8.1",
+ "der 0.8.2",
  "digest 0.11.3",
  "elliptic-curve 0.14.1",
  "rfc6979 0.6.0",
@@ -4295,7 +4295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5693,7 +5693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5734,9 +5734,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 dependencies = [
  "serde",
 ]
@@ -5758,7 +5758,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6955,7 +6955,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7933,7 +7933,7 @@ version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
 dependencies = [
- "der 0.8.1",
+ "der 0.8.2",
  "spki 0.8.0",
 ]
 
@@ -7976,7 +7976,7 @@ dependencies = [
  "aes 0.9.3",
  "aes-gcm",
  "cbc 0.2.1",
- "der 0.8.1",
+ "der 0.8.2",
  "pbkdf2 0.13.0",
  "rand_core 0.10.1",
  "scrypt 0.12.0",
@@ -8000,7 +8000,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der 0.8.1",
+ "der 0.8.2",
  "pkcs5 0.8.1",
  "rand_core 0.10.1",
  "spki 0.8.0",
@@ -8706,7 +8706,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8942,9 +8942,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37a4ca5c6ca42aa3e6df2fd32b987a65d32a4c2159a6f3fe0fd1df306a2658f"
+checksum = "2acbc41a996f7652b2ddd9dfd98cc4ff602cfd742ae35382f07f608405ab50ed"
 dependencies = [
  "arc-swap",
  "arcstr",
@@ -9326,7 +9326,7 @@ dependencies = [
  "curve25519-dalek 5.0.0",
  "data-encoding",
  "delegate",
- "der 0.8.1",
+ "der 0.8.2",
  "digest 0.11.3",
  "ecdsa 0.17.0",
  "ed25519-dalek 3.0.0",
@@ -11065,7 +11065,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11148,7 +11148,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11419,7 +11419,7 @@ checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct 1.0.0",
  "ctutils",
- "der 0.8.1",
+ "der 0.8.2",
  "hybrid-array",
  "subtle",
  "zeroize",
@@ -11993,7 +11993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
- "der 0.8.1",
+ "der 0.8.2",
 ]
 
 [[package]]
@@ -12405,10 +12405,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13527,7 +13527,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,10 +256,10 @@ clap = { version = "4.6.6" }
 const-str = { version = "1.1.0" }
 convert_case = "0.12.0"
 criterion = { version = "0.8" }
-crossbeam-queue = "0.3.13"
-crossbeam-channel = "0.5.16"
-crossbeam-deque = "0.8.7"
-crossbeam-utils = "0.8.22"
+crossbeam-queue = "0.3.14"
+crossbeam-channel = "0.5.17"
+crossbeam-deque = "0.8.8"
+crossbeam-utils = "0.8.23"
 datafusion = { default-features = false, version = "55.0.0" }
 derive_builder = "0.20.2"
 enumset = "1.1.14"
@@ -306,7 +306,7 @@ rustfs-erasure-codec = { version = "8.0.2" }
 reed-solomon-simd = "3.1.0"
 regex = { version = "1.13.1" }
 rumqttc = { package = "rumqttc-next", version = "0.34.0" }
-redis = { version = "1.6.0" }
+redis = { version = "1.7.0" }
 rustify = { version = "0.7", default-features = false }
 rustix = { version = "1.1.4" }
 rust-embed = { version = "8.12.0" }


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#2240. This is an independent dependency refresh, not a Scanner/Heal feature implementation or issue closeout.

## Summary of Changes

Refresh eight resolved package versions after the shared `cargo update` and `cargo upgrade` pass. Only `Cargo.toml` and `Cargo.lock` change; package count remains 1,154, no new package names are introduced, and existing feature selections and the exact `hotpath = 0.25.0` pin are retained.

| Package | Previous | Updated |
| --- | --- | --- |
| crossbeam-channel | 0.5.16 | 0.5.17 |
| crossbeam-deque | 0.8.7 | 0.8.8 |
| crossbeam-epoch | 0.9.20 | 0.9.21 |
| crossbeam-queue | 0.3.13 | 0.3.14 |
| crossbeam-utils | 0.8.22 | 0.8.23 |
| der | 0.8.1 | 0.8.2 |
| ipnet | 2.12.1 | 2.12.2 |
| redis | 1.6.0 | 1.7.0 |

Crossbeam includes upstream channel/guard soundness fixes and 32-bit/ThreadSanitizer improvements; this does not claim those upstream defects were reproduced in RustFS. [Channel fix](https://github.com/crossbeam-rs/crossbeam/pull/1295). DER restores rejection of unconsumed bytes within nested messages, so malformed encodings previously accepted by the regression may now fail. [DER fix](https://github.com/RustCrypto/formats/pull/2401). Redis updates multiplexed disconnect/error reporting, including RESP3/Unix behavior, while retaining its existing feature and MSRV declarations. [Redis release](https://github.com/redis-rs/redis-rs/releases/tag/redis-1.7.0).

The resolver also reselects existing package edges within their declared version ranges: ten Windows-only consumers now resolve `windows-sys 0.59.0` instead of `0.60.2`/`0.61.2`, and unchanged `tempfile 3.27.0` resolves `getrandom 0.3.4` instead of `0.4.3`. Both getrandom versions and the Windows package versions already existed in the lockfile; these are edge changes, not additional package upgrades.

## Verification

Commit `6a5d81ee331f0c3f96434c49fb502cd7d67e0cc3` is based on main `d7b7d1835ff94a014f45f1709e90b9d9301f3928`. All commands below used the exact manifest/lockfile tree subsequently committed, with no further source or dependency changes.

- `cargo check --locked -p rustfs-targets -p rustfs-scanner --lib -j4`: passed, exit 0. This covers ordinary library builds, including the Redis client and the scanner's RSA/DER dependency chain.
- `cargo nextest run --locked -p rustfs-targets --lib -j4 -E 'test(target::redis::tests::)'`: 22 passed, exit 0, zero ignored. Existing local fake RESP-server tests exercised PING, reconnect/retry recovery, exhaustion, and failure accounting; configuration tests covered credentials, RESP3 URL selection, TLS policy, and deadlines. The run had loopback permission so the existing permission-denied early-return path did not substitute for server assertions. No live Redis deployment was used.
- `cargo nextest run --locked -p rustfs-lock -p rustfs-obs -p rustfs-crypto --lib -j4 -E '(package(rustfs-lock) & test(fast_lock::object_pool::tests::)) | (package(rustfs-obs) & test(cleaner::tests::test_parallel_cleanup)) | (package(rustfs-crypto) & test(license_token::tests::))'`: 9 passed, exit 0, zero ignored. This includes 2 SegQueue object-pool tests, 2 parallel cleanup tests within/above bounded-channel capacity, and 5 RSA token/key parsing and signing tests. Together with Redis, 31 distinct tests passed.

`git diff --check d7b7d1835ff94a014f45f1709e90b9d9301f3928...HEAD` passed. Manifest/source comparisons and focused `cargo tree --locked` queries confirmed the active consumers and feature selections. No Rust source changed, so Rust formatting was not rerun.

Not run: live Redis/Valkey, RESP3 disconnects over Unix sockets, Redis TLS handshakes against real servers, the full cryptographic/SSH key matrix, a dedicated RustFS malformed nested-DER regression, Windows/32-bit execution, ThreadSanitizer, full-workspace gates, or performance benchmarks. Compilation and these focused tests do not establish those lanes.

## Impact

No RustFS API, configuration, repair algorithm, persistence format, or explicit outbound-client default is changed. Dependency behavior can still change at decoding, disconnect reporting, and platform boundaries; the scope is not described as runtime-neutral.

- Correctness and coverage: 31 focused consumer tests pass, including real local transport and parallel cleanup paths; this is not exhaustive dependency qualification.
- Concurrency: the Crossbeam consumers compile and their selected capacity/pool regressions pass; 32-bit atomic-index and sanitizer-specific behavior remains unverified.
- Compatibility and security: Redis's existing `connection-manager`, `tokio-rustls-comp`, and `tls-rustls-insecure` capabilities are unchanged, as is RustFS's opt-in insecure TLS policy. Redis's optional native-TLS dependency update is not enabled by this consumer. DER's stricter nested-input rejection is intentional and is covered here by source review plus valid/invalid key consumer smoke tests, not a full format matrix.
- Simplicity and performance: this remains a two-file version/lockfile update with no new adapter or feature switch. The ipnet aggregation endpoint correction was inspected; the current hyper-util proxy consumer uses parsing/containment rather than `aggregate()`. No throughput or latency improvement is claimed.

## Additional Notes

Two independent reviews of the final dependency diff and active upstream source contracts passed without actionable findings. They covered correctness, concurrency, crypto/security, compatibility, resource behavior and the limits of the recorded consumer tests; they do not convert the unrun lanes above into verified results.

The Windows edge changes affect dirs-sys, errno, io-extras, is-terminal, nu-ansi-term, quinn-udp, rustix, rustls-platform-verifier, tempfile, and winapi-util. Their declared constraints permit the selected version, but no Windows build was run. Rollback is a coordinated revert of both Cargo files. Scanner/Heal feature PRs do not need to contain or depend on this refresh.
