### PR TITLE
docs(heal): clarify start retries and execution budgets

### DIFF
--- a/docs/operations/scanner-runtime-controls.md
+++ b/docs/operations/scanner-runtime-controls.md
@@ -299,6 +299,24 @@ Heal knobs are environment-only and read by `HealConfig::default` (`crates/heal/
 | `RUSTFS_HEAL_MRF_REPLAY_BATCH` | `256` (`DEFAULT_HEAL_MRF_REPLAY_BATCH`) | Intents per replay push round. |
 | `RUSTFS_HEAL_DANGLING_DELETE_GRACE_SECS` | `3600` (`DEFAULT_HEAL_DANGLING_DELETE_GRACE_SECS`, `crates/ecstore/src/set_disk/core/io_primitives.rs`) | A recently modified object is never deleted as dangling inside this window; `0` disables the grace window. |
 
+### Admin heal start, retries, and budgets
+
+Admin heal has three separate budgets. Increasing one does not extend the others:
+
+| Budget | Existing behavior |
+|---|---|
+| Control request | A start/query/cancel envelope has a bounded lifetime derived from the internode RPC timeout, with room for the transport response. It bounds control execution, not the admitted repair task. The HTTP caller can also stop waiting independently. |
+| Task execution | `RUSTFS_HEAL_TASK_TIMEOUT_SECS` supplies the default of 300 seconds when the execution has no explicit timeout. Elapsed execution time is deducted before a recoverable scheduler retry, which keeps the request identity and remaining budget. Object/listing backoff and pressure pacing inside an execution consume that budget; time queued or in the scheduler's between-attempt backoff is not a new absolute wall-clock deadline. Zero is not an unlimited execution budget. |
+| Object/listing retry | A recursive bucket/prefix traversal retries recoverable failures at most three times after the initial attempt, with 2/4/8-second delays plus the existing task-derived jitter. Object retries also obey the bounded delayed window and its 30-second age, checked at safe boundaries; listing retries keep their cursor. These limits do not extend the task execution budget or force an in-flight storage operation to finish within the retry age. |
+
+For a large admin heal, select a finite configured execution budget appropriate to the expected work and contention, and inspect progress while it runs. Investigate stalled work and object failures before increasing this budget; a larger timeout must not hide lock or quorum problems. A longer HTTP or internode timeout does not keep a repair task alive past its execution budget. A successful start response returns the canonical token for accepted or merged work; it does not prove that repair has completed. Query that token without `forceStart`; terminal timeout/cancellation reports retain completed progress while the task report remains available.
+
+Capability preflight runs before constructing and admitting a start request. However, the public `cluster heal coordination unavailable` error can also follow a transport failure or an invalid coordinator response after a request was sent. An unknown or lost HTTP response is therefore not proof that no task was admitted.
+
+The coordinator can replay the result of the exact original RPC envelope within its existing replay lifetime and coordinator epoch. Reusing an ID with changed parameters or nonce is rejected. This bounded, process-local receipt cache is not a general HTTP idempotency key or a restart-surviving admission receipt. Each new HTTP start constructs a new request/envelope, and a fresh `forceStart` intentionally requests a distinct start: do not automatically resend it after an ambiguous response. A fresh non-forced request follows the configured overlap policy, rather than recovering the original receipt. The v3 API rejects `forceStart` combined with `clientToken` or `forceStop`.
+
+Implementation references: `rustfs/src/admin/handlers/heal.rs` (`submit_cluster_heal_start`, `new_heal_control_metadata`), `rustfs/src/storage/rpc/node_service.rs` (`execute_heal_control_envelope_with_manager`), `crates/protos/src/lib.rs` (`heal_control_execution_timeout`), and `crates/heal/src/heal/task.rs` (`retry_request_with_remaining_timeout`, `remaining_timeout`, `bucket_object_retry_delay`). These contracts do not replace the separate real response-loss, long-task, or start-latency validation lanes.
+
 ### Running admin heal pacing
 
 The manager passes its existing workload provider and a configuration snapshot into each admin execution. Bucket/prefix listing and object boundaries resample foreground pressure; erasure-set page workers also resample after earlier work releases page capacity. `High`, `Urgent`, and `force_start` do not exempt ordinary admin execution from this runtime pacing. The existing start-time bypass and overlap-control meanings are unchanged.


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#2271 and rustfs/backlog#2240.

## Summary of Changes

Document the existing admin heal control-request, cumulative task-execution, and object/listing retry budgets in the operational controls guide. Explain which waits consume execution time and why a larger caller/RPC timeout does not extend an admitted task's budget.

Distinguish bounded exact RPC-envelope replay from a fresh HTTP start. Clarify that an ambiguous response does not prove admission failed, and that callers must not blindly repeat `forceStart` or treat a receipt as repair completion. No default, runtime behavior, API, or idempotency mechanism changes.

## Verification

Final single commit: `d9727242c6399cbc61dce21f12523329cb6048ea`.

- Cross-checked the documented contracts against main `c130d00d4b83bb6c9ac3bd534f706024907159ae`: admin request construction, coordinator replay, scheduler retry preparation, task remaining-time accounting, and recursive retry limits.
- `git diff --check`: passed.
- `bash scripts/check_doc_paths.sh`: passed. Cargo formatting, compilation, and tests were not run because the change is documentation-only.

## Impact

Operational clarification only. The default execution timeout remains 300 seconds; this does not add an absolute wall-clock deadline across queue/backoff intervals, a durable admission receipt, or a new HTTP retry guarantee.

## Additional Notes

Only `docs/operations/scanner-runtime-controls.md` changes. The separate real response-loss, complete long-task budget, and start-latency verification requirements remain open; this documentation patch does not close the entire W09 issue.
