### PR TITLE
fix(filemeta): keep data dir of a version awaiting purge replication

### DIFF
--- a/crates/e2e_test/src/replication_extension_test.rs
+++ b/crates/e2e_test/src/replication_extension_test.rs
@@ -3908,6 +3908,86 @@ async fn test_bucket_replication_replicates_directory_marker_in_versioned_bucket
     Ok(())
 }
 
+/// Regression for rustfs/backlog#2340 (not Wasabi specific): permanently
+/// deleting a version whose payload lives in a data dir must leave the source
+/// clean once the purge replicates. Managed-SSE objects are never inlined and a
+/// plain object above the inline threshold takes the same layout. The version
+/// retained with a pending purge used to lose its data dir, so the purge state
+/// could never be applied (`VersionNotFound` on every retry) and the bucket
+/// stayed `BucketNotEmpty` while `ListObjectVersions` was already empty.
+#[tokio::test]
+async fn test_bucket_replication_version_purge_of_non_inline_object_releases_source_bucket() -> TestResult {
+    init_logging();
+
+    let (source_env, target_env, source_bucket, target_bucket) = build_sse_replication_pair("purge-datadir", true, true).await?;
+    let target_arn = wait_for_remote_target_arn(&source_env, &source_bucket).await?;
+    put_bucket_replication_with_delete_statuses(&source_env, &source_bucket, &target_arn, "Enabled", Some("Enabled")).await?;
+    let source_client = source_env.create_s3_client();
+    let target_client = target_env.create_s3_client();
+
+    let sse_key = "sse-object.bin";
+    let large_key = "large-object.bin";
+    let sse_put = source_client
+        .put_object()
+        .bucket(&source_bucket)
+        .key(sse_key)
+        .body(ByteStream::from_static(b"encrypted source payload"))
+        .server_side_encryption(ServerSideEncryption::Aes256)
+        .send()
+        .await?;
+    let large_put = source_client
+        .put_object()
+        .bucket(&source_bucket)
+        .key(large_key)
+        .body(ByteStream::from(vec![0x5a; 2 * 1024 * 1024]))
+        .send()
+        .await?;
+    let purged = [
+        (sse_key, sse_put.version_id().ok_or("SSE PUT omitted version ID")?.to_string()),
+        (large_key, large_put.version_id().ok_or("large PUT omitted version ID")?.to_string()),
+    ];
+    assert_replication_converged(&source_client, &source_bucket, &target_client, &target_bucket).await?;
+
+    for (key, version_id) in &purged {
+        source_client
+            .delete_object()
+            .bucket(&source_bucket)
+            .key(*key)
+            .version_id(version_id)
+            .send()
+            .await?;
+    }
+    assert_replication_converged(&source_client, &source_bucket, &target_client, &target_bucket).await?;
+    let target_state = list_replication_state(&target_client, &target_bucket).await?;
+    assert!(target_state.is_empty(), "target retained an explicitly purged version: {target_state:?}");
+
+    // The purge state is applied on the source asynchronously after the target
+    // acknowledges the delete; only then does the retained version go away and
+    // the bucket become deletable. A listing that is empty while DeleteBucket
+    // keeps answering BucketNotEmpty is exactly the regression.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        let listing = source_client.list_object_versions().bucket(&source_bucket).send().await?;
+        let listed = listing.versions().len() + listing.delete_markers().len();
+        match source_client.delete_bucket().bucket(&source_bucket).send().await {
+            Ok(_) => break,
+            Err(err) if err.code() == Some("BucketNotEmpty") => {
+                if tokio::time::Instant::now() >= deadline {
+                    return Err(format!(
+                        "source bucket stayed BucketNotEmpty after the version purge replicated; \
+                         ListObjectVersions shows {listed} entries"
+                    )
+                    .into());
+                }
+                sleep(Duration::from_millis(500)).await;
+            }
+            Err(err) => return Err(err.into()),
+        }
+    }
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_bucket_replication_disabled_delete_marker_does_not_propagate() -> TestResult {
     init_logging();

--- a/crates/filemeta/src/filemeta.rs
+++ b/crates/filemeta/src/filemeta.rs
@@ -692,10 +692,15 @@ impl FileMeta {
                             }
                         }
 
-                        let old_dir = v.object.as_ref().map(|v| v.data_dir).unwrap_or_default();
+                        // The version stays on disk while the purge replicates
+                        // (status PENDING/FAILED); its data dir must stay with
+                        // it. Returning the dir here made the disk layer delete
+                        // it, which turned every non-inline retained version
+                        // into an unreadable zombie: the purge state could never
+                        // be applied and the bucket could never be deleted.
                         self.set_idx(i, v)?;
 
-                        return Ok(old_dir);
+                        return Ok(None);
                     }
                     found_index = Some(i);
                 }
@@ -2700,6 +2705,58 @@ mod test {
             fm.versions.is_empty(),
             "delete-marker version purge should remove the local marker instead of rewriting purge metadata onto it"
         );
+    }
+
+    /// Regression for rustfs/backlog#2340: a version purge that still awaits
+    /// the replication target keeps the object version on disk with a pending
+    /// purge status. Its data dir must be retained with it; handing the dir
+    /// back here made the disk layer delete it, leaving every non-inline
+    /// retained version unreadable. The dir is released only once the purge
+    /// completes and the version itself goes away.
+    #[test]
+    fn delete_version_pending_version_purge_retains_object_data_dir() {
+        let version_id = Uuid::new_v4();
+        let data_dir = Uuid::new_v4();
+        let mut fm = FileMeta::new();
+        let mut fi = FileInfo::new("object", 2, 2);
+        fi.version_id = Some(version_id);
+        fi.data_dir = Some(data_dir);
+        fi.mod_time = Some(OffsetDateTime::now_utc());
+        fm.add_version(fi).unwrap();
+
+        let pending_purge = FileInfo {
+            name: "object".to_string(),
+            version_id: Some(version_id),
+            mark_deleted: true,
+            replication_state_internal: Some(ReplicationState {
+                version_purge_status_internal: Some("target=PENDING;".to_string()),
+                purge_targets: version_purge_statuses_map("target=PENDING;"),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let freed = fm.delete_version(&pending_purge).unwrap();
+        assert_eq!(freed, None, "a pending purge must not release the retained version's data dir");
+        assert_eq!(fm.versions.len(), 1, "the version must stay until the purge replicates");
+        let retained = fm
+            .into_fileinfo("vol", "object", &version_id.to_string(), false, false, true)
+            .unwrap();
+        assert_eq!(retained.data_dir, Some(data_dir));
+        assert_eq!(retained.version_purge_status(), VersionPurgeStatusType::Pending);
+
+        let completed_purge = FileInfo {
+            name: "object".to_string(),
+            version_id: Some(version_id),
+            replication_state_internal: Some(ReplicationState {
+                version_purge_status_internal: Some("target=COMPLETE;".to_string()),
+                purge_targets: version_purge_statuses_map("target=COMPLETE;"),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let freed = fm.delete_version(&completed_purge).unwrap();
+        assert_eq!(freed, Some(data_dir), "a completed purge removes the version and releases its data dir");
+        assert!(fm.versions.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

rustfs/backlog#2340 (site-replication finding: deleting a managed-SSE object version leaves the source looping on `VersionNotFound` and blocks `DeleteBucket`). Not Wasabi specific: it reproduces between two local RustFS sites and with bucket replication.

## Summary of Changes

Permanently deleting a version on a replicated bucket keeps that version in `xl.meta` with a pending purge status until the target acknowledges the delete. `FileMeta::delete_version` handed the retained version's data dir back to the disk layer in that branch, and `delete_version_inner` deleted it. Inline objects have no data dir, so small plaintext objects never showed the problem. Managed-SSE objects (never inlined) and any plaintext object above the inline threshold lost their payload while the version stayed on disk: the next metadata read of that version failed with `VersionNotFound`, `apply_replication_delete_state` failed on every retry with `Version not found: <bucket>/<object>-<versionId>`, `ListObjectVersions` was already empty, and `DeleteBucket` kept answering `BucketNotEmpty` (`bucket_delete_blocked blocker=visible_version`).

The retained-version branch now returns no data dir, matching MinIO `xlMetaV2.deleteVersion` (`return "", err` under `updateVersion`). The data dir is released by the existing path once the purge completes and the version itself is removed.

## Verification

Tested commit: this branch head on top of `origin/main` `8a2049870`; after the rebase onto `cf1c45eb9` (to take #7315's neighbouring test) the purge e2e and the directory-marker e2e were re-run against a binary built from the rebased head: 2 passed.

- `cargo test -p rustfs-filemeta --lib`: 271 passed. The new `delete_version_pending_version_purge_retains_object_data_dir` asserts the pending purge returns `None` and keeps the version and data dir, and that the completed purge returns the data dir and removes the version; it fails on the previous code at the first assertion.
- `cargo nextest run -p e2e_test -E 'test(test_bucket_replication_version_purge_of_non_inline_object_releases_source_bucket)'`: new test with an SSE-S3 object and a 2 MiB plaintext object, both purged by version. Before the fix (binary built from the parent commit): `FAIL` with `source bucket stayed BucketNotEmpty after the version purge replicated; ListObjectVersions shows 0 entries`. After the fix: `PASS`.
- Two paired local sites (`scripts/test/site_replication_smoke.py` `start_site`/`ensure_pair`, local KMS): before the fix the source logged `replication_resync_target_operation_failed operation=apply_replication_delete_state error="Version not found: …"` and `bucket_delete_blocked blocker=visible_version sample=encrypted/xl.meta`, with only `xl.meta` left in the object directory; after the fix `DeleteBucket` succeeds for both the SSE-S3 object and a 2 MiB plaintext object and the object directory is gone.
- `make pre-commit` and `cargo clippy --all-targets -- -D warnings`: clean.

- `cargo test -p rustfs-ecstore --lib purge` (60 passed) and `cargo test -p rustfs-ecstore --lib delete_version` (23 passed): the ecstore callers of `delete_version` keep their expectations.

Not run: the full `rustfs-ecstore` test suite. Remaining risk: none identified beyond the changed branch; the completed-purge and non-replicated delete paths are unchanged.

## Impact

Behavior fix for every replicated bucket: version purges of non-inline objects (managed SSE, objects above the inline threshold) no longer strand an unreadable version that blocks bucket deletion. No on-disk format, API, or configuration change.

Adversarial review (high risk: replication/persistence), two sequential passes:

- Correctness: traced pending, failed, and completed purge statuses through `delete_version`; only the retained-version branch changed, the completed purge still frees the data dir via the removal path, and a shared data dir is still protected by `shared_data_dir_count`. No finding.
- Concurrency/durability: no lock or commit-order change; the disk layer's rollback staging only runs when a data dir is returned, which is now only for removed versions. No finding.
- Compatibility: `xl.meta` layout unchanged; behavior now equals MinIO's `deleteVersion` for the same branch. No finding.
- Test coverage: the unit test and the e2e both fail when the hunk is reverted (observed for the e2e). No finding.

## Additional Notes

The companion findings from the same report (checksum forwarding, directory-marker versioning, object-key validation) are handled in separate PRs.
