### PR TITLE
test(scanner): add crash-restart heal evidence case

### DIFF
--- a/.config/scanner-heal-required-tests.json
+++ b/.config/scanner-heal-required-tests.json
@@ -8,10 +8,26 @@
       "suite": "e2e_test",
       "name": "heal_erasure_disk_rebuild_test::tests::test_cluster_root_heal_recovers_remote_shards_after_background_target_restart",
       "oracle": "background-target-restart.json",
+      "evidence": "process-restart",
+      "unclean_shutdown_marker": false,
       "min_objects": 9,
       "max_objects": 65,
       "topology": {"nodes": 4, "drives_per_node": 1},
       "scope": "Target process restart, exact unversioned S3 bodies and replacement-disk shards; not power loss or EC8+4."
+    },
+    "background-target-crash": {
+      "gate": "G14",
+      "task": "W21",
+      "lane": "e2e-nightly",
+      "suite": "e2e_test",
+      "name": "heal_erasure_disk_rebuild_test::tests::test_cluster_root_heal_recovers_remote_shards_after_background_target_crash",
+      "oracle": "background-target-crash.json",
+      "evidence": "process-crash-restart",
+      "unclean_shutdown_marker": true,
+      "min_objects": 9,
+      "max_objects": 65,
+      "topology": {"nodes": 4, "drives_per_node": 1},
+      "scope": "Target process killed during partial background rebuild, real unclean-shutdown marker, exact unversioned S3 bodies and replacement-disk shards; not power loss or EC8+4."
     }
   },
   "release_pending": {

--- a/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
+++ b/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
@@ -58,11 +58,22 @@ mod tests {
     struct ScannerHealEvidenceCase {
         id: &'static str,
         oracle: &'static str,
+        evidence: &'static str,
+        unclean_shutdown_marker: bool,
     }
 
     const BACKGROUND_TARGET_RESTART_EVIDENCE: ScannerHealEvidenceCase = ScannerHealEvidenceCase {
         id: "background-target-restart",
         oracle: "background-target-restart.json",
+        evidence: "process-restart",
+        unclean_shutdown_marker: false,
+    };
+
+    const BACKGROUND_TARGET_CRASH_EVIDENCE: ScannerHealEvidenceCase = ScannerHealEvidenceCase {
+        id: "background-target-crash",
+        oracle: "background-target-crash.json",
+        evidence: "process-crash-restart",
+        unclean_shutdown_marker: true,
     };
 
     struct RestartEvidenceContext {
@@ -98,6 +109,8 @@ mod tests {
             || case.oracle.contains('/')
             || case.oracle.contains('\\')
             || case.oracle.contains("..")
+            || !matches!(case.evidence, "process-restart" | "process-crash-restart")
+            || (case.evidence == "process-crash-restart") != case.unclean_shutdown_marker
         {
             return Err("invalid scanner/heal evidence case".into());
         }
@@ -951,6 +964,16 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_cluster_root_heal_recovers_remote_shards_after_background_target_crash()
+    -> Result<(), Box<dyn Error + Send + Sync>> {
+        timeout(
+            Duration::from_secs(420),
+            run_cluster_root_heal_interruption(InterruptionScenario::BackgroundTargetCrash),
+        )
+        .await?
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_cluster_root_heal_recovers_remote_shards_after_coordinator_restart() -> Result<(), Box<dyn Error + Send + Sync>>
     {
         timeout(
@@ -986,21 +1009,27 @@ mod tests {
     enum InterruptionScenario {
         IsolatedTargetRestart,
         BackgroundTargetRestart,
+        BackgroundTargetCrash,
         BackgroundCoordinatorRestart,
         TargetEndpointBlackhole,
     }
 
     async fn run_cluster_root_heal_interruption(scenario: InterruptionScenario) -> Result<(), Box<dyn Error + Send + Sync>> {
         let server_binary = rustfs_binary_path();
-        let evidence_run = if scenario == InterruptionScenario::BackgroundTargetRestart {
-            restart_evidence_run(&server_binary, BACKGROUND_TARGET_RESTART_EVIDENCE)?
-        } else {
-            None
+        let evidence_run = match scenario {
+            InterruptionScenario::BackgroundTargetRestart => {
+                restart_evidence_run(&server_binary, BACKGROUND_TARGET_RESTART_EVIDENCE)?
+            }
+            InterruptionScenario::BackgroundTargetCrash => {
+                restart_evidence_run(&server_binary, BACKGROUND_TARGET_CRASH_EVIDENCE)?
+            }
+            _ => None,
         };
         let mut evidence_objects = Vec::new();
         let (background_enabled, interruption_node, interruption_kind) = match scenario {
             InterruptionScenario::IsolatedTargetRestart => (false, 1, "target_restart"),
             InterruptionScenario::BackgroundTargetRestart => (true, 1, "background_target_restart"),
+            InterruptionScenario::BackgroundTargetCrash => (true, 1, "background_target_crash"),
             InterruptionScenario::BackgroundCoordinatorRestart => (true, 0, "coordinator_restart"),
             InterruptionScenario::TargetEndpointBlackhole => (false, 1, "target_endpoint_blackhole"),
         };
@@ -1067,6 +1096,7 @@ mod tests {
             .unwrap_or(4 * 1024 * 1024)
             .clamp(1024 * 1024, 16 * 1024 * 1024);
         let mut expected_manifests = Vec::with_capacity(online_object_count);
+        let mut unclean_shutdown_marker_observed = None;
         for index in 0..online_object_count {
             let key = format!("cluster/online/object-{index:04}.bin");
             let payload_seed = u8::try_from(index + 1).expect("clamped object count must fit in u8");
@@ -1433,7 +1463,11 @@ mod tests {
                 "Restored target endpoint forwarding"
             );
         } else {
-            cluster.stop_node(interruption_node)?;
+            if scenario == InterruptionScenario::BackgroundTargetRestart {
+                cluster.stop_node_gracefully(interruption_node).await?;
+            } else {
+                cluster.stop_node(interruption_node)?;
+            }
             let stopped_count = metadata_count(&replaced_disk, bucket, &expected_manifests);
             assert!(
                 stopped_count > 0 && stopped_count < expected_manifests.len(),
@@ -1449,9 +1483,12 @@ mod tests {
                 .join(".rustfs.sys")
                 .join("unclean-shutdown");
             if background_enabled {
+                let marker_exists = unclean_shutdown_marker.is_file();
+                unclean_shutdown_marker_observed = Some(marker_exists);
+                let expected_marker = !matches!(scenario, InterruptionScenario::BackgroundTargetRestart);
                 assert!(
-                    unclean_shutdown_marker.is_file(),
-                    "background restart must retain the real unclean-shutdown marker"
+                    marker_exists == expected_marker,
+                    "background restart/crash lane observed unexpected unclean-shutdown marker state"
                 );
             } else {
                 match std::fs::remove_file(&unclean_shutdown_marker) {
@@ -1651,13 +1688,14 @@ mod tests {
                 "server build changed during restart"
             );
             let evidence = serde_json::json!({
-                "schema": 1, "case": evidence_context.case.id, "evidence": "process-restart",
+                "schema": 1, "case": evidence_context.case.id, "evidence": evidence_context.case.evidence,
                 "run_id": evidence_context.run.run_id, "source_revision": evidence_context.run.source_revision,
                 "test_build": compiled_test_identity(),
                 "binary_sha256": evidence_context.run.binary.sha256,
                 "test_binary_sha256": evidence_context.run.test_binary.sha256,
                 "topology": {"nodes": cluster.nodes.len(), "drives_per_node": cluster.nodes[0].data_dirs.len()},
                 "pid_before": target_pid, "pid_after": restarted_pid,
+                "unclean_shutdown_marker": unclean_shutdown_marker_observed.unwrap_or(false),
                 "objects": evidence_objects, "node_listings": node_listings,
             });
             let data = serde_json::to_vec(&evidence)?;

--- a/scripts/check_test_wiring.py
+++ b/scripts/check_test_wiring.py
@@ -10,7 +10,6 @@ import re
 import subprocess
 import sys
 import tempfile
-import tomllib
 import unittest
 import uuid
 import xml.etree.ElementTree as ET
@@ -18,6 +17,11 @@ from datetime import datetime, timezone
 from unittest import mock
 from pathlib import Path
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 from scanner_abba import MAX_JSON_BYTES, digest, number, read_json, require, sha, write_json
 

--- a/scripts/check_test_wiring.py
+++ b/scripts/check_test_wiring.py
@@ -894,6 +894,10 @@ def scanner_heal_oracle_names(root: Path) -> tuple[str, ...]:
         require(isinstance(oracle, str) and oracle.endswith(".json"), f"invalid oracle for {case_id}")
         path = Path(oracle)
         require(not path.is_absolute() and ".." not in path.parts, f"oracle path escapes run directory for {case_id}")
+        require(requirement.get("evidence") in ("process-restart", "process-crash-restart"),
+                f"invalid evidence for {case_id}")
+        require(type(requirement.get("unclean_shutdown_marker")) is bool,
+                f"invalid unclean-shutdown marker expectation for {case_id}")
         names.add(oracle)
     return tuple(sorted(names))
 
@@ -1024,9 +1028,11 @@ def check_scanner_heal_evidence(root: Path, directory: Path, case_id: str) -> li
             require(digest(path) == execution["artifacts"][requirement["oracle"]], "oracle hash mismatch")
             oracle = read_json(path)
             evidence_integer(oracle.get("schema"), "oracle schema", 1, 1)
-            require(oracle.get("evidence") == "process-restart", "not real process-restart evidence")
+            require(oracle.get("evidence") == requirement["evidence"], f"not real {requirement['evidence']} evidence")
             require(oracle.get("case") == name and oracle.get("run_id") == run["run_id"], "oracle belongs to another case/run")
             require(oracle.get("source_revision") == run["source_revision"], "oracle source mismatch")
+            require(oracle.get("unclean_shutdown_marker") is requirement["unclean_shutdown_marker"],
+                    "unclean-shutdown marker evidence mismatch")
             built = oracle["test_build"]
             for key in ("source_revision", "dirty", "lock_blob", "features"):
                 require(built[key] == expected_build[key], f"compiled test {key} mismatch")
@@ -1240,7 +1246,7 @@ class SelfTests(unittest.TestCase):
         run_dir.mkdir()
         registry = read_json(ROOT / ".config/scanner-heal-required-tests.json")
         write_json(root / ".config/scanner-heal-required-tests.json", registry)
-        requirement = registry["cases"]["background-target-restart"]
+        requirements = registry["cases"]
         binary = directory / "fake-binary"
         binary.write_bytes(b"parser fixture, not a real build")
         binary.chmod(0o700)
@@ -1251,14 +1257,23 @@ class SelfTests(unittest.TestCase):
                                                         "lock_blob": "c" * 40, "features": "default"},
                                          "started_at": datetime.now(timezone.utc).timestamp() - 1,
                                          "binary": build, "test_binary": build})
-        write_json(run_dir / "listing.json", {"rust-suites": {requirement["suite"]: {
-            "binary-id": requirement["suite"], "binary-path": str(binary), "package-name": "e2e_test", "build-platform": "target",
+        suite = "e2e_test"
+        write_json(run_dir / "listing.json", {"rust-suites": {suite: {
+            "binary-id": suite, "binary-path": str(binary), "package-name": "e2e_test", "build-platform": "target",
             "testcases": {
-            requirement["name"]: {"ignored": False, "filter-match": {"status": "matches"}}
-        }}}})
+                requirement["name"]: {"ignored": False, "filter-match": {"status": "matches"}}
+                for requirement in requirements.values()
+            }
+        }}})
         (run_dir / "junit.xml").write_text(
-            f'<testsuites><testsuite><testcase name="{requirement["name"]}" classname="{requirement["suite"]}" '
-            f'timestamp="{datetime.now(timezone.utc).isoformat(timespec="milliseconds")}"/></testsuite></testsuites>')
+            "<testsuites><testsuite>"
+            + "".join(
+                f'<testcase name="{requirement["name"]}" classname="{requirement["suite"]}" '
+                f'timestamp="{datetime.now(timezone.utc).isoformat(timespec="milliseconds")}"/>'
+                for requirement in requirements.values()
+            )
+            + "</testsuite></testsuites>"
+        )
         physical = {"has_xl_meta": True, "version_id": None, "data_dir": "data-generation",
                     "erasure_index": 1, "data_blocks": 2, "parity_blocks": 2, "expected_part_numbers": [1],
                     "present_part_fingerprints": {"1": {"size": 12, "sha256": "c" * 64}},
@@ -1268,15 +1283,17 @@ class SelfTests(unittest.TestCase):
                "expected_physical": physical, "physical": physical}
         objects = [dict(obj, key=f"object-{index}") for index in range(9)]
         objects[-1] = dict(objects[-1], expected_physical=None)
-        write_json(run_dir / "background-target-restart.json", {
-            "schema": 1, "evidence": "process-restart", "case": "background-target-restart",
-            "run_id": "a" * 32, "source_revision": "b" * 40,
-            "test_build": {"source_revision": "b" * 40, "dirty": False, "lock_blob": "c" * 40,
-                           "features": "default", "target": "aarch64-apple-darwin", "profile": "debug", "rustflags_hex": ""},
-            "binary_sha256": build["sha256"], "test_binary_sha256": build["sha256"],
-            "topology": {"nodes": 4, "drives_per_node": 1}, "pid_before": 10, "pid_after": 11,
-            "objects": objects, "node_listings": [[item["key"] for item in objects]] * 4,
-        })
+        for case_id, requirement in requirements.items():
+            write_json(run_dir / requirement["oracle"], {
+                "schema": 1, "evidence": requirement["evidence"], "case": case_id,
+                "run_id": "a" * 32, "source_revision": "b" * 40,
+                "test_build": {"source_revision": "b" * 40, "dirty": False, "lock_blob": "c" * 40,
+                               "features": "default", "target": "aarch64-apple-darwin", "profile": "debug", "rustflags_hex": ""},
+                "binary_sha256": build["sha256"], "test_binary_sha256": build["sha256"],
+                "topology": requirement["topology"], "pid_before": 10, "pid_after": 11,
+                "unclean_shutdown_marker": requirement["unclean_shutdown_marker"],
+                "objects": objects, "node_listings": [[item["key"] for item in objects]] * 4,
+            })
         finish_scanner_heal_receipt(run_dir, 0, root)
         return root, run_dir
 
@@ -1331,6 +1348,19 @@ class SelfTests(unittest.TestCase):
             errors = check_scanner_heal_evidence(root, run_dir, "release")
             self.assertEqual(len(errors), 21)
             self.assertTrue(all(error.startswith("pending ") for error in errors))
+
+    def test_scanner_heal_crash_case_rejects_restart_oracle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root, run_dir = self.scanner_heal_fixture(Path(tmp))
+            path = run_dir / "background-target-crash.json"
+            oracle = read_json(path)
+            oracle["evidence"] = "process-restart"
+            oracle["unclean_shutdown_marker"] = False
+            write_json(path, oracle)
+            (run_dir / "execution.json").unlink()
+            finish_scanner_heal_receipt(run_dir, 0, root)
+
+            self.assertTrue(check_scanner_heal_evidence(root, run_dir, "background-target-crash"))
 
     def test_scanner_heal_rejects_broken_execution_and_artifacts(self) -> None:
         for fault in ("exit", "missing", "zero", "skipped", "failed", "retry", "filtered", "ignored", "stale",

--- a/scripts/scanner_abba.py
+++ b/scripts/scanner_abba.py
@@ -72,7 +72,12 @@ def report_number(value):
 
 def digest(path):
     with Path(path).open("rb") as stream:
-        return hashlib.file_digest(stream, "sha256").hexdigest()
+        if hasattr(hashlib, "file_digest"):
+            return hashlib.file_digest(stream, "sha256").hexdigest()
+        hasher = hashlib.sha256()
+        while chunk := stream.read(1024 * 1024):
+            hasher.update(chunk)
+        return hasher.hexdigest()
 
 
 def read_json(path):


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#2269.
Refs rustfs/backlog#2240.

## Summary

- Add a distinct `background-target-crash` scanner/heal evidence case to the required-test registry.
- Split graceful restart evidence from crash-restart evidence with an explicit unclean-shutdown marker.
- Extend the wiring checker so the crash case cannot be satisfied by a copied restart oracle.

## Verification

- PASS: `/Users/zhi/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 scripts/check_test_wiring.py --self-test`
- PASS: `/Users/zhi/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 scripts/check_test_wiring.py`
- PASS: `cargo +nightly-aarch64-apple-darwin test --locked -q -p e2e_test background_target_crash --no-run -j4`
- PASS: `cargo +nightly-aarch64-apple-darwin fmt --package e2e_test --check`
- PASS: `git diff --check origin/main...HEAD`
- NOTE: system `/usr/bin/python3` is Python 3.9 and lacks `tomllib`; the checker passes with Python 3.12, which matches the CI Python 3.12 setup.
- NOTE: workspace-wide `cargo fmt --all --check` is blocked by unrelated formatting already present on current `origin/main` in `crates/crypto/src/encdec/aes.rs`.

## Impact

- Test and evidence-wiring change only.
- The new case is compile/wiring verified, but this PR does not claim that the full 4-node crash E2E lane has been executed.
- Remaining W21 work: same-window field evidence, 3x4 EC8+4 and multi-set/pool coverage, real crash-run artifact capture, and release gate approval.

## Additional Notes

N/A
