### PR TITLE
fix(ecstore): isolate pool metadata read probes

### DIFF
--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -4490,11 +4490,20 @@ impl PoolMetaWriteState {
 
     fn observe_selection(&mut self, selection: &PoolMetaSelection) -> Result<()> {
         self.pool_meta_absent = selection.absent;
+        self.validate_selection(selection)?;
+        if self.cluster_epoch.is_none()
+            && let Some((_, metadata_epoch)) = selection.generation_identity
+        {
+            self.cluster_epoch = Some(metadata_epoch);
+        }
+        Ok(())
+    }
+
+    fn validate_selection(&self, selection: &PoolMetaSelection) -> Result<()> {
         if let Some(expected_cluster_id) = self.expected_cluster_id
             && let Some((cluster_id, _)) = selection.generation_identity
             && cluster_id != expected_cluster_id
         {
-            self.block_writes();
             return Err(Error::other(format!(
                 "pool metadata incompatible: cluster identity {cluster_id} does not match deployment {expected_cluster_id}"
             )));
@@ -4503,16 +4512,10 @@ impl PoolMetaWriteState {
             && let Some((_, metadata_epoch)) = selection.generation_identity
             && metadata_epoch != identity_epoch
         {
-            self.block_writes();
             return Err(Error::other(format!(
                 "pool metadata recovery required: committed epoch {} does not match cluster identity epoch {identity_epoch}",
                 metadata_epoch
             )));
-        }
-        if self.cluster_epoch.is_none()
-            && let Some((_, metadata_epoch)) = selection.generation_identity
-        {
-            self.cluster_epoch = Some(metadata_epoch);
         }
         Ok(())
     }
@@ -4546,26 +4549,25 @@ impl PoolMetaWriteState {
         if !self.pool_meta_absent {
             return Ok(());
         }
+        let result = self.validate_missing_metadata_can_initialize();
+        if result.is_err() {
+            self.block_writes();
+        }
+        result
+    }
+
+    fn validate_missing_metadata_can_initialize(&self) -> Result<()> {
         match self.identity_initialized {
             Some(false) if self.bootstrap_identity_proven() && self.identity_fresh_bootstrap_nonce.is_some() => Ok(()),
-            Some(false) => {
-                self.block_writes();
-                Err(Error::other(
-                    "pool metadata recovery required: pending cluster identity exists but this startup has no verified fresh-bootstrap proof or legacy-adoption proof",
-                ))
-            }
-            Some(true) => {
-                self.block_writes();
-                Err(Error::other(
-                    "pool metadata recovery required: initialized cluster identity exists but every pool.bin replica is missing",
-                ))
-            }
-            None => {
-                self.block_writes();
-                Err(Error::other(
-                    "pool metadata recovery required: no durable bootstrap identity or pool.bin replica is available",
-                ))
-            }
+            Some(false) => Err(Error::other(
+                "pool metadata recovery required: pending cluster identity exists but this startup has no verified fresh-bootstrap proof or legacy-adoption proof",
+            )),
+            Some(true) => Err(Error::other(
+                "pool metadata recovery required: initialized cluster identity exists but every pool.bin replica is missing",
+            )),
+            None => Err(Error::other(
+                "pool metadata recovery required: no durable bootstrap identity or pool.bin replica is available",
+            )),
         }
     }
 
@@ -5145,12 +5147,12 @@ fn select_pool_meta_replicas_for_read_probe<R>(
 where
     R: Into<PoolMetaReplicaRead>,
 {
-    // Read-only planning probes must fail the current request on unsafe pool
-    // metadata, but they must not permanently poison the shared writer gate.
-    let mut probe_state = write_state.clone();
-    let selection = select_pool_meta_replicas_observing(&mut probe_state, replicas)?;
-    probe_state.observe_replicas(selection.replica_state);
-    probe_state.ensure_write_safe(operation)?;
+    let selection = select_pool_meta_replica_reads(replicas.into_iter().map(Into::into).collect())?;
+    write_state.validate_selection(&selection)?;
+    selection.replica_state.ensure_write_safe(operation)?;
+    if selection.absent && (write_state.expected_cluster_id.is_some() || write_state.identity_initialized.is_some()) {
+        write_state.validate_missing_metadata_can_initialize()?;
+    }
     Ok(selection)
 }
 
@@ -9014,7 +9016,7 @@ impl ECStore {
 
     async fn acquire_pool_meta_read_guard(
         &self,
-        write_state: &mut PoolMetaWriteState,
+        write_state: &PoolMetaWriteState,
         operation: &str,
     ) -> Result<(rustfs_lock::NamespaceLockGuard, PoolMeta)> {
         write_state.ensure_write_safe(operation)?;
@@ -9172,9 +9174,9 @@ impl ECStore {
         target_pool_indices: &[usize],
         phase: &'static str,
     ) -> Result<(rustfs_lock::NamespaceLockGuard, bool)> {
-        let mut save_guard = self.pool_meta_save_gate.lock().await;
+        let save_guard = self.pool_meta_save_gate.lock().await;
         let (pool_meta_guard, snapshot) = self
-            .acquire_pool_meta_read_guard(&mut save_guard, "target capacity admission failed")
+            .acquire_pool_meta_read_guard(&save_guard, "target capacity admission failed")
             .await?;
         for target_pool_index in target_pool_indices.iter().copied() {
             ensure_external_decommission_target_admission(&snapshot, target_pool_index, phase)?;
@@ -9208,9 +9210,9 @@ impl ECStore {
     pub(crate) async fn acquire_decommission_capacity_release_fence_with_active_source(
         &self,
     ) -> Result<(rustfs_lock::NamespaceLockGuard, bool)> {
-        let mut save_guard = self.pool_meta_save_gate.lock().await;
+        let save_guard = self.pool_meta_save_gate.lock().await;
         let (pool_meta_guard, snapshot) = self
-            .acquire_pool_meta_read_guard(&mut save_guard, "capacity release fence failed")
+            .acquire_pool_meta_read_guard(&save_guard, "capacity release fence failed")
             .await?;
         let has_active_source = pool_meta_has_active_decommission(&snapshot);
         drop(save_guard);
@@ -9275,9 +9277,9 @@ impl ECStore {
         }
 
         let (reconciliations, model_version) = {
-            let mut save_guard = self.pool_meta_save_gate.lock().await;
+            let save_guard = self.pool_meta_save_gate.lock().await;
             let (_read_guard, snapshot) = self
-                .acquire_pool_meta_read_guard(&mut save_guard, "exact delete capacity reconciliation failed")
+                .acquire_pool_meta_read_guard(&save_guard, "exact delete capacity reconciliation failed")
                 .await?;
             let reconciliations = plan_exact_delete_capacity_reconciliations(&snapshot, object, exact)?;
             let model_version = active_decommission_capacity_model(&snapshot)?;
@@ -9882,9 +9884,9 @@ impl ECStore {
         let non_growing_replacement = matches!(mode, DecommissionCapacityMutationMode::NonGrowingReplacement);
         let temporary_release = matches!(mode, DecommissionCapacityMutationMode::TemporaryRelease);
         let mut operation = Some(operation);
-        let mut save_guard = self.pool_meta_save_gate.lock().await;
+        let save_guard = self.pool_meta_save_gate.lock().await;
         let (read_guard, snapshot) = self
-            .acquire_pool_meta_read_guard(&mut save_guard, "target capacity admission failed")
+            .acquire_pool_meta_read_guard(&save_guard, "target capacity admission failed")
             .await?;
         let admission_now = OffsetDateTime::now_utc();
         let admitted_owner = capacity_owner.and_then(|owner| {
@@ -10891,9 +10893,9 @@ impl ECStore {
         // global lock, then fence the exact target cohort before taking the
         // write lock used to publish the terminal transition.
         let terminal_fence_plan = if acquire_runtime_fence {
-            let mut read_save_guard = self.pool_meta_save_gate.lock().await;
+            let read_save_guard = self.pool_meta_save_gate.lock().await;
             let (read_guard, snapshot) = self
-                .acquire_pool_meta_read_guard(&mut read_save_guard, "decommission cancel fence planning failed")
+                .acquire_pool_meta_read_guard(&read_save_guard, "decommission cancel fence planning failed")
                 .await?;
             let plan = decommission_capacity_terminal_fence_plan(&snapshot, idx)?;
             drop(read_guard);
@@ -16889,6 +16891,87 @@ mod tests {
         assert!(err.to_string().contains("requires 60 bytes, but 59 bytes are available"));
     }
 
+    async fn single_pool_capacity_admission_test_store() -> (Vec<tempfile::TempDir>, Arc<ECStore>) {
+        let (temp_dirs, store) =
+            crate::services::rebalance::test_store_with_persisted_rebalance_meta(RebalanceMeta::default()).await;
+        crate::bucket::metadata_sys::init_bucket_metadata_sys(Arc::clone(&store), Vec::new()).await;
+        (temp_dirs, store)
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn single_pool_public_writes_skip_decommission_capacity_admission() {
+        let (_temp_dirs, store) = single_pool_capacity_admission_test_store().await;
+        let bucket = format!("single-pool-capacity-skip-{}", uuid::Uuid::new_v4());
+        store
+            .make_bucket(&bucket, &MakeBucketOptions::default())
+            .await
+            .expect("create single-pool bucket before blocking pool metadata writes");
+        let incarnation = store.bucket_incarnation_id(&bucket).await.expect("load bucket incarnation");
+        store.pool_meta_save_gate.lock().await.block_writes_after_fence_loss();
+
+        let object = "ordinary-put.bin";
+        let mut put_data = crate::object_api::PutObjReader::from_vec(b"ordinary single-pool body".to_vec());
+        store
+            .put_object(&bucket, object, &mut put_data, &ObjectOptions::default())
+            .await
+            .expect("single-pool ordinary PUT must not enter decommission capacity admission");
+        store
+            .get_object_info(&bucket, object, &ObjectOptions::default())
+            .await
+            .expect("single-pool ordinary PUT must remain readable");
+
+        let multipart_object = "ordinary-multipart.bin";
+        let upload = store
+            .new_multipart_upload(
+                &bucket,
+                multipart_object,
+                &ObjectOptions {
+                    expected_bucket_incarnation_id: Some(incarnation),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("single-pool MPU creation must not enter decommission capacity admission");
+        let mut part_data = crate::object_api::PutObjReader::from_vec(b"single-pool multipart body".to_vec());
+        let part = store
+            .put_object_part(
+                &bucket,
+                multipart_object,
+                &upload.upload_id,
+                1,
+                &mut part_data,
+                &ObjectOptions {
+                    expected_bucket_incarnation_id: Some(incarnation),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("single-pool UploadPart must not enter decommission capacity admission");
+        store
+            .clone()
+            .complete_multipart_upload(
+                &bucket,
+                multipart_object,
+                &upload.upload_id,
+                vec![crate::storage_api_contracts::multipart::CompletePart {
+                    part_num: part.part_num,
+                    etag: part.etag,
+                    ..Default::default()
+                }],
+                &ObjectOptions {
+                    expected_bucket_incarnation_id: Some(incarnation),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("single-pool CompleteMultipartUpload must not enter decommission capacity admission");
+        store
+            .get_object_info(&bucket, multipart_object, &ObjectOptions::default())
+            .await
+            .expect("single-pool completed MPU must remain readable");
+    }
+
     #[tokio::test]
     #[serial_test::serial]
     async fn multipart_mutations_locate_later_upload_before_reserved_pool_admission() {
@@ -17962,6 +18045,67 @@ mod tests {
     }
 
     #[test]
+    fn pool_meta_read_probe_does_not_latch_writer_state() {
+        let write_state = PoolMetaWriteState::default();
+        select_pool_meta_replicas_for_read_probe(
+            &write_state,
+            vec![PoolMetaReplica::Unreadable("transient read failure".to_string())],
+            "capacity probe",
+        )
+        .expect_err("an unreadable probe replica must fail the current admission");
+
+        assert!(
+            write_state.ensure_write_safe("ordinary object write").is_ok(),
+            "a read-only capacity probe must not permanently latch the pool metadata writer"
+        );
+    }
+
+    #[test]
+    fn pool_meta_read_probe_rejects_missing_runtime_metadata_without_latching() {
+        let write_state = PoolMetaWriteState {
+            expected_cluster_id: Some(uuid::Uuid::new_v4()),
+            identity_initialized: Some(true),
+            ..Default::default()
+        };
+        select_pool_meta_replicas_for_read_probe(&write_state, vec![PoolMetaReplica::Missing], "capacity probe")
+            .expect_err("runtime metadata disappearance must reject the current probe");
+        write_state
+            .ensure_write_safe("ordinary object write")
+            .expect("a missing-metadata probe must not permanently latch the writer");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn pool_meta_read_guard_does_not_latch_after_unreadable_replica() {
+        let (_temp_dirs, store, _other_store) = crate::services::rebalance::test_two_pool_stores(None).await;
+        let mut saved_disks = Vec::new();
+        for set in &store.pools[1].disk_set {
+            let mut disks = set.disks.write().await;
+            let original = std::mem::take(&mut *disks);
+            let disk_count = original.len();
+            saved_disks.push((set.clone(), original));
+            *disks = vec![None; disk_count];
+        }
+
+        let write_state = store.pool_meta_save_gate.lock().await;
+        store
+            .acquire_pool_meta_read_guard(&write_state, "capacity probe")
+            .await
+            .expect_err("an unreadable metadata replica must reject this probe");
+        write_state
+            .ensure_write_safe("ordinary object write")
+            .expect("a failed read-only probe must remain retryable");
+
+        for (set, disks) in saved_disks {
+            *set.disks.write().await = disks;
+        }
+        store
+            .acquire_pool_meta_read_guard(&write_state, "capacity probe retry")
+            .await
+            .expect("a read-only probe must succeed after the replica recovers");
+    }
+
+    #[test]
     fn pool_meta_write_state_blocks_when_selection_has_no_valid_replica() {
         let replicas = vec![
             PoolMetaReplica::Unreadable("pool 0 read quorum unavailable".to_string()),
@@ -17978,41 +18122,6 @@ mod tests {
             err.to_string()
                 .contains("restart after all replicas are readable and consistent")
         );
-    }
-
-    #[test]
-    fn pool_meta_read_probe_does_not_latch_writer_state() {
-        let write_state = PoolMetaWriteState::default();
-        select_pool_meta_replicas_for_read_probe(
-            &write_state,
-            vec![PoolMetaReplica::Unreadable("transient read failure".to_string())],
-            "capacity probe",
-        )
-        .expect_err("an unreadable probe replica must fail the current admission");
-
-        write_state
-            .ensure_write_safe("ordinary object write")
-            .expect("a read-only capacity probe must not permanently latch the pool metadata writer");
-    }
-
-    #[tokio::test]
-    #[serial_test::serial]
-    async fn pool_meta_read_guard_does_not_latch_after_unreadable_replica() {
-        let (_temp_dirs, store, _other_store) = crate::services::rebalance::test_two_pool_stores(None).await;
-        for set in &store.pools[1].disk_set {
-            let mut disks = set.disks.write().await;
-            let disk_count = disks.len();
-            *disks = vec![None; disk_count];
-        }
-
-        let mut write_state = store.pool_meta_save_gate.lock().await;
-        store
-            .acquire_pool_meta_read_guard(&mut write_state, "capacity probe")
-            .await
-            .expect_err("an unreadable metadata replica must reject this probe");
-        write_state
-            .ensure_write_safe("ordinary object write")
-            .expect("a failed read-only probe must remain retryable");
     }
 
     #[test]

--- a/crates/ecstore/src/store/multipart.rs
+++ b/crates/ecstore/src/store/multipart.rs
@@ -526,12 +526,8 @@ impl ECStore {
         if self.single_pool() {
             self.apply_decommission_target_mutation_fence(0, object, &mut opts, mutation_fence)
                 .await;
-            return self
-                .run_decommission_capacity_admitted_mutation(0, None, None, || async {
-                    self.pools[0].new_multipart_upload(bucket, object, &opts).await
-                })
-                .await
-                .map(|res| (res, 0, opts.expected_bucket_incarnation_id));
+            let result = self.pools[0].new_multipart_upload(bucket, object, &opts).await?;
+            return Ok((result, 0, opts.expected_bucket_incarnation_id));
         }
 
         if opts.data_movement && opts.version_id.is_some() {
@@ -658,7 +654,9 @@ impl ECStore {
     ) -> Result<PartInfo> {
         check_put_object_part_args(bucket, object, upload_id)?;
         let (mut opts, _bucket_lifecycle_guard) = self.guard_multipart_bucket_incarnation(bucket, opts).await?;
-        opts.decommission_capacity_admission = crate::bucket::metadata_sys::object_store_if_initialized_in(&self.ctx).await;
+        if !self.single_pool() {
+            opts.decommission_capacity_admission = crate::bucket::metadata_sys::object_store_if_initialized_in(&self.ctx).await;
+        }
         let opts = &opts;
 
         if self.single_pool() {
@@ -982,7 +980,9 @@ impl ECStore {
     ) -> Result<ObjectInfo> {
         check_complete_multipart_args(bucket, object, upload_id)?;
         let (mut opts, _bucket_lifecycle_guard) = self.guard_multipart_bucket_incarnation(bucket, opts).await?;
-        opts.decommission_capacity_admission = crate::bucket::metadata_sys::object_store_if_initialized_in(&self.ctx).await;
+        if !self.single_pool() {
+            opts.decommission_capacity_admission = crate::bucket::metadata_sys::object_store_if_initialized_in(&self.ctx).await;
+        }
         let opts = &opts;
 
         if self.single_pool() {

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -3123,6 +3123,9 @@ impl ECStore {
         Fut: std::future::Future<Output = Result<T>>,
     {
         let (lock_object, target_object) = objects;
+        if self.single_pool() {
+            return operation(opts).await;
+        }
         let (capacity_guard, has_active_decommission) = if capacity_releasing {
             self.acquire_decommission_capacity_release_fence_with_active_source().await?
         } else {
@@ -3220,6 +3223,9 @@ impl ECStore {
         F: FnOnce(HealOpts) -> Fut,
         Fut: std::future::Future<Output = Result<T>>,
     {
+        if self.single_pool() {
+            return operation(opts).await;
+        }
         let (capacity_guard, has_active_decommission) = self
             .acquire_external_decommission_capacity_fence_with_active_source(&[target_pool_idx], "heal")
             .await?;
@@ -4162,7 +4168,9 @@ impl ECStore {
             .select_put_object_pool_idx(bucket, object.as_str(), data.size(), &opts)
             .await?;
         let mut opts = opts;
-        opts.decommission_capacity_admission = crate::bucket::metadata_sys::object_store_if_initialized_in(&self.ctx).await;
+        if !self.single_pool() {
+            opts.decommission_capacity_admission = crate::bucket::metadata_sys::object_store_if_initialized_in(&self.ctx).await;
+        }
         self.pools[idx]
             .put_object_with_old_current_size(bucket, object.as_str(), data, &opts)
             .await
@@ -4340,8 +4348,10 @@ impl ECStore {
                     object_lock_config_snapshot: dst_opts.object_lock_config_snapshot.clone(),
                     ..Default::default()
                 };
-                put_opts.decommission_capacity_admission =
-                    crate::bucket::metadata_sys::object_store_if_initialized_in(&self.ctx).await;
+                if !self.single_pool() {
+                    put_opts.decommission_capacity_admission =
+                        crate::bucket::metadata_sys::object_store_if_initialized_in(&self.ctx).await;
+                }
                 return if let Some(reader) = src_info.put_object_reader.as_mut() {
                     self.pools[pool_idx]
                         .put_object(dst_bucket, &dst_object, reader, &put_opts)
@@ -4376,8 +4386,10 @@ impl ECStore {
                         object_lock_config_snapshot: dst_opts.object_lock_config_snapshot.clone(),
                         ..Default::default()
                     };
-                    put_opts.decommission_capacity_admission =
-                        crate::bucket::metadata_sys::object_store_if_initialized_in(&self.ctx).await;
+                    if !self.single_pool() {
+                        put_opts.decommission_capacity_admission =
+                            crate::bucket::metadata_sys::object_store_if_initialized_in(&self.ctx).await;
+                    }
                     return self.pools[pool_idx]
                         .put_object(dst_bucket, &dst_object, reader, &put_opts)
                         .await;
@@ -4422,7 +4434,10 @@ impl ECStore {
             object_lock_config_snapshot: dst_opts.object_lock_config_snapshot.clone(),
             ..Default::default()
         };
-        put_opts.decommission_capacity_admission = crate::bucket::metadata_sys::object_store_if_initialized_in(&self.ctx).await;
+        if !self.single_pool() {
+            put_opts.decommission_capacity_admission =
+                crate::bucket::metadata_sys::object_store_if_initialized_in(&self.ctx).await;
+        }
 
         if let Some(put_object_reader) = src_info.put_object_reader.as_mut() {
             return self.pools[pool_idx]
@@ -5057,7 +5072,7 @@ impl ECStore {
             }
         }
 
-        let _capacity_fence = if latest_marker_objects.iter().any(|creates_marker| *creates_marker) {
+        let _capacity_fence = if !self.single_pool() && latest_marker_objects.iter().any(|creates_marker| *creates_marker) {
             let target_pool_indices = (0..self.pools.len()).collect::<Vec<_>>();
             match self
                 .acquire_external_decommission_capacity_fence(&target_pool_indices, "batch_delete")
@@ -5375,7 +5390,6 @@ impl ECStore {
         // self-deadlocked on the inner commits.
         let object_name = object.as_str();
         if self.single_pool() {
-            opts.decommission_capacity_admission = Some(Arc::clone(&self));
             return self.pools[0]
                 .clone()
                 .restore_transitioned_object(bucket, object_name, &opts)


### PR DESCRIPTION
## Related Issues

Refs #7350.
Refs rustfs/backlog#2364.

## Summary of Changes

- Split pool metadata read-only admission probes from the sticky writer state machine. Read probes still reject the current request on unsafe pool metadata, incompatible cluster identity, epoch mismatch, or runtime metadata disappearance, but they no longer permanently latch the shared writer gate.
- Keep true pool metadata writes, startup recovery, and fence-loss paths fail-closed by preserving the mutating observing path for real write transactions.
- Skip decommission capacity admission on standalone single-pool public writes and multipart commits because single-pool deployments cannot start or complete decommission/rebalance target movement.
- Add single-pool PUT/MPU regression coverage that blocks the pool metadata writer gate first, then proves public PUT, NewMultipartUpload, UploadPart, and CompleteMultipartUpload do not re-enter impossible decommission capacity admission.

## Verification

Verified head: `c8cd8a5bd469a804c66199f91011d9647d830e94`, based on `origin/main` at `c9c6bb7a24eb9fa8f158c350efde789b50dbf514`.

- PASS: `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-ecstore --lib single_pool_public_writes_skip_decommission_capacity_admission -j4` (`1 passed`).
- PASS: `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-ecstore --lib pool_meta -j4` (`116 passed`).
- PASS: `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-ecstore --lib store::object -j4` (`118 passed`).
- PASS: `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-ecstore --lib store::multipart -j4` (`8 passed`).
- PASS: `cargo +nightly-aarch64-apple-darwin check --locked -q -p rustfs-ecstore --lib -j4`.
- PASS: `cargo +nightly-aarch64-apple-darwin fmt --package rustfs-ecstore --check`.
- PASS: `./scripts/check_architecture_migration_rules.sh`.
- PASS: `git diff --check origin/main...HEAD`.

Not run: full workspace gates, real Ceph/RBD sustained-write reproduction, multi-node decommission/rebalance E2E, readiness/metrics/error-code follow-up validation. A full `fmt --all` pass is not listed because current main has an unrelated crypto formatting delta outside this diff; the changed package fmt passed.

## Impact

Standalone single-pool deployments no longer pay or fail an impossible decommission capacity probe on ordinary object writes and MPU commits. Multi-pool admission and active decommission/rebalance fencing remain in place. No on-disk format, wire protocol, dependency, configuration, S3 API, or metadata key changes.

## Additional Notes

Two independent adversarial reviews covered correctness, compatibility, test coverage, concurrency/durability, and performance. The review found one test-coverage gap for single-pool public writes; this PR adds `single_pool_public_writes_skip_decommission_capacity_admission`, and the follow-up review confirmed the finding is closed. #2364 remains open for runtime readiness/metrics, dedicated error semantics, real Ceph sustained-write E2E, and any future distributed epoch/read-lease optimization.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
