### PR TITLE
fix(scanner): replay recovery intents at startup

### DIFF
--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -87,9 +87,10 @@ pub use scanner::{
     ScannerCycleScheduleStatus, ScannerPauseBacklogAlertReason, ScannerPauseBacklogPhase, ScannerPauseBacklogStatus,
     ScannerPauseBacklogThresholds, ScannerRecoveryIntentAcceptResult, ScannerRecoveryIntentConflict, ScannerRecoveryIntentRecord,
     ScannerRecoveryIntentRequest, ScannerUsageStateResetResult, accept_scanner_usage_recovery_intent,
-    get_scanner_usage_recovery_intent, init_data_scanner, init_scanner_with_recovery, reset_scanner_cycle_recovery,
-    reset_scanner_usage_state_for_full_rebuild, run_scanner_usage_recovery_intent, scanner_cycle_recovery_status,
-    scanner_cycle_schedule_status, scanner_pause_backlog_status, scanner_recovery_actor_sha256, scanner_topology_digest,
+    get_scanner_usage_recovery_intent, init_data_scanner, init_scanner_with_recovery,
+    replay_pending_scanner_usage_recovery_intents, reset_scanner_cycle_recovery, reset_scanner_usage_state_for_full_rebuild,
+    run_scanner_usage_recovery_intent, scanner_cycle_recovery_status, scanner_cycle_schedule_status,
+    scanner_pause_backlog_status, scanner_recovery_actor_sha256, scanner_topology_digest,
 };
 pub use scanner_io::{
     ScannerDirtyUsageAckError, ScannerDirtyUsageBucket, ScannerDirtyUsageSnapshot, ScannerDirtyUsageState,

--- a/crates/scanner/src/scanner.rs
+++ b/crates/scanner/src/scanner.rs
@@ -956,22 +956,48 @@ pub async fn init_scanner_with_recovery(
     enabled: bool,
 ) -> Option<tokio::task::JoinHandle<()>> {
     if enabled {
-        init_data_scanner(ctx, storeapi).await;
-        return None;
-    }
-    Some(tokio::spawn(async move {
-        if let Err(error) = resume_scanner_cycle_cleanup(ctx, storeapi).await {
+        if let Err(error) = replay_pending_scanner_usage_recovery_intents(ctx.clone(), storeapi.clone()).await {
             warn!(
                 target: "rustfs::scanner",
                 event = EVENT_SCANNER_PERSIST_STATE,
                 component = LOG_COMPONENT_SCANNER,
                 subsystem = LOG_SUBSYSTEM_RUNTIME,
-                state = "disabled_cleanup_deferred",
+                state = "recovery_intent_replay_deferred",
                 error = %error,
-                "Disabled scanner cleanup remains pending for an operator retry"
+                "Scanner recovery intent replay remains pending"
             );
         }
+        init_data_scanner(ctx, storeapi).await;
+        return None;
+    }
+    Some(tokio::spawn(async move {
+        run_disabled_scanner_recovery(ctx, storeapi).await;
     }))
+}
+
+async fn run_disabled_scanner_recovery(ctx: CancellationToken, storeapi: Arc<ECStore>) {
+    if let Err(error) = resume_scanner_cycle_cleanup(ctx.clone(), storeapi.clone()).await {
+        warn!(
+            target: "rustfs::scanner",
+            event = EVENT_SCANNER_PERSIST_STATE,
+            component = LOG_COMPONENT_SCANNER,
+            subsystem = LOG_SUBSYSTEM_RUNTIME,
+            state = "disabled_cleanup_deferred",
+            error = %error,
+            "Disabled scanner cleanup remains pending for an operator retry"
+        );
+    }
+    if let Err(error) = replay_pending_scanner_usage_recovery_intents(ctx, storeapi).await {
+        warn!(
+            target: "rustfs::scanner",
+            event = EVENT_SCANNER_PERSIST_STATE,
+            component = LOG_COMPONENT_SCANNER,
+            subsystem = LOG_SUBSYSTEM_RUNTIME,
+            state = "disabled_recovery_intent_replay_deferred",
+            error = %error,
+            "Disabled scanner recovery intent replay remains pending for an operator retry"
+        );
+    }
 }
 
 async fn init_data_scanner_with_storage<S>(ctx: CancellationToken, storeapi: Arc<S>)
@@ -3593,8 +3619,8 @@ pub use cycle_state::{
     SCANNER_RECOVERY_INTENT_ACTION_USAGE_FULL_REBUILD, ScannerCycleRecoveryMarker, ScannerCycleRecoveryStatus,
     ScannerRecoveryIntentAcceptResult, ScannerRecoveryIntentConflict, ScannerRecoveryIntentRecord, ScannerRecoveryIntentRequest,
     ScannerUsageStateResetResult, accept_scanner_usage_recovery_intent, get_scanner_usage_recovery_intent,
-    reset_scanner_cycle_recovery, reset_scanner_usage_state_for_full_rebuild, run_scanner_usage_recovery_intent,
-    scanner_cycle_recovery_status, scanner_recovery_actor_sha256,
+    replay_pending_scanner_usage_recovery_intents, reset_scanner_cycle_recovery, reset_scanner_usage_state_for_full_rebuild,
+    run_scanner_usage_recovery_intent, scanner_cycle_recovery_status, scanner_recovery_actor_sha256,
 };
 pub(crate) use cycle_state::{
     current_scanner_leader_epoch, decode_persisted_scanner_cycle_fence, load_scanner_cycle_state_for_startup,

--- a/crates/scanner/src/scanner/cycle_state.rs
+++ b/crates/scanner/src/scanner/cycle_state.rs
@@ -17,7 +17,7 @@ use crate::ScannerGetObjectReader;
 use crate::data_usage_define::{
     DATA_USAGE_BLOOM_RECOVERY_PATH, DATA_USAGE_RECOVERY_PATH, usage_floor_primary_read_error_allows_backup,
 };
-use crate::storage_api::owner::ObjectIO as _;
+use crate::storage_api::owner::{ListOperations as _, ObjectIO as _};
 use std::sync::atomic::AtomicU64;
 use tokio::io::AsyncReadExt as _;
 
@@ -37,6 +37,8 @@ const SCANNER_USAGE_STATE_RESET_MODE_FULL_REBUILD: &str = "full-rebuild";
 const SCANNER_RECOVERY_INTENT_SCHEMA_VERSION: u16 = 1;
 const SCANNER_RECOVERY_INTENT_PREFIX: &str = ".usage.v2.recovery-intents";
 const MAX_SCANNER_RECOVERY_INTENT_BYTES: u64 = 16 * 1024;
+const MAX_SCANNER_RECOVERY_INTENT_REPLAY_KEYS: i32 = 100;
+const MAX_SCANNER_RECOVERY_INTENT_REPLAY_PAGES: usize = 1024;
 const SCANNER_RECOVERY_INTENT_STATE_ACCEPTED: &str = "accepted";
 const SCANNER_RECOVERY_INTENT_STATE_RUNNING: &str = "running";
 const SCANNER_RECOVERY_INTENT_STATE_COMPLETED: &str = "completed";
@@ -723,6 +725,108 @@ pub async fn run_scanner_usage_recovery_intent(
             Err(err)
         }
     }
+}
+
+pub async fn replay_pending_scanner_usage_recovery_intents(
+    ctx: CancellationToken,
+    storeapi: Arc<ECStore>,
+) -> Result<usize, ScannerError> {
+    let prefix = format!("{SCANNER_RECOVERY_INTENT_PREFIX}/");
+    let mut continuation = None;
+    let mut replayed = 0_usize;
+
+    for _ in 0..MAX_SCANNER_RECOVERY_INTENT_REPLAY_PAGES {
+        if ctx.is_cancelled() {
+            return Ok(replayed);
+        }
+        let page = storeapi
+            .clone()
+            .list_objects_v2(
+                RUSTFS_META_BUCKET,
+                &prefix,
+                continuation,
+                None,
+                MAX_SCANNER_RECOVERY_INTENT_REPLAY_KEYS,
+                false,
+                None,
+                false,
+            )
+            .await
+            .map_err(|err| ScannerError::Other(format!("failed to list scanner recovery intents: {err}")))?;
+
+        for object in page.objects {
+            if ctx.is_cancelled() {
+                return Ok(replayed);
+            }
+            let Some(intent_id) = object
+                .name
+                .strip_prefix(&prefix)
+                .and_then(|name| name.strip_suffix(".json"))
+                .filter(|name| !name.contains('/'))
+            else {
+                continue;
+            };
+            let path = match scanner_recovery_intent_path(intent_id) {
+                Ok(path) => path,
+                Err(error) => {
+                    warn!(
+                        target: "rustfs::scanner",
+                        event = EVENT_SCANNER_PERSIST_STATE,
+                        component = LOG_COMPONENT_SCANNER,
+                        subsystem = LOG_SUBSYSTEM_RUNTIME,
+                        state = "recovery_intent_replay_skipped",
+                        intent_id = %intent_id,
+                        error = %error,
+                        "Scanner recovery intent replay skipped one invalid record"
+                    );
+                    continue;
+                }
+            };
+            let record = match read_recovery_intent_record(storeapi.clone(), &path).await {
+                Ok(Some(record)) => record,
+                Ok(None) => continue,
+                Err(error) => {
+                    warn!(
+                        target: "rustfs::scanner",
+                        event = EVENT_SCANNER_PERSIST_STATE,
+                        component = LOG_COMPONENT_SCANNER,
+                        subsystem = LOG_SUBSYSTEM_RUNTIME,
+                        state = "recovery_intent_replay_skipped",
+                        intent_id = %intent_id,
+                        error = %error,
+                        "Scanner recovery intent replay skipped one invalid record"
+                    );
+                    continue;
+                }
+            };
+            if !matches!(
+                record.state.as_str(),
+                SCANNER_RECOVERY_INTENT_STATE_ACCEPTED | SCANNER_RECOVERY_INTENT_STATE_RUNNING
+            ) {
+                continue;
+            }
+            if run_scanner_usage_recovery_intent(ctx.clone(), storeapi.clone(), record.intent_id)
+                .await?
+                .is_some()
+            {
+                replayed = replayed.saturating_add(1);
+            }
+        }
+
+        if !page.is_truncated {
+            return Ok(replayed);
+        }
+        continuation = page.next_continuation_token;
+        if continuation.is_none() {
+            return Err(ScannerError::Other(
+                "scanner recovery intent listing was truncated without a continuation token".to_string(),
+            ));
+        }
+    }
+
+    Err(ScannerError::Other(
+        "scanner recovery intent replay exceeded the bounded page limit".to_string(),
+    ))
 }
 
 fn recovery_status(state: &str, reason: Option<&str>, retryable: bool) -> ScannerCycleRecoveryStatus {

--- a/crates/scanner/src/scanner/tests/recovery_control.rs
+++ b/crates/scanner/src/scanner/tests/recovery_control.rs
@@ -401,6 +401,115 @@ async fn scanner_recovery_intent_query_rejects_oversized_records() {
 
 #[tokio::test]
 #[serial]
+async fn scanner_recovery_intent_replay_runs_only_non_terminal_records() {
+    let (_dir, store) = setup_scanner_cycle_store().await;
+    let accepted = match accept_scanner_usage_recovery_intent(
+        store.clone(),
+        recovery_intent_request("intent-key-0004-accepted", "operator-a"),
+    )
+    .await
+    .expect("accepted intent should persist")
+    {
+        ScannerRecoveryIntentAcceptResult::Accepted { record } => record,
+        other => panic!("first accepted intent must create a durable record: {other:?}"),
+    };
+    let mut running = match accept_scanner_usage_recovery_intent(
+        store.clone(),
+        recovery_intent_request("intent-key-0004-running", "operator-a"),
+    )
+    .await
+    .expect("running fixture intent should persist")
+    {
+        ScannerRecoveryIntentAcceptResult::Accepted { record } => record,
+        other => panic!("running fixture must create a durable record: {other:?}"),
+    };
+    running.state = "running".to_string();
+    save_config(
+        store.clone(),
+        &format!(".usage.v2.recovery-intents/{}.json", running.intent_id),
+        serde_json::to_vec(&running).expect("running intent should encode"),
+    )
+    .await
+    .expect("running intent fixture should persist");
+    let mut completed = match accept_scanner_usage_recovery_intent(
+        store.clone(),
+        recovery_intent_request("intent-key-0004-completed", "operator-a"),
+    )
+    .await
+    .expect("completed fixture intent should persist")
+    {
+        ScannerRecoveryIntentAcceptResult::Accepted { record } => record,
+        other => panic!("completed fixture must create a durable record: {other:?}"),
+    };
+    completed.state = "completed".to_string();
+    save_config(
+        store.clone(),
+        &format!(".usage.v2.recovery-intents/{}.json", completed.intent_id),
+        serde_json::to_vec(&completed).expect("completed intent should encode"),
+    )
+    .await
+    .expect("completed intent fixture should persist");
+    let corrupt_id = scanner_recovery_actor_sha256("corrupt-replay-intent");
+    save_config(
+        store.clone(),
+        &format!(".usage.v2.recovery-intents/{corrupt_id}.json"),
+        b"{corrupt".to_vec(),
+    )
+    .await
+    .expect("corrupt intent fixture should persist");
+    save_config(store.clone(), ".usage.v2.recovery-intents/not-a-canonical-intent-id.json", b"{}".to_vec())
+        .await
+        .expect("invalid intent filename fixture should persist");
+
+    let replayed = replay_pending_scanner_usage_recovery_intents(CancellationToken::new(), store.clone())
+        .await
+        .expect("pending intent replay should skip invalid records and continue");
+    assert_eq!(replayed, 2);
+
+    let accepted_after = get_scanner_usage_recovery_intent(store.clone(), &accepted.intent_id)
+        .await
+        .expect("accepted replay record should read")
+        .expect("accepted replay record should remain durable");
+    assert_eq!(accepted_after.state, "completed");
+    let running_after = get_scanner_usage_recovery_intent(store.clone(), &running.intent_id)
+        .await
+        .expect("running replay record should read")
+        .expect("running replay record should remain durable");
+    assert_eq!(running_after.state, "completed");
+    let completed_after = get_scanner_usage_recovery_intent(store, &completed.intent_id)
+        .await
+        .expect("completed replay record should read")
+        .expect("completed replay record should remain durable");
+    assert_eq!(completed_after, completed);
+}
+
+#[tokio::test]
+#[serial]
+async fn disabled_startup_replays_persisted_recovery_intent_without_starting_scanner() {
+    let (_dir, store) = setup_scanner_cycle_store().await;
+    let record = match accept_scanner_usage_recovery_intent(
+        store.clone(),
+        recovery_intent_request("intent-key-0005-disabled-startup", "operator-a"),
+    )
+    .await
+    .expect("disabled startup fixture intent should persist")
+    {
+        ScannerRecoveryIntentAcceptResult::Accepted { record } => record,
+        other => panic!("disabled startup fixture must create a durable record: {other:?}"),
+    };
+
+    let restarted = restart_scanner_cycle_store_from(&store).await;
+    run_disabled_startup(CancellationToken::new(), restarted.clone()).await;
+
+    let replayed = get_scanner_usage_recovery_intent(restarted, &record.intent_id)
+        .await
+        .expect("disabled startup replay record should read")
+        .expect("disabled startup replay record should remain durable");
+    assert_eq!(replayed.state, "completed");
+}
+
+#[tokio::test]
+#[serial]
 async fn disabled_cleanup_reopens_persisted_intent_without_starting_scanner() {
     let (_dir, store) = setup_scanner_cycle_store().await;
     seed_cleanup(&store, "cleanup-pending").await;

--- a/crates/scanner/src/storage_api.rs
+++ b/crates/scanner/src/storage_api.rs
@@ -139,7 +139,7 @@ pub(crate) mod owner {
     pub(crate) use rustfs_ecstore::api::set_disk::test_util::hold_namespace_commit as ecstore_hold_namespace_commit;
 
     pub(crate) use super::storage_contracts::{
-        HTTPPreconditions, HTTPRangeSpec, NS_SCANNER_PROTOCOL_VERSION, ObjectIO, ObjectOperations, ObjectToDelete,
+        HTTPPreconditions, HTTPRangeSpec, ListOperations, NS_SCANNER_PROTOCOL_VERSION, ObjectIO, ObjectOperations, ObjectToDelete,
     };
 
     pub(crate) use super::{


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#2279 and rustfs/backlog#2240.

## Summary of Changes

Durable scanner usage recovery intents are now replayed from `.usage.v2.recovery-intents/` during scanner startup. Startup lists the meta-bucket intent prefix with a bounded page budget, skips terminal records, skips malformed records without blocking later intents, and executes only `accepted` or `running` records through the existing CAS-backed executor.

When the scanner is disabled, startup still performs finite recovery work: it resumes the existing cycle cleanup path and then replays already accepted durable recovery intents without enabling ordinary namespace scanning.

## Verification

Tested commit: `6f0900ffb`.

- `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-scanner --lib scanner_recovery_intent -j4` PASS: 7/7 recovery intent tests passed, including bounded replay of accepted/running records while terminal, malformed, and invalid-name records are skipped.
- `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-scanner --lib disabled_startup_replays_persisted_recovery_intent_without_starting_scanner -j4` PASS: disabled startup replays a persisted intent and does not start the normal scanner runtime.
- `cargo +nightly-aarch64-apple-darwin fmt --package rustfs-scanner --check` PASS.
- `./scripts/check_architecture_migration_rules.sh` PASS.
- `git diff --check` PASS.

Not run: distributed crash/restart cluster E2E, mixed-version node matrix, and long-running recovery throughput lanes. Those remain required before closing the parent Scanner/Heal V2 recovery-intent issue.

## Impact

This closes the gap where an async scanner usage reset accepted by the admin API could be left durable but unexecuted after the original handler task or process disappeared. Startup now makes accepted/running intents retryable across process restarts. The change does not alter the persisted intent schema and does not add dependencies.

Adversarial review summary:

- Correctness: non-terminal selection, terminal skip, invalid filename skip, corrupt record skip, and disabled-startup execution were attacked by focused tests.
- Concurrency/durability: replay reuses the existing persisted CAS state transitions; enabled startup waits for replay before starting the ordinary scanner runtime to avoid reset/scan overlap.
- Compatibility: no schema bump or new wire fields; old records remain readable by the existing decoder.
- Performance: replay is startup-only and bounded by page count/key count; no PUT/GET/object hot path changes.

## Additional Notes

The existing executor still relies on the durable intent state for idempotency and does not add a separate owner lease in this PR. Real multi-node duplicate-executor fencing remains a follow-up item for the full W16 closeout.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
