### PR TITLE
test(ilm): realign source-marker assertions with handler order

### DIFF
--- a/rustfs/src/admin/handlers/ilm_transition.rs
+++ b/rustfs/src/admin/handlers/ilm_transition.rs
@@ -1939,7 +1939,7 @@ mod tests {
         let gate = extract_block_between_markers(
             production,
             "async fn authorize_recovery_admin_request",
-            "fn transition_transaction_id_from_params",
+            "async fn authorize_transition_admin_request",
         );
         assert!(gate.contains("let credentials = authorize_admin_request("));
         assert!(gate.contains("recovery_actor_sha256(&credentials)"));
@@ -2153,7 +2153,7 @@ mod tests {
         let inspect = src
             .split("impl Operation for TransitionReconcileInspectHandler")
             .nth(1)
-            .and_then(|block| block.split("pub struct IlmRecoveryControlListHandler").next())
+            .and_then(|block| block.split("impl Operation for TransitionReconcileApplyHandler").next())
             .expect("inspect handler block");
         assert!(inspect.contains("AdminAction::ListTierAction"));
         assert!(!inspect.contains("AdminAction::SetTierAction"));
@@ -2502,7 +2502,7 @@ mod tests {
         let wrapper = extract_block_between_markers(
             production,
             "async fn authorize_transition_admin_request",
-            "async fn authorize_recovery_admin_request",
+            "fn transition_transaction_id_from_params",
         );
 
         assert_eq!(


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#2240 (follow-up to #7311). Unblocks the `Test and Lint` lanes on every open PR, including #7307, #7313 and #7315.

## Summary of Changes

Test-only. Three source-inspection tests in `rustfs/src/admin/handlers/ilm_transition.rs` cut their blocks with markers that no longer match the order of the production code on `main`: `authorize_recovery_admin_request` is defined before `authorize_transition_admin_request`, and `IlmRecoveryControlListHandler` is defined before the `TransitionReconcileInspectHandler` impl. With the markers from #7311 the recovery gate block ran into the transition wrapper (`MaskedAccessKey` found), the transition wrapper block had no end marker after its start (`expected end marker` panic), and the inspect block ran to the end of the file (`AdminAction::SetTierAction` found). The markers now follow the actual order: recovery gate ends at the transition wrapper, the transition wrapper ends at `transition_transaction_id_from_params`, and the inspect block ends at the apply handler impl. No production code changes.

## Verification

Tested commit: this branch head on `origin/main` `a04ddc237`.

- Failing before: the `main` CI run for `a04ddc237` (workflow run 34043538081) fails `Test and Lint`, `Test and Lint (sftp)`, `Test and Lint (rio-v2)` and `Test and Lint (swift)` on exactly these three tests: `recovery_actor_binding_uses_the_authenticated_presented_access_key` (`ilm_transition.rs:2700`, expected end marker), `transition_admin_gate_routes_through_the_shared_gate` (`ilm_transition.rs:1946`, `!gate.contains("MaskedAccessKey")`), `transition_reconcile_routes_use_read_and_write_tier_actions` (`ilm_transition.rs:2159`, `!inspect.contains("AdminAction::SetTierAction")`). #7311 was merged with those lanes skipped.
- Passing after: `cargo nextest run -p rustfs -E 'test(recovery_actor_binding_uses_the_authenticated_presented_access_key) | test(transition_admin_gate_routes_through_the_shared_gate) | test(transition_reconcile_routes_use_read_and_write_tier_actions)'`: 3 passed.
- `cargo fmt --all --check` and `git diff --check`: clean.

Not run: other lanes; the diff changes three string literals inside `#[cfg(test)]`.

## Impact

CI only. No runtime, API, or configuration impact.

## Additional Notes

N/A.
