### PR TITLE
docs(ilm): restore transition gate doc comment after handler reorder

### DIFF
--- a/rustfs/src/admin/handlers/ilm_transition.rs
+++ b/rustfs/src/admin/handlers/ilm_transition.rs
@@ -467,9 +467,9 @@ async fn authorize_manual_transition_request(req: &S3Request<Body>) -> S3Result<
     authorize_transition_admin_request(req, AdminAction::SetTierAction).await
 }
 
-/// The credential pre-check keeps this endpoint family's historical
-/// missing-credentials message (the shared gate reports "get cred failed") and
-/// still yields the masked actor every transition audit log records.
+/// Recovery endpoints bind their audit actor to the authenticated access key
+/// (hashed, never the presented key itself); the credential pre-check keeps
+/// this endpoint family's historical missing-credentials message.
 async fn authorize_recovery_admin_request(req: &S3Request<Body>, action: AdminAction) -> S3Result<String> {
     if req.credentials.is_none() {
         return Err(admin_s3_error(AdminS3ErrorCode::InvalidRequest, "authentication required"));
@@ -478,6 +478,9 @@ async fn authorize_recovery_admin_request(req: &S3Request<Body>, action: AdminAc
     Ok(recovery_actor_sha256(&credentials))
 }
 
+/// The credential pre-check keeps this endpoint family's historical
+/// missing-credentials message (the shared gate reports "get cred failed") and
+/// still yields the masked actor every transition audit log records.
 async fn authorize_transition_admin_request(req: &S3Request<Body>, action: AdminAction) -> S3Result<String> {
     let Some(input_cred) = req.credentials.as_ref() else {
         return Err(s3_error!(InvalidRequest, "authentication required"));


### PR DESCRIPTION
## What

Restore the doc comment on `authorize_transition_admin_request` in `rustfs/src/admin/handlers/ilm_transition.rs` and give `authorize_recovery_admin_request` its own accurate description. No behavior change.

## Why

Commit 086ee8e48 (#7297) reordered the two admin gates and left the transition gate's doc comment ("still yields the masked actor every transition audit log records") attached to the recovery gate, which returns a hashed actor rather than the masked access key. The source-introspection test breakage from that same reorder was already fixed on main by #7321, so this PR was rebased onto main and now only carries the documentation residue.

## Verification

- Source-marker probes (`recovery_actor_binding_uses_the_authenticated_presented_access_key`, `transition_admin_gate_routes_through_the_shared_gate`, `manual_transition_logs_masked_actor_and_aggregate_counters`) re-simulated against the edited file: the recovery block still excludes `MaskedAccessKey`, the transition block still carries exactly one shared-gate call.
- `rustfmt --check` on the file passes.

Refs #7321.