### PR TITLE
test(ilm): align feature matrix lifecycle assertions

### DIFF
--- a/rustfs/src/admin/handlers/ilm_transition.rs
+++ b/rustfs/src/admin/handlers/ilm_transition.rs
@@ -2153,7 +2153,7 @@ mod tests {
         let inspect = src
             .split("impl Operation for TransitionReconcileInspectHandler")
             .nth(1)
-            .and_then(|block| block.split("impl Operation for TransitionReconcileApplyHandler").next())
+            .and_then(|block| block.split("pub struct IlmRecoveryControlListHandler").next())
             .expect("inspect handler block");
         assert!(inspect.contains("AdminAction::ListTierAction"));
         assert!(!inspect.contains("AdminAction::SetTierAction"));
@@ -2502,7 +2502,7 @@ mod tests {
         let wrapper = extract_block_between_markers(
             production,
             "async fn authorize_transition_admin_request",
-            "fn transition_transaction_id_from_params",
+            "async fn authorize_recovery_admin_request",
         );
 
         assert_eq!(

--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -4070,14 +4070,13 @@ mod tests {
                     abort_incomplete_multipart_upload: None,
                     del_marker_expiration: None,
                     filter: Some(s3s::dto::LifecycleRuleFilter {
-                        prefix: Some("logs/".to_string()),
-                        tag: Some(s3s::dto::Tag {
-                            key: Some("env".to_string()),
-                            value: Some("prod".to_string()),
+                        and: Some(s3s::dto::LifecycleRuleAndOperator {
+                            prefix: Some("logs/".to_string()),
+                            ..Default::default()
                         }),
                         ..Default::default()
                     }),
-                    id: Some("two-predicates".to_string()),
+                    id: Some("one-member-and".to_string()),
                     noncurrent_version_expiration: None,
                     noncurrent_version_transitions: None,
                     prefix: None,
@@ -4087,7 +4086,7 @@ mod tests {
             &ObjectLockConfiguration::default(),
         )
         .await
-        .expect_err("a Filter with two predicates is a schema violation");
+        .expect_err("a Filter And with one predicate is a schema violation");
         assert_eq!(*lifecycle_validation_error(&malformed).code(), S3ErrorCode::MalformedXML);
 
         let invalid_value = validate_lifecycle_config(


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#2240.

## Summary of Changes

This is a narrow CI self-test alignment for current `main` after the lifecycle and ILM recovery updates.

- Narrow the ILM source-inspection tests to the intended transition reconciliation blocks, so newly inserted ILM recovery handlers do not make the tests count unrelated `AdminAction` usage.
- Update the lifecycle validation regression to keep covering the S3 error-code mapping with a still-malformed one-member `Filter/And` shape, after sibling `Prefix` plus `Tag` predicates became accepted for S3 compatibility.

No production behavior is changed.

## Verification

Tested commit: `9008d3973`.

- `CARGO_BUILD_JOBS=2 cargo nextest run --locked --profile ci -p rustfs --features swift -E 'test(transition_admin_gate_routes_through_the_shared_gate) | test(transition_reconcile_routes_use_read_and_write_tier_actions) | test(put_bucket_lifecycle_validation_errors_keep_their_s3_code)' -j2` passed: 3 passed, 4688 skipped.
- `CARGO_BUILD_JOBS=2 cargo nextest run --locked --profile ci -p rustfs -p rustfs-ecstore --features rio-v2 -E 'test(transition_admin_gate_routes_through_the_shared_gate) | test(transition_reconcile_routes_use_read_and_write_tier_actions) | test(put_bucket_lifecycle_validation_errors_keep_their_s3_code)' -j2` passed: 3 passed, 10148 skipped.
- `CARGO_BUILD_JOBS=2 cargo nextest run --locked --profile ci -p rustfs --features sftp -E 'test(transition_admin_gate_routes_through_the_shared_gate) | test(transition_reconcile_routes_use_read_and_write_tier_actions) | test(put_bucket_lifecycle_validation_errors_keep_their_s3_code)' -j2` passed: 3 passed, 4667 skipped.
- `cargo fmt --all --check` passed.
- `git diff --check` passed.

Not run: full CI locally. The patch only updates tests, and the focused checks cover the three tests that were failing in the affected CI feature lanes.

## Impact

No runtime, API, storage-format, compatibility, or configuration impact is expected. This should unblock unrelated Scanner/Heal V2 pull requests that currently inherit these CI self-test failures.

## Additional Notes

N/A.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
