### PR TITLE
test(scanner): cover concurrent cycle reset convergence

### DIFF
--- a/crates/scanner/src/scanner/tests/recovery_control.rs
+++ b/crates/scanner/src/scanner/tests/recovery_control.rs
@@ -339,6 +339,52 @@ async fn disabled_cleanup_lock_busy_preserves_intent_without_force_unlock() {
 
 #[tokio::test]
 #[serial]
+async fn concurrent_full_rescan_requests_converge_to_one_recovery_fence() {
+    let (_dir, store) = setup_scanner_cycle_store().await;
+    seed_cleanup(&store, "blocked").await;
+    let before = persisted_state(&store).await;
+    let lock = store
+        .new_ns_lock(RUSTFS_META_BUCKET, "leader.lock")
+        .await
+        .expect("leader lock");
+    let guard = lock
+        .get_write_lock_quiet(Duration::from_secs(1))
+        .await
+        .expect("hold live leader before concurrent admin resets");
+
+    let first = tokio::spawn(reset_scanner_cycle_recovery(CancellationToken::new(), store.clone()));
+    let second = tokio::spawn(reset_scanner_cycle_recovery(CancellationToken::new(), store.clone()));
+    tokio::task::yield_now().await;
+    assert_eq!(
+        persisted_state(&store).await,
+        before,
+        "waiting admin reset requests must not mutate state before leader ownership"
+    );
+
+    drop(guard);
+    let (first, second) = tokio::time::timeout(Duration::from_secs(15), async { tokio::join!(first, second) })
+        .await
+        .expect("both admin reset requests should finish after the live owner releases the lock");
+    let first = first.expect("first admin reset task should not panic");
+    let second = second.expect("second admin reset task should not panic");
+    assert!(first.is_ok(), "first admin reset failed: {first:?}");
+    assert!(second.is_ok(), "second admin reset failed: {second:?}");
+
+    assert_reset_fences(&store).await;
+    let completed = persisted_state(&store).await;
+    reset_scanner_cycle_recovery(CancellationToken::new(), store.clone())
+        .await
+        .expect("lost-reply retry after a completed reset should be idempotent");
+    assert_eq!(
+        persisted_state(&store).await,
+        completed,
+        "a later retry must not create a second reset identity or rewrite durable fences"
+    );
+    assert_eq!(scanner_cycle_recovery_status().state, "healthy");
+}
+
+#[tokio::test]
+#[serial]
 async fn disabled_cleanup_movement_pause_preserves_intent_for_later_startup() {
     let (_dir, store) = setup_scanner_cycle_store().await;
     seed_cleanup(&store, "cleanup-pending").await;


### PR DESCRIPTION
## Related Issues
rustfs/backlog#2264

## Summary of Changes
Adds a focused Scanner/Heal V2 W15 regression test for concurrent explicit cycle reset requests. The test holds the real ECStore scanner leader namespace lock, starts two admin-style full-rescan reset calls against the same persisted recovery marker, then releases the live owner and verifies both calls converge to the same durable recovery fence. A later lost-reply retry must observe the completed fence without rewriting cycle state, usage state, or creating another reset identity.

## Verification
Tested commit: c397dceae6f8b7d104e450a71cab5e7b75b9d9d18.

- `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-scanner --lib concurrent_full_rescan_requests_converge_to_one_recovery_fence -j4`: 1 passed, 0 failed.
- `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-scanner --lib disabled_cleanup_ -j4`: 13 passed, 0 failed.
- `cargo +nightly-aarch64-apple-darwin fmt -p rustfs-scanner --check`: passed.
- `git diff --check`: passed.
- Adversarial validation: correctness, simplicity, and test-coverage lenses found no issue. The new oracle exercises the real ECStore lock path, asserts persisted state before lock ownership, verifies final cycle/usage fences, and confirms a later retry is idempotent.

Not fully completed by this test-only PR: old-writer/new-reader mixed-version fixture, lock-held I/O timing quantification, distributed crash/restart matrix, and full CI.

`cargo +nightly-aarch64-apple-darwin fmt --all --check` was not green because the current tree has an unrelated rustfmt diff in `crates/crypto/src/encdec/aes.rs`; this PR does not touch that file.

## Impact
Test-only. No runtime, wire-format, disk-format, configuration, or API behavior changes.

## Additional Notes
This is an incremental W15 evidence PR. It should not close rustfs/backlog#2264 by itself because the mixed-version and timing gates remain open.
