### PR TITLE
docs(s3): record object-key path-segment validation as intentional

### DIFF
--- a/docs/architecture/s3-compatibility-matrix.md
+++ b/docs/architecture/s3-compatibility-matrix.md
@@ -55,6 +55,14 @@ Standard S3 areas that must not be described as complete:
 
 `excluded_tests.txt` holds tests that must not block the compatibility gate: vendor-specific or non-portable behavior, and intentionally unsupported product behavior such as ACL authorization.
 
+## Intentional Deviations From AWS S3
+
+Object keys are stored as file-system paths under each drive (`{drive}/{bucket}/{object}/xl.meta`), the same layout MinIO uses. The rules below exist to keep that layout unambiguous and are not compatibility gaps to close; clients that need the AWS behavior must adapt on their side.
+
+| Behavior | RustFS | AWS S3 | Why |
+|---|---|---|---|
+| Object key with a `.` or `..` path segment, or an empty segment (`//`), such as `a//b/./c/../d` | `400 InvalidArgument` (`check_object_args` in `crates/ecstore/src/bucket/utils.rs`, mirroring MinIO `IsValidObjectPrefix`) | Accepted as an opaque key | A `..` segment would resolve to a parent directory and `.`/`//` segments would alias other keys on disk; encoding them would change the MinIO-compatible on-disk format. |
+
 ## Update Rule
 
 When a feature starts passing, move its test entries from `unimplemented_tests.txt` to `implemented_tests.txt` and update the row here in the same PR. Do not change README wording beyond the supported coverage. Handler-level status (missing, stubbed, or diverging endpoints) is tracked in [minio-rustfs-router-compatibility.md](minio-rustfs-router-compatibility.md).


### PR DESCRIPTION
## Related Issues

rustfs/backlog#2340 (finding: the source rejects the key `a//b/./c/../d` with `400 InvalidArgument` while AWS S3 and Wasabi accept it). Not Wasabi specific.

## Summary of Changes

Documentation only. The rejection is deliberate and inherited from MinIO: `check_object_args` in `crates/ecstore/src/bucket/utils.rs` refuses object keys with a `.` or `..` path segment (`has_bad_path_component`) or an empty segment (`//`), the same rules as MinIO `IsValidObjectPrefix`. Object keys are stored as file-system paths under each drive, so a `..` segment would resolve to a parent directory and `.`/`//` segments would alias other keys on disk; accepting them would require encoding such segments and would change the MinIO-compatible on-disk layout. This PR records the rule as an intentional deviation in the S3 compatibility matrix instead of relaxing it.

## Verification

- `git diff --check`: clean.
- `scripts/check_doc_paths.sh`: passed (the new row cites `crates/ecstore/src/bucket/utils.rs`).
- No code change; Cargo formatting, compilation, Clippy, and tests skipped per the documentation tier in AGENTS.md.

## Impact

Documentation: `docs/architecture/s3-compatibility-matrix.md` gains an "Intentional Deviations From AWS S3" section. No runtime change.

## Additional Notes

Evaluated and rejected: accepting the key at the S3 layer and encoding the offending segments at the storage layer. That would create a second key encoding beside `__XLDIR__`, diverge from MinIO's on-disk format, and make listings ambiguous between an encoded `..` segment and a literal directory, for a key shape that AWS itself only tolerates as an opaque string. The other findings from the same report are handled in separate PRs.
