### PR TITLE
fix(scanner): pass dirty scopes to distributed scope resolution

### DIFF
--- a/crates/scanner/src/scanner_io/io_cycle.rs
+++ b/crates/scanner/src/scanner_io/io_cycle.rs
@@ -172,9 +172,13 @@ where
             return default_result(resolution.requested_scope);
         };
         dirty_buckets.extend(remote_dirty_usage.dirty_buckets);
+        // Peer snapshots contribute bucket names only; the local prefix scopes
+        // would narrow a bucket a peer dirtied elsewhere, so the merged scope
+        // stays at bucket granularity (same rule as the local fallthrough).
         let scope = scoped_scan_scope_from_dirty_buckets(
             resolution.requested_scope,
             dirty_buckets,
+            None,
             true,
             resolution.all_buckets,
             resolution.baseline_proof,


### PR DESCRIPTION
## Related Issues

N/A (build break on `main` after #7208 and #7322 merged within minutes of each other; every open PR's merge commit currently fails to compile `rustfs-scanner`).

## Summary of Changes

#7208 added the `dirty_scopes` parameter to `scoped_scan_scope_from_dirty_buckets`; #7322 added a new call in `resolve_bucket_scan_scope` (`crates/scanner/src/scanner_io/io_cycle.rs`, distributed branch) written against the previous five-argument signature. `main` at `14c99a994` and later fails with `error[E0061]: this function takes 6 arguments but 5 arguments were supplied`.

The distributed call now passes `None` for the dirty scopes. Peer snapshots contribute bucket names only, so the local prefix scopes could narrow a bucket a peer dirtied elsewhere; the merged scope therefore stays at bucket granularity, which is the same rule the local fallthrough already applies with `(!distributed).then_some(...)`. No behavior change for the single-node path.

## Verification

Tested commit: this branch head on `origin/main` `a2bad0953`.

- Failing before: `cargo check -p rustfs-scanner` on `origin/main` fails with `E0061` at `crates/scanner/src/scanner_io/io_cycle.rs:175`; the `main` CI run for `14c99a994` fails for the same reason.
- `cargo check -p rustfs-scanner --tests`: clean.
- `cargo nextest run -p rustfs-scanner -E 'test(/scoped_scan|scope_resolution|dirty_usage|resolve_bucket_scope/)'`: 37 passed.
- `cargo fmt --all --check`: clean.

Not run: full workspace gates; the diff is one argument at one call site.

## Impact

Restores compilation of `rustfs-scanner` on `main`. Distributed scope resolution scans dirtied buckets whole instead of by prefix, as it did before the merge race; single-node prefix scoping is unchanged.

## Additional Notes

N/A.
