### PR TITLE
test(scanner): cover reset cleanup across store reopen

### DIFF
--- a/crates/scanner/src/scanner/tests.rs
+++ b/crates/scanner/src/scanner/tests.rs
@@ -5289,6 +5289,103 @@ async fn scanner_usage_state_reset_resumes_every_cleanup_boundary_without_rewrit
 }
 
 #[tokio::test]
+#[serial]
+async fn scanner_usage_state_reset_resumes_real_store_cleanup_boundaries_after_reopen() {
+    let primary_path = DATA_USAGE_OBJ_NAME_PATH.as_str();
+    let cleanup_paths = [
+        format!("{primary_path}.bkp"),
+        LEGACY_DATA_USAGE_OBJ_NAME_PATH.as_str().to_string(),
+        format!("{}.bkp", LEGACY_DATA_USAGE_OBJ_NAME_PATH.as_str()),
+        DATA_USAGE_OBSERVED_OBJ_NAME_PATH.as_str().to_string(),
+    ];
+
+    for completed in 0..=cleanup_paths.len() {
+        let (_temp_dir, store) = setup_scanner_cycle_store().await;
+        let cycle = CurrentCycle {
+            current: 12,
+            next: 42,
+            cycle_completed: vec![Utc::now()],
+            started: Utc::now(),
+        };
+        save_config(
+            store.clone(),
+            DATA_USAGE_BLOOM_NAME_PATH.as_str(),
+            encode_scanner_cycle_state(&cycle, 3).expect("cycle state should encode"),
+        )
+        .await
+        .expect("cycle state should persist");
+        let marker = scanner_usage_bootstrap_marker(std::time::SystemTime::UNIX_EPOCH, Some(3));
+        save_config(
+            store.clone(),
+            primary_path,
+            serde_json::to_vec(&marker).expect("usage reset marker should encode"),
+        )
+        .await
+        .expect("usage reset marker should persist");
+
+        for path in cleanup_paths.iter().skip(completed) {
+            let mut usage = complete_usage_with_bucket_count(Some(std::time::SystemTime::UNIX_EPOCH), 0);
+            usage.scanner_epoch = Some(1);
+            usage.scanner_cycle = Some(12);
+            save_config(store.clone(), path, serde_json::to_vec(&usage).expect("cleanup slot should encode"))
+                .await
+                .expect("cleanup slot should persist");
+        }
+        for path in ["buckets/quota-reservations/ledger", "buckets/example/incarnation"] {
+            save_config(store.clone(), path, b"retain".to_vec())
+                .await
+                .expect("unrelated state should persist before reopen");
+        }
+
+        let restarted = restart_scanner_cycle_store_from(&store).await;
+        let intent_before = read_config_with_revision(restarted.clone(), primary_path)
+            .await
+            .expect("reopened reset intent should be readable");
+
+        let result = reset_scanner_usage_state_for_full_rebuild(CancellationToken::new(), restarted.clone())
+            .await
+            .expect("reopened usage reset should complete");
+
+        assert_eq!(result.leader_epoch, 3, "boundary {completed}");
+        assert_eq!(result.next_cycle, 42, "boundary {completed}");
+        assert_eq!(result.reset_paths.len(), cleanup_paths.len() + 1 - completed, "boundary {completed}");
+        assert_eq!(
+            read_config_with_revision(restarted.clone(), primary_path)
+                .await
+                .expect("completed reset intent should remain readable"),
+            intent_before,
+            "boundary {completed}: resumed cleanup must not rewrite the reset intent"
+        );
+
+        let (floor, state) = persisted_usage_floor_for_startup(restarted.clone(), false)
+            .await
+            .expect("completed reset marker should remain resumable");
+        assert_eq!(floor.leader_epoch, 3, "boundary {completed}");
+        assert_eq!(state, PersistedUsageFloorStartup::BootstrapPending, "boundary {completed}");
+        assert!(
+            persisted_usage_floor(restarted.clone()).await.is_err(),
+            "boundary {completed}: bootstrap marker must not become an authoritative floor"
+        );
+
+        for path in &cleanup_paths {
+            assert!(
+                matches!(read_config(restarted.clone(), path).await, Err(EcstoreError::ConfigNotFound)),
+                "boundary {completed}: reset should remove stale usage slot {path}"
+            );
+        }
+        for path in ["buckets/quota-reservations/ledger", "buckets/example/incarnation"] {
+            assert_eq!(
+                read_config(restarted.clone(), path)
+                    .await
+                    .expect("unrelated state should survive reopened reset"),
+                b"retain",
+                "boundary {completed}: reset must preserve non-scanner-state config"
+            );
+        }
+    }
+}
+
+#[tokio::test]
 async fn scanner_usage_state_reset_stops_usage_fence_after_owner_loss() {
     let store = Arc::new(MemoryConfigStore::default());
     let mut usage = complete_usage_with_bucket_count(Some(std::time::SystemTime::UNIX_EPOCH), 0);


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#2264.

## Summary of Changes

Adds a focused scanner usage-state reset regression that exercises partially completed cleanup after reopening a real ECStore-backed scanner test store.

The new test seeds each persisted boundary where the reset bootstrap intent already exists and zero through four stale usage cleanup slots have been removed. It then recreates the store, resumes the full-rebuild reset path, and verifies:

- the reset completes with the existing leader epoch and cycle cursor,
- the bootstrap intent bytes and ETag revision are not rewritten during resumed cleanup,
- all stale primary-backup, legacy, legacy-backup, and observed usage slots are removed,
- unrelated quota/incarnation-style config objects remain intact, and
- the bootstrap marker remains a restart-resumable fence rather than becoming an authoritative usage floor.

No production behavior is changed.

## Verification

Tested commit: ce297201cdd86fed9db342091187af2e28817e91.

- `cargo test --locked -p rustfs-scanner --lib scanner_usage_state_reset_resumes_real_store_cleanup_boundaries_after_reopen -j4` passed: 1 test passed, 783 filtered out.
- `cargo fmt --all --check` passed.
- `git diff --check` passed.

An earlier local command used the wrong package (`rustfs-ecstore`) and selected 0 tests, so it is not counted as validation evidence.

Not run: actual separate OS process restart, old-binary/new-binary mixed-version matrix, and distributed dual-admin lock competition. This PR narrows W15's persistent-store evidence gap but does not claim those remaining matrices are complete.

## Impact

Test-only change. It increases regression coverage for scanner reset crash/reopen recovery without changing runtime behavior, public API, configuration, disk format, or S3-visible behavior.

## Additional Notes

Adversarial review notes:

- Correctness: attacked all cleanup cardinalities from none removed to all removed and asserted exact reset output, final slot state, and non-authoritative bootstrap semantics.
- Concurrency/durability: attacked restart replay by reconstructing ECStore from the same disks before resume and comparing the bootstrap intent revision before and after cleanup.
- Compatibility: reused the current primary, backup, legacy, legacy-backup, and observed usage object names without introducing new on-disk keys or migration behavior.
- Test coverage: this is still persistent-store reopen coverage, not an actual process-boundary or mixed-version fixture.
