### PR TITLE
feat(scanner): replay recovery intents at startup

### DIFF
--- a/crates/scanner/src/scanner.rs
+++ b/crates/scanner/src/scanner.rs
@@ -956,10 +956,34 @@ pub async fn init_scanner_with_recovery(
     enabled: bool,
 ) -> Option<tokio::task::JoinHandle<()>> {
     if enabled {
-        init_data_scanner(ctx, storeapi).await;
+        tokio::spawn(async move {
+            if let Err(error) = resume_scanner_usage_recovery_intents(ctx.clone(), storeapi.clone()).await {
+                warn!(
+                    target: "rustfs::scanner",
+                    event = EVENT_SCANNER_PERSIST_STATE,
+                    component = LOG_COMPONENT_SCANNER,
+                    subsystem = LOG_SUBSYSTEM_RUNTIME,
+                    state = "startup_recovery_intent_deferred",
+                    error = %error,
+                    "Scanner recovery intent replay was deferred"
+                );
+            }
+            init_data_scanner(ctx, storeapi).await;
+        });
         return None;
     }
     Some(tokio::spawn(async move {
+        if let Err(error) = resume_scanner_usage_recovery_intents(ctx.clone(), storeapi.clone()).await {
+            warn!(
+                target: "rustfs::scanner",
+                event = EVENT_SCANNER_PERSIST_STATE,
+                component = LOG_COMPONENT_SCANNER,
+                subsystem = LOG_SUBSYSTEM_RUNTIME,
+                state = "disabled_recovery_intent_deferred",
+                error = %error,
+                "Disabled scanner recovery intent replay was deferred"
+            );
+        }
         if let Err(error) = resume_scanner_cycle_cleanup(ctx, storeapi).await {
             warn!(
                 target: "rustfs::scanner",

--- a/crates/scanner/src/scanner/cycle_state.rs
+++ b/crates/scanner/src/scanner/cycle_state.rs
@@ -36,7 +36,10 @@ const CACHE_CYCLE_AHEAD: &str = "cache_cycle_ahead";
 const SCANNER_USAGE_STATE_RESET_MODE_FULL_REBUILD: &str = "full-rebuild";
 const SCANNER_RECOVERY_INTENT_SCHEMA_VERSION: u16 = 1;
 const SCANNER_RECOVERY_INTENT_PREFIX: &str = ".usage.v2.recovery-intents";
+const SCANNER_RECOVERY_INTENT_INDEX_PATH: &str = ".usage.v2.recovery-intents/index.json";
 const MAX_SCANNER_RECOVERY_INTENT_BYTES: u64 = 16 * 1024;
+const MAX_SCANNER_RECOVERY_INTENT_INDEX_BYTES: u64 = 32 * 1024;
+const MAX_SCANNER_RECOVERY_INTENT_INDEX_ENTRIES: usize = 256;
 const SCANNER_RECOVERY_INTENT_STATE_ACCEPTED: &str = "accepted";
 const SCANNER_RECOVERY_INTENT_STATE_RUNNING: &str = "running";
 const SCANNER_RECOVERY_INTENT_STATE_COMPLETED: &str = "completed";
@@ -175,6 +178,14 @@ pub struct ScannerRecoveryIntentRecord {
     pub idempotency_key_sha256: String,
     pub request_sha256: String,
     pub accepted_at_unix_secs: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct ScannerRecoveryIntentIndex {
+    schema_version: u16,
+    intent_ids: Vec<String>,
+    updated_at_unix_secs: u64,
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
@@ -530,6 +541,113 @@ fn decode_recovery_intent_record(data: &[u8]) -> Result<ScannerRecoveryIntentRec
     Ok(record)
 }
 
+fn empty_recovery_intent_index() -> ScannerRecoveryIntentIndex {
+    ScannerRecoveryIntentIndex {
+        schema_version: SCANNER_RECOVERY_INTENT_SCHEMA_VERSION,
+        intent_ids: Vec::new(),
+        updated_at_unix_secs: unix_now_secs(),
+    }
+}
+
+fn validate_recovery_intent_index(index: &ScannerRecoveryIntentIndex) -> Result<(), ScannerError> {
+    if index.schema_version != SCANNER_RECOVERY_INTENT_SCHEMA_VERSION {
+        return Err(ScannerError::Other("scanner recovery intent index schema is unsupported".to_string()));
+    }
+    if index.intent_ids.len() > MAX_SCANNER_RECOVERY_INTENT_INDEX_ENTRIES {
+        return Err(ScannerError::Other(
+            "scanner recovery intent index exceeds the bounded entry count".to_string(),
+        ));
+    }
+    for (position, intent_id) in index.intent_ids.iter().enumerate() {
+        if !is_canonical_sha256(intent_id) {
+            return Err(ScannerError::Other(
+                "scanner recovery intent index contains an invalid intent id".to_string(),
+            ));
+        }
+        if index.intent_ids[..position].contains(intent_id) {
+            return Err(ScannerError::Other(
+                "scanner recovery intent index contains a duplicate intent id".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn decode_recovery_intent_index(data: &[u8]) -> Result<ScannerRecoveryIntentIndex, ScannerError> {
+    let index: ScannerRecoveryIntentIndex = serde_json::from_slice(data)
+        .map_err(|err| ScannerError::Other(format!("scanner recovery intent index is invalid: {err}")))?;
+    validate_recovery_intent_index(&index)?;
+    Ok(index)
+}
+
+async fn read_recovery_intent_index_with_revision(
+    storeapi: Arc<impl ScannerObjectIO>,
+) -> Result<(ScannerRecoveryIntentIndex, DataUsageCacheRevision), ScannerError> {
+    match read_config_with_revision(storeapi, SCANNER_RECOVERY_INTENT_INDEX_PATH).await {
+        Ok((data, revision)) => {
+            let Some(data) = data else {
+                return Ok((empty_recovery_intent_index(), revision));
+            };
+            if data.is_empty() || data.len() > usize::try_from(MAX_SCANNER_RECOVERY_INTENT_INDEX_BYTES).unwrap_or(usize::MAX) {
+                return Err(ScannerError::Other(
+                    "scanner recovery intent index exceeds the bounded object size".to_string(),
+                ));
+            }
+            decode_recovery_intent_index(&data).map(|index| (index, revision))
+        }
+        Err(
+            EcstoreError::FileNotFound
+            | EcstoreError::VolumeNotFound
+            | EcstoreError::ObjectNotFound(_, _)
+            | EcstoreError::BucketNotFound(_)
+            | EcstoreError::ConfigNotFound,
+        ) => Ok((empty_recovery_intent_index(), DataUsageCacheRevision::Missing)),
+        Err(err) => Err(ScannerError::Other(format!("failed to read scanner recovery intent index: {err}"))),
+    }
+}
+
+async fn ensure_scanner_recovery_intent_indexed(
+    storeapi: Arc<impl ScannerObjectIO>,
+    intent_id: &str,
+) -> Result<(), ScannerError> {
+    if !is_canonical_sha256(intent_id) {
+        return Err(ScannerError::Other("scanner recovery intent id is invalid".to_string()));
+    }
+    for _ in 0..8 {
+        let (mut index, revision) = read_recovery_intent_index_with_revision(storeapi.clone()).await?;
+        if index.intent_ids.iter().any(|existing| existing == intent_id) {
+            return Ok(());
+        }
+        if index.intent_ids.len() >= MAX_SCANNER_RECOVERY_INTENT_INDEX_ENTRIES {
+            return Err(ScannerError::Other("scanner recovery intent index is full".to_string()));
+        }
+        index.intent_ids.push(intent_id.to_string());
+        index.updated_at_unix_secs = unix_now_secs();
+        let encoded = serde_json::to_vec(&index)
+            .map_err(|err| ScannerError::Other(format!("failed to encode scanner recovery intent index: {err}")))?;
+        if encoded.len() > usize::try_from(MAX_SCANNER_RECOVERY_INTENT_INDEX_BYTES).unwrap_or(usize::MAX) {
+            return Err(ScannerError::Other(
+                "scanner recovery intent index exceeds the bounded object size".to_string(),
+            ));
+        }
+        match save_config_with_preconditions(
+            storeapi.clone(),
+            SCANNER_RECOVERY_INTENT_INDEX_PATH,
+            encoded,
+            revision.preconditions(),
+        )
+        .await
+        {
+            Ok(_) => return Ok(()),
+            Err(EcstoreError::PreconditionFailed) => continue,
+            Err(err) => return Err(ScannerError::Other(format!("failed to persist scanner recovery intent index: {err}"))),
+        }
+    }
+    Err(ScannerError::Other(
+        "scanner recovery intent index changed repeatedly during update".to_string(),
+    ))
+}
+
 fn compare_recovery_intent(
     expected: &ScannerRecoveryIntentRecord,
     existing: ScannerRecoveryIntentRecord,
@@ -633,18 +751,54 @@ pub async fn accept_scanner_usage_recovery_intent(
         .map_err(|err| ScannerError::Other(format!("failed to encode scanner recovery intent: {err}")))?;
     match save_config_with_preconditions(storeapi.clone(), &path, encoded, DataUsageCacheRevision::Missing.preconditions()).await
     {
-        Ok(_) => Ok(ScannerRecoveryIntentAcceptResult::Accepted { record: candidate }),
+        Ok(_) => {
+            ensure_scanner_recovery_intent_indexed(storeapi, &candidate.intent_id).await?;
+            Ok(ScannerRecoveryIntentAcceptResult::Accepted { record: candidate })
+        }
         Err(EcstoreError::PreconditionFailed) => {
-            let existing = read_recovery_intent_record(storeapi, &path).await?;
+            let existing = read_recovery_intent_record(storeapi.clone(), &path).await?;
             let Some(existing) = existing else {
                 return Err(ScannerError::Other(
                     "scanner recovery intent disappeared after creation conflict".to_string(),
                 ));
             };
-            Ok(compare_recovery_intent(&candidate, existing))
+            let result = compare_recovery_intent(&candidate, existing);
+            if let ScannerRecoveryIntentAcceptResult::Replayed { record } = &result {
+                ensure_scanner_recovery_intent_indexed(storeapi, &record.intent_id).await?;
+            }
+            Ok(result)
         }
         Err(err) => Err(ScannerError::Other(format!("failed to persist scanner recovery intent: {err}"))),
     }
+}
+
+pub(crate) async fn resume_scanner_usage_recovery_intents(
+    ctx: CancellationToken,
+    storeapi: Arc<ECStore>,
+) -> Result<usize, ScannerError> {
+    let (index, _) = read_recovery_intent_index_with_revision(storeapi.clone()).await?;
+    let mut resumed = 0_usize;
+    for intent_id in index.intent_ids {
+        if ctx.is_cancelled() {
+            return Err(ScannerError::Other("scanner recovery intent startup replay was cancelled".to_string()));
+        }
+        let Some(record) = get_scanner_usage_recovery_intent(storeapi.clone(), &intent_id).await? else {
+            continue;
+        };
+        if !matches!(
+            record.state.as_str(),
+            SCANNER_RECOVERY_INTENT_STATE_ACCEPTED | SCANNER_RECOVERY_INTENT_STATE_RUNNING
+        ) {
+            continue;
+        }
+        if run_scanner_usage_recovery_intent(ctx.clone(), storeapi.clone(), intent_id)
+            .await?
+            .is_some()
+        {
+            resumed = resumed.saturating_add(1);
+        }
+    }
+    Ok(resumed)
 }
 
 async fn transition_scanner_usage_recovery_intent(

--- a/crates/scanner/src/scanner/tests/recovery_control.rs
+++ b/crates/scanner/src/scanner/tests/recovery_control.rs
@@ -283,6 +283,147 @@ async fn scanner_recovery_intent_executor_persists_completed_progress() {
 
 #[tokio::test]
 #[serial]
+async fn scanner_recovery_intent_startup_replays_indexed_non_terminal_records() {
+    let (_dir, store) = setup_scanner_cycle_store().await;
+    let completed_record = match accept_scanner_usage_recovery_intent(
+        store.clone(),
+        recovery_intent_request("intent-key-0001-startup-done", "operator-a"),
+    )
+    .await
+    .expect("completed seed intent should persist")
+    {
+        ScannerRecoveryIntentAcceptResult::Accepted { record } => record,
+        other => panic!("seed request must create a durable intent: {other:?}"),
+    };
+    run_scanner_usage_recovery_intent(CancellationToken::new(), store.clone(), completed_record.intent_id.clone())
+        .await
+        .expect("seed intent should execute")
+        .expect("seed intent should reset");
+
+    let accepted_record = match accept_scanner_usage_recovery_intent(
+        store.clone(),
+        recovery_intent_request("intent-key-0002-startup-accepted", "operator-a"),
+    )
+    .await
+    .expect("accepted startup intent should persist")
+    {
+        ScannerRecoveryIntentAcceptResult::Accepted { record } => record,
+        other => panic!("accepted request must create a durable intent: {other:?}"),
+    };
+    let mut running_record = match accept_scanner_usage_recovery_intent(
+        store.clone(),
+        recovery_intent_request("intent-key-0003-startup-running", "operator-a"),
+    )
+    .await
+    .expect("running startup intent should persist")
+    {
+        ScannerRecoveryIntentAcceptResult::Accepted { record } => record,
+        other => panic!("running request must create a durable intent: {other:?}"),
+    };
+    running_record.state = "running".to_string();
+    save_config(
+        store.clone(),
+        &format!(".usage.v2.recovery-intents/{}.json", running_record.intent_id),
+        serde_json::to_vec(&running_record).expect("running intent should encode"),
+    )
+    .await
+    .expect("persist simulated in-flight intent");
+
+    let restarted = restart_scanner_cycle_store_from(&store).await;
+    let resumed = resume_scanner_usage_recovery_intents(CancellationToken::new(), restarted.clone())
+        .await
+        .expect("startup replay should discover non-terminal intents");
+    assert_eq!(resumed, 2);
+    for intent_id in [
+        completed_record.intent_id.as_str(),
+        accepted_record.intent_id.as_str(),
+        running_record.intent_id.as_str(),
+    ] {
+        let record = get_scanner_usage_recovery_intent(restarted.clone(), intent_id)
+            .await
+            .expect("intent should remain readable")
+            .expect("intent should remain durable");
+        assert_eq!(record.state, "completed");
+    }
+    let after_first_startup = persisted_state(&restarted).await;
+    let resumed_again = resume_scanner_usage_recovery_intents(CancellationToken::new(), restarted.clone())
+        .await
+        .expect("terminal startup replay should be idempotent");
+    assert_eq!(resumed_again, 0);
+    assert_eq!(persisted_state(&restarted).await, after_first_startup);
+}
+
+#[tokio::test]
+#[serial]
+async fn scanner_recovery_intent_replay_repairs_missing_startup_index() {
+    let (_dir, store) = setup_scanner_cycle_store().await;
+    let request = recovery_intent_request("intent-key-0004-reindex", "operator-a");
+    let accepted = accept_scanner_usage_recovery_intent(store.clone(), request.clone())
+        .await
+        .expect("initial intent should persist");
+    let record = match accepted {
+        ScannerRecoveryIntentAcceptResult::Accepted { record } => record,
+        other => panic!("initial request must create a durable intent: {other:?}"),
+    };
+    save_config(
+        store.clone(),
+        ".usage.v2.recovery-intents/index.json",
+        serde_json::to_vec(&serde_json::json!({
+            "schema_version": 1,
+            "intent_ids": [],
+            "updated_at_unix_secs": 1,
+        }))
+        .expect("empty recovery index should encode"),
+    )
+    .await
+    .expect("simulate an intent persisted before its index update");
+
+    let replay = accept_scanner_usage_recovery_intent(store.clone(), request)
+        .await
+        .expect("lost response replay should repair the startup index");
+    assert_eq!(replay, ScannerRecoveryIntentAcceptResult::Replayed { record: record.clone() });
+
+    let restarted = restart_scanner_cycle_store_from(&store).await;
+    let resumed = resume_scanner_usage_recovery_intents(CancellationToken::new(), restarted.clone())
+        .await
+        .expect("repaired index should be startup-discoverable");
+    assert_eq!(resumed, 1);
+    let completed = get_scanner_usage_recovery_intent(restarted, &record.intent_id)
+        .await
+        .expect("completed intent should read")
+        .expect("completed intent should remain durable");
+    assert_eq!(completed.state, "completed");
+}
+
+#[tokio::test]
+#[serial]
+async fn scanner_recovery_intent_startup_rejects_corrupt_index_without_running_records() {
+    let (_dir, store) = setup_scanner_cycle_store().await;
+    let request = recovery_intent_request("intent-key-0005-corrupt-index", "operator-a");
+    let record = match accept_scanner_usage_recovery_intent(store.clone(), request)
+        .await
+        .expect("intent should persist")
+    {
+        ScannerRecoveryIntentAcceptResult::Accepted { record } => record,
+        other => panic!("initial request must create a durable intent: {other:?}"),
+    };
+    save_config(store.clone(), ".usage.v2.recovery-intents/index.json", b"{broken".to_vec())
+        .await
+        .expect("corrupt startup index");
+
+    let error = resume_scanner_usage_recovery_intents(CancellationToken::new(), store.clone())
+        .await
+        .expect_err("corrupt index must stop startup replay");
+    assert!(error.to_string().contains("scanner recovery intent index is invalid"));
+    let retained = get_scanner_usage_recovery_intent(store, &record.intent_id)
+        .await
+        .expect("intent should remain readable")
+        .expect("intent should remain durable");
+    assert_eq!(retained.state, "accepted");
+}
+
+#[tokio::test]
+#[serial]
 async fn scanner_recovery_intent_executor_persists_failed_progress() {
     let (_dir, store) = setup_scanner_cycle_store().await;
     let record = match accept_scanner_usage_recovery_intent(


### PR DESCRIPTION
## Related Issues

Part of rustfs/backlog#2279.

## Summary of Changes

Persist a bounded scanner recovery intent index alongside durable full-rebuild recovery intents, and repair that index when the same idempotent request is replayed after a lost response.

On startup, `init_scanner_with_recovery` now replays indexed non-terminal scanner recovery intents before starting the normal scanner loop. The disabled scanner branch also performs the same finite intent replay without enabling ordinary namespace scanning. Terminal intents remain durable and are not executed a second time, while corrupt or oversized indexes fail closed instead of being treated as empty.

No dependency, wire protocol, public admin route, or external madmin API changes are included.

## Verification

Tested commit: `96e2780d3a04a77091ef59c7a4e9a5200cefb869`.

- `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-scanner --lib scanner_recovery_intent -j4`: PASS, 9/9.
- `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-scanner --lib disabled_cleanup_ -j4`: PASS, 13/13.
- `cargo +nightly-aarch64-apple-darwin check --locked -q -p rustfs-scanner --lib -j4`: PASS.
- `cargo +nightly-aarch64-apple-darwin fmt --package rustfs-scanner --check`: PASS.
- `git diff --check`: PASS.

Two adversarial passes were completed for correctness/compatibility and concurrency/durability/test coverage. One startup ordering finding was fixed by replaying intents before the normal scanner loop is started.

Not run: real process crash/restart, mixed-version startup, and distributed cluster recovery. Older records persisted before this index existed are repairable by replaying the same idempotent request, but this PR does not add raw prefix enumeration for pre-index records.

## Impact

Scanner recovery intents accepted before a restart no longer depend on the original admin request task surviving. Indexed `accepted` and `running` full-rebuild intents are rediscovered and completed on startup. Invalid index data is surfaced as a deferred replay error and does not silently clear or execute recovery work.

## Additional Notes

This is a focused W16 startup rediscovery slice. The broader backlog item remains open for full process crash/restart evidence, mixed-version behavior, and end-to-end disabled-scanner recovery validation.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
