### PR TITLE
test(scanner): settle fixture writes before activity baseline

### DIFF
--- a/crates/scanner/src/scanner_io/tests.rs
+++ b/crates/scanner/src/scanner_io/tests.rs
@@ -452,6 +452,14 @@ async fn scoped_scan_same_cycle_maintenance_rewalks_after_root_delivery_failure(
                 .put_object(bucket, "initial", &mut reader, &ScannerObjectOptions::default())
                 .await
                 .expect("initial object should persist");
+            let lock = store.pools[0].disk_set[0]
+                .new_ns_lock(bucket, "initial")
+                .await
+                .expect("fixture namespace lock should be created");
+            let _settled = lock
+                .get_write_lock(Duration::from_secs(30))
+                .await
+                .expect("fixture rename tail should finish before the usage scan");
         }
         let ctx = CancellationToken::new();
         let budget = ScannerCycleBudget::new(&ctx, ScannerCycleBudgetConfig::default());
@@ -501,6 +509,15 @@ async fn scoped_scan_same_cycle_maintenance_rewalks_after_root_delivery_failure(
             .put_object("cold-bucket", "new", &mut reader, &ScannerObjectOptions::default())
             .await
             .expect("new cold object should persist");
+        let lock = store.pools[0].disk_set[0]
+            .new_ns_lock("cold-bucket", "new")
+            .await
+            .expect("fixture namespace lock should be created");
+        let _settled = lock
+            .get_write_lock(Duration::from_secs(30))
+            .await
+            .expect("fixture rename tail should finish before the usage scan");
+        drop(_settled);
         record_dirty_usage_bucket("hot-bucket");
         if scan_mode == HealScanMode::Normal && !requires_full_scan {
             record_dirty_usage_bucket("cold-bucket");


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Wait for quorum-acknowledged fixture writes to drain their rename tails before taking the scanner activity baseline. Without that boundary, a tail can complete during the scan and correctly classify the result as `Superseded`, making the maintenance rewalk test flaky.

## Verification

- Before the change, ten sequential executions failed on run 2 with `left: Superseded`, `right: Complete`.
- After the change, ten sequential executions of `cargo test -q -p rustfs-scanner scanner_io::tests::scoped_scan_same_cycle_maintenance_rewalks_after_root_delivery_failure -- --exact` passed on the final diff before the no-conflict rebase.
- `cargo fmt --all` and `git diff --check` passed.

## Impact

Test-only. Production scanner behavior is unchanged.

## Additional Notes

N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
