### PR TITLE
test(scanner): cover overflow service cohort rotation

### DIFF
--- a/crates/scanner/src/scanner_io/guards.rs
+++ b/crates/scanner/src/scanner_io/guards.rs
@@ -865,6 +865,41 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn service_cohort_overflow_eventually_services_every_stable_member() {
+        let source = DataUsageCacheSource::new(0, 0);
+        let inventory = cohort_inventory(&["aa", "bb", "cc", "dd", "ee", "ff"]);
+        let mut cohort = ScannerServiceCohort {
+            max_members: 2,
+            max_name_bytes: 4,
+            ..Default::default()
+        };
+        let mut admitted = HashSet::new();
+        for _ in 0..3 {
+            cohort.refresh(&inventory);
+            let mut buckets = inventory[&source].clone();
+            cohort.order_buckets(source, &mut buckets);
+            for bucket in buckets.iter().take(2) {
+                admitted.insert(bucket.name.clone());
+                cohort.record_admitted(source, &bucket.name);
+            }
+        }
+        assert_eq!(
+            admitted,
+            HashSet::from([
+                "aa".to_string(),
+                "bb".to_string(),
+                "cc".to_string(),
+                "dd".to_string(),
+                "ee".to_string(),
+                "ff".to_string(),
+            ]),
+            "stable overflow inventory must rotate every member through the tracked window"
+        );
+        assert!(cohort.overflowed);
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn service_cohort_bounds_names_and_does_not_reset_duplicate_dirty_age() {
         let source = DataUsageCacheSource::new(0, 0);
         let mut cohort = ScannerServiceCohort {


### PR DESCRIPTION
## Related Issues
Part of rustfs/backlog#2273 and rustfs/backlog#2240.

## Summary of Changes
Adds a focused scanner service cohort regression that covers a stable overflow inventory. The test constrains the bounded cohort to two members and proves that repeated service rounds rotate all stable buckets through the tracked window, rather than only preserving priority for waiters that were already admitted into the current cohort.

## Verification
Commit tested: 72a547e44b. Local changes: none after commit.

- `cargo test --locked -p rustfs-scanner --lib service_cohort_overflow_eventually_services_every_stable_member -j4`: 1 passed, 0 failed, 0 ignored.
- `cargo fmt --all --check`: passed.
- `git diff --check`: passed.

Not run: broader scanner integration, restart, distributed, and performance lanes. This PR is test-only and does not implement durable enumeration work quantum.

## Impact
No runtime behavior change. The added regression improves coverage for the W05 overflow fairness contract.

## Additional Notes
N/A.
