### PR TITLE
fix(ecstore): roll back failed CAS directory fsync

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -8708,6 +8708,34 @@ impl DiskAPI for LocalDisk {
                         });
                     }
 
+                    let rollback_after_fsync_failure = |parent: &Path, current: Option<&[u8]>| -> std::io::Result<()> {
+                        match current {
+                            Some(previous) => {
+                                let rollback_temporary =
+                                    parent.join(format!(".{}.{}.rollback.tmp", path.replace('/', "_"), Uuid::new_v4()));
+                                let rollback_result = (|| -> std::io::Result<()> {
+                                    let mut staged = std::fs::OpenOptions::new()
+                                        .create_new(true)
+                                        .write(true)
+                                        .open(&rollback_temporary)?;
+                                    staged.write_all(previous)?;
+                                    staged.sync_all()?;
+                                    std::fs::rename(&rollback_temporary, &file_path)
+                                })();
+                                if let Err(err) = rollback_result {
+                                    let _ = std::fs::remove_file(&rollback_temporary);
+                                    return Err(err);
+                                }
+                            }
+                            None => match std::fs::remove_file(&file_path) {
+                                Ok(()) => {}
+                                Err(err) if err.kind() == ErrorKind::NotFound => {}
+                                Err(err) => return Err(err),
+                            },
+                        }
+                        os::fsync_dir_std(parent)
+                    };
+
                     match replacement {
                         Some(replacement) => {
                             let parent = file_path
@@ -8727,14 +8755,19 @@ impl DiskAPI for LocalDisk {
                                 let _ = std::fs::remove_file(&temporary);
                                 return Err(err);
                             }
-                            if sync_metadata {
-                                os::fsync_dir_std(parent)?;
+                            if sync_metadata && let Err(err) = os::fsync_dir_std(parent) {
+                                rollback_after_fsync_failure(parent, current.as_deref())?;
+                                return Err(err);
                             }
                         }
                         None => {
                             std::fs::remove_file(&file_path)?;
-                            if sync_metadata && let Some(parent) = file_path.parent() {
-                                os::fsync_dir_std(parent)?;
+                            if sync_metadata
+                                && let Some(parent) = file_path.parent()
+                                && let Err(err) = os::fsync_dir_std(parent)
+                            {
+                                rollback_after_fsync_failure(parent, current.as_deref())?;
+                                return Err(err);
                             }
                         }
                     }
@@ -22164,6 +22197,110 @@ mod test {
             disk.read_all(RUSTFS_META_BUCKET, HEALING_MARKER_PATH).await,
             Err(DiskError::FileNotFound)
         ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn conditional_file_update_dir_fsync_failure_restores_previous_bytes() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+        let previous = Bytes::from_static(b"previous-owner");
+        let successor = Bytes::from_static(b"successor-owner");
+
+        assert_eq!(
+            disk.compare_and_update_file(RUSTFS_META_BUCKET, HEALING_MARKER_PATH, None, Some(previous.clone()))
+                .await
+                .expect("previous owner should commit"),
+            ConditionalFileUpdate::Updated
+        );
+
+        let marker_path = disk
+            .get_object_path(RUSTFS_META_BUCKET, HEALING_MARKER_PATH)
+            .expect("marker path should resolve");
+        let parent = marker_path.parent().expect("marker path should have a parent");
+        os::fsync_dir_recorder::set_failure(parent, ErrorKind::Other);
+
+        let err = disk
+            .compare_and_update_file(RUSTFS_META_BUCKET, HEALING_MARKER_PATH, Some(previous.clone()), Some(successor))
+            .await
+            .expect_err("directory fsync failure must fail the CAS update");
+        assert!(matches!(err, DiskError::Io(ref err) if err.kind() == ErrorKind::Other));
+        assert_eq!(
+            disk.read_all(RUSTFS_META_BUCKET, HEALING_MARKER_PATH)
+                .await
+                .expect("previous bytes should remain readable after rollback"),
+            previous
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn conditional_file_update_dir_fsync_failure_removes_new_file_without_anchor() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+        ensure_test_volume(&disk, RUSTFS_META_BUCKET).await;
+        let marker_path = disk
+            .get_object_path(RUSTFS_META_BUCKET, HEALING_MARKER_PATH)
+            .expect("marker path should resolve");
+        let parent = marker_path.parent().expect("marker path should have a parent");
+        os::fsync_dir_recorder::set_failure(parent, ErrorKind::Other);
+
+        let err = disk
+            .compare_and_update_file(
+                RUSTFS_META_BUCKET,
+                HEALING_MARKER_PATH,
+                None,
+                Some(Bytes::from_static(b"successor-owner")),
+            )
+            .await
+            .expect_err("directory fsync failure must fail the CAS create");
+        assert!(matches!(err, DiskError::Io(ref err) if err.kind() == ErrorKind::Other));
+        assert!(
+            matches!(disk.read_all(RUSTFS_META_BUCKET, HEALING_MARKER_PATH).await, Err(DiskError::FileNotFound)),
+            "uncommitted successor bytes must be removed when no previous anchor exists"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn conditional_file_delete_dir_fsync_failure_restores_previous_bytes() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+        let previous = Bytes::from_static(b"previous-owner");
+
+        assert_eq!(
+            disk.compare_and_update_file(RUSTFS_META_BUCKET, HEALING_MARKER_PATH, None, Some(previous.clone()))
+                .await
+                .expect("previous owner should commit"),
+            ConditionalFileUpdate::Updated
+        );
+
+        let marker_path = disk
+            .get_object_path(RUSTFS_META_BUCKET, HEALING_MARKER_PATH)
+            .expect("marker path should resolve");
+        let parent = marker_path.parent().expect("marker path should have a parent");
+        os::fsync_dir_recorder::set_failure(parent, ErrorKind::Other);
+
+        let err = disk
+            .compare_and_update_file(RUSTFS_META_BUCKET, HEALING_MARKER_PATH, Some(previous.clone()), None)
+            .await
+            .expect_err("directory fsync failure must fail the CAS delete");
+        assert!(matches!(err, DiskError::Io(ref err) if err.kind() == ErrorKind::Other));
+        assert_eq!(
+            disk.read_all(RUSTFS_META_BUCKET, HEALING_MARKER_PATH)
+                .await
+                .expect("previous bytes should be restored after failed delete"),
+            previous
+        );
     }
 
     #[cfg(unix)]

--- a/crates/ecstore/src/disk/os.rs
+++ b/crates/ecstore/src/disk/os.rs
@@ -92,6 +92,9 @@ pub(crate) mod fsync_dir_recorder {
     static LIMITED: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
     static GROUPED: Mutex<Vec<(PathBuf, usize)>> = Mutex::new(Vec::new());
     #[cfg(unix)]
+    static FAILURES: std::sync::LazyLock<Mutex<HashMap<PathBuf, io::ErrorKind>>> =
+        std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+    #[cfg(unix)]
     static BEFORE_LIMITED: std::sync::LazyLock<Mutex<HashMap<PathBuf, Hook>>> =
         std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
     static BEFORE_GROUP_BATCH: std::sync::LazyLock<Mutex<HashMap<PathBuf, Hook>>> =
@@ -149,6 +152,19 @@ pub(crate) mod fsync_dir_recorder {
 
     pub(crate) fn was_fsynced(dir: &Path) -> bool {
         contains_path(&RECORDED.lock().expect("fsync dir recorder poisoned"), dir)
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn set_failure(dir: &Path, kind: io::ErrorKind) {
+        FAILURES
+            .lock()
+            .expect("fsync dir failure hook poisoned")
+            .insert(dir.to_path_buf(), kind);
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn take_failure(dir: &Path) -> Option<io::ErrorKind> {
+        remove_path_keyed(&FAILURES, dir, "fsync dir failure hook poisoned")
     }
 
     #[cfg(unix)]
@@ -426,6 +442,10 @@ pub fn fsync_dir_std(dir: impl AsRef<Path>) -> io::Result<()> {
     fsync_dir_recorder::record(dir.as_ref());
     #[cfg(unix)]
     {
+        #[cfg(test)]
+        if let Some(kind) = fsync_dir_recorder::take_failure(dir.as_ref()) {
+            return Err(io::Error::from(kind));
+        }
         std::fs::File::open(dir.as_ref())?.sync_all()?;
     }
     #[cfg(not(unix))]


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#2263.
Related to rustfs/backlog#2240.

## Summary of Changes

The Unix local-disk `compare_and_update_file` path now rolls back the visible control-file mutation when the data rename/remove has completed but the required parent-directory fsync fails:

- replace restores the previous bytes through a synced rollback temporary file;
- create removes the unanchored new file;
- delete restores the previous bytes through the same rollback path.

This keeps a failed metadata CAS publication from advancing a recovery anchor after the call has returned an error.

## Verification

Tested commit: `022f1ecce515f47bc375543558ccd2ca543ee66c`.

- `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-ecstore --lib conditional_file -j4`: passed, 5/5 focused CAS tests.
- `cargo +nightly-aarch64-apple-darwin fmt --package rustfs-ecstore --check`: passed.
- `git diff --check origin/main...HEAD`: passed.

Adversarial validation:

- Correctness/test coverage reviewer: null verdict. Attacked replace/create/delete after parent fsync failure, CAS lock fencing, and inversion of the rollback assertions.
- Concurrency/durability/compatibility/performance reviewer: null verdict. Attacked rename/remove -> fsync failure -> rollback, rollback failure surfacing, mixed-version/no-format-change behavior, and success-path performance. No PR blocker found.

Not run successfully:

- `cargo +nightly-aarch64-apple-darwin clippy --locked -q -p rustfs-ecstore --lib -j4 -- -D warnings`: blocked by an unrelated existing `clippy::needless_bool` failure in `rustfs-io-metrics`.

Remaining risk: this is Unix local-disk unit coverage with injected parent fsync errors. It is not a real power-loss, device EIO, Windows control-file CAS, distributed crash, mixed-version, or end-to-end MRF recovery matrix.

## Impact

No S3 API or on-disk format change. Failed CAS publications become more conservative: the local file state is restored to the previous anchor, or removed for failed creates, before the error is returned.

## Additional Notes

This advances W12's CAS/fsync boundary evidence. It does not close W12 or the Scanner/Heal V2 epic by itself.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
