### PR TITLE
chore(deps): refresh scanner heal continuation lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3946,7 +3946,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4295,7 +4295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5693,7 +5693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5758,7 +5758,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6955,7 +6955,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8706,7 +8706,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11066,7 +11066,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11149,7 +11149,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12409,7 +12409,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13528,7 +13528,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Related Issues
Related: rustfs/backlog#2240.

## Summary of Changes
Refresh the shared lockfile baseline for the next Scanner/Heal V2 continuation batch after running `cargo update` and `cargo upgrade` on current `origin/main`.

The generated diff only changes transitive `windows-sys` selections in `Cargo.lock`. No manifest, Rust source, API, feature, or runtime behavior changes are included.

## Verification
Tested commit: `24dcab1937b5fe4037d7de1c72d95f64b9e362a4`.

- `cargo update` passed.
- `cargo upgrade` passed.
- `cargo metadata --no-deps --locked --format-version 1` passed.
- `cargo +nightly-aarch64-apple-darwin check --locked -q -p rustfs-scanner -p rustfs-heal -j4` passed.
- `git diff --check` passed.

## Impact
No S3 API, admin API, scanner/heal runtime, on-disk format, or configuration impact. This is a lockfile-only dependency resolution refresh.

## Additional Notes
This PR is intentionally separated from functional Scanner/Heal V2 work so implementation branches can avoid repeating lockfile churn.
