### PR TITLE
test(ecstore): drain source writes before corrupting shards

### DIFF
--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -16291,7 +16291,23 @@ mod transition_upload_integrity_tests {
             let bucket = format!("transition-real-bitrot-{}", position.label());
             let object = format!("{}-corrupt.bin", position.label());
             let payload = vec![0x41; 2 * 1024 * 1024];
-            let original = write_source(&set_disks, &disk_stores, &bucket, &object, &payload).await;
+            // Corruption edits physical shards, so every healthy rename must finish first.
+            for disk in &disk_stores {
+                disk.make_volume(&bucket).await.expect("bucket volume should be created");
+            }
+            let mut reader = PutObjReader::from_vec(payload.to_vec());
+            let original = set_disks
+                .put_object(
+                    &bucket,
+                    &object,
+                    &mut reader,
+                    &ObjectOptions {
+                        write_completion: WriteCompletion::TailDrained,
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect("source object should be written");
             let source = set_disks
                 .get_object_fileinfo(
                     &bucket,


### PR DESCRIPTION
## Related Issues

Relates to https://github.com/rustfs/backlog/issues/2337.

## Summary of Changes

The default CI run failed while preparing bitrot corruption: the test read a shard that did not yet exist, before calling `transition_object`. Its seed PUT used the default quorum completion boundary, which allows rename futures to remain in flight.

Only this test's seed changes (17 additions, one deletion). It uses the existing `put_object` path with `WriteCompletion::TailDrained` before editing physical shards. The shared helper, other callers, all three corruption positions and every transition, metadata and remote cleanup assertion stay unchanged.

## Verification

Candidate: `955ac63ac786a9fc8f37fc6bb6d5c57cd68b2c9f`.

- Before: [CI job 101454084327](https://github.com/rustfs/rustfs/actions/runs/34020988192/job/101454084327) at `09c29dc5e39baebab5dfccf2c086d4c0730d7d9d` failed in `corrupt_shard_at` with `NotFound`. The log does not identify the delayed disk.
- Passed: `rustfmt --edition 2024 --check crates/ecstore/src/set_disk/ops/object.rs`, `git diff --check`, and whole-file inverse comparison confirming that only the seed changed.
- Two independent static reviews found no blockers: correctness, simplicity and coverage; completion boundary and compatibility.

Native validation on `955ac63ac786a9fc8f37fc6bb6d5c57cd68b2c9f`: exact discovery selected one test; it passed through First/Middle/Last and the final remote cleanup assertions. One setup check passed separately; zero retries. Run UUID: `aa2b9f58-869d-4ec8-9983-a9417ba39784`.

```sh
cargo nextest run -p rustfs-ecstore --lib --locked --offline --features test-util --profile ci --build-jobs 2 --test-threads 1 --retries 0 --no-tests fail -E 'package(=rustfs-ecstore) & test(=set_disk::ops::object::transition_upload_integrity_tests::real_bitrot_producer_failures_do_not_commit_transition)'
```

The initial package-only listing omitted `test-util` and selected zero tests, so no native test ran. The command above enables the feature required by this module; workspace CI also enables it through the application test dependency. Full CI remains pending.

## Impact

Test-only. TailDrained waits for the rename futures; it preserves quorum and fsync semantics and does not require every disk to succeed. Real missing, empty or unwritable shards still fail the original strict preparation checks. Production defaults and on-disk/RPC formats are unchanged.

## Additional Notes

The existing CI failure supplies the before-change evidence. No sleep, polling, retry or relaxed assertion is added.
