### PR TITLE
fix(replication): carry the compression layout through SSE-C passthrough

### DIFF
--- a/crates/e2e_test/src/fake_s3_target/mod.rs
+++ b/crates/e2e_test/src/fake_s3_target/mod.rs
@@ -584,6 +584,10 @@ struct MultipartPart {
     body: Bytes,
     e_tag: String,
     digest: [u8; 16],
+    /// Plaintext length declared by an SSE-C passthrough sender
+    /// (`x-rustfs-replication-part-actual-size`); RustFS validates the 5 MiB
+    /// minimum against it rather than against the stored bytes.
+    actual_size: Option<usize>,
 }
 
 #[derive(Clone)]
@@ -2624,6 +2628,11 @@ impl S3 for FakeBackend {
 
     async fn upload_part(&self, req: S3Request<UploadPartInput>) -> S3Result<S3Response<UploadPartOutput>> {
         let fault = request_fault(&req);
+        let declared_actual_size = req
+            .headers
+            .get("x-rustfs-replication-part-actual-size")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<usize>().ok());
         let _body_permit = timeout(MAX_FAULT_DURATION, Arc::clone(&self.body_limit).acquire_owned())
             .await
             .map_err(|_| s3s::s3_error!(RequestTimeout, "fake target body limiter wait exceeded 30 seconds"))?
@@ -2665,6 +2674,7 @@ impl S3 for FakeBackend {
                 body,
                 e_tag: e_tag.clone(),
                 digest,
+                actual_size: declared_actual_size,
             },
         );
         Ok(apply_response_fault(
@@ -2734,7 +2744,9 @@ impl S3 for FakeBackend {
                 if requested_etag != &stored.e_tag {
                     return Err(s3s::s3_error!(InvalidPart, "part ETag does not match"));
                 }
-                if index + 1 != requested_parts.len() && stored.body.len() < MIN_MULTIPART_PART_BYTES {
+                if index + 1 != requested_parts.len()
+                    && stored.actual_size.unwrap_or(stored.body.len()) < MIN_MULTIPART_PART_BYTES
+                {
                     return Err(s3s::s3_error!(EntityTooSmall, "non-final multipart part is smaller than 5 MiB"));
                 }
                 selected.push((*number, stored.clone()));

--- a/crates/e2e_test/src/replication_extension_test.rs
+++ b/crates/e2e_test/src/replication_extension_test.rs
@@ -10183,3 +10183,199 @@ async fn test_get_object_tagging_proxies_unreplicated_object_to_replication_targ
     target.shutdown().await;
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// backlog#2363
+// ---------------------------------------------------------------------------
+
+/// Wait until the source reports a terminal replication status for `key`.
+async fn wait_terminal_replication_status(
+    client: &Client,
+    bucket: &str,
+    key: &str,
+    ssec: bool,
+    timeout: Duration,
+) -> Result<String, Box<dyn Error + Send + Sync>> {
+    let customer_key = BASE64_STANDARD.encode_to_string(REPL17_SSEC_KEY);
+    let customer_key_md5 = sse_customer_key_md5_base64(REPL17_SSEC_KEY);
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let request = client.head_object().bucket(bucket).key(key);
+        let head = if ssec {
+            request
+                .sse_customer_algorithm("AES256")
+                .sse_customer_key(&customer_key)
+                .sse_customer_key_md5(&customer_key_md5)
+                .send()
+                .await?
+        } else {
+            request.send().await?
+        };
+        let status = head.replication_status().map(|status| status.as_str().to_string());
+        if matches!(status.as_deref(), Some("COMPLETED") | Some("FAILED")) {
+            return Ok(status.unwrap_or_default());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(format!("{bucket}/{key}: replication never reached a terminal status; last {status:?}").into());
+        }
+        sleep(Duration::from_millis(250)).await;
+    }
+}
+
+/// backlog#2363: SSE-C ciphertext passthrough of objects the source stored
+/// compressed. The replica on a RustFS target must decrypt to the original
+/// bytes for a single PUT and for a multipart upload.
+#[tokio::test]
+async fn test_bucket_replication_sse_c_compressed_passthrough() -> TestResult {
+    init_logging();
+    const PART_SIZE: usize = 5 * 1024 * 1024;
+
+    let mut source_env = RustFSTestEnvironment::new().await?;
+    let mut target_env = RustFSTestEnvironment::new().await?;
+    let mut source_process_env = replication_fast_env();
+    source_process_env.extend_from_slice(LOOPBACK_REPLICATION_TARGET_ENV);
+    source_process_env.extend_from_slice(FAST_SCANNER_ENV);
+    source_process_env.extend_from_slice(&[
+        ("NO_PROXY", "127.0.0.1,localhost"),
+        ("HTTP_PROXY", ""),
+        ("HTTPS_PROXY", ""),
+        ("RUSTFS_COMPRESSION_ENABLED", "true"),
+        ("RUSTFS_COMPRESSION_MULTIPART_ENABLED", "true"),
+    ]);
+    source_env.start_rustfs_server_with_env(vec![], &source_process_env).await?;
+    target_env
+        .start_rustfs_server_without_cleanup_with_env(&[
+            ("NO_PROXY", "127.0.0.1,localhost"),
+            ("HTTP_PROXY", ""),
+            ("HTTPS_PROXY", ""),
+        ])
+        .await?;
+
+    let source_bucket = "ssec-compressed-src";
+    let target_bucket = "ssec-compressed-dst";
+    let source_client = source_env.create_s3_client();
+    let target_client = target_env.create_s3_client();
+    source_client.create_bucket().bucket(source_bucket).send().await?;
+    target_client.create_bucket().bucket(target_bucket).send().await?;
+    enable_bucket_versioning(&source_env, source_bucket).await?;
+    enable_bucket_versioning(&target_env, target_bucket).await?;
+    let target_arn = set_replication_target(&source_env, source_bucket, &target_env, target_bucket).await?;
+    put_bucket_replication(&source_env, source_bucket, &target_arn).await?;
+
+    let customer_key = BASE64_STANDARD.encode_to_string(REPL17_SSEC_KEY);
+    let customer_key_md5 = sse_customer_key_md5_base64(REPL17_SSEC_KEY);
+    let text = |len: usize, seed: u32| -> Vec<u8> {
+        let mut out = Vec::with_capacity(len + 64);
+        let mut line = 0u64;
+        while out.len() < len {
+            out.extend_from_slice(format!("ssec compressed passthrough seed={seed} line={line} lorem ipsum dolor\n").as_bytes());
+            line += 1;
+        }
+        out.truncate(len);
+        out
+    };
+
+    let single_key = "ssec-compressed-single.txt";
+    let single_body = text(1024 * 1024 + 17, 1);
+    source_client
+        .put_object()
+        .bucket(source_bucket)
+        .key(single_key)
+        .content_type("text/plain")
+        .body(ByteStream::from(single_body.clone()))
+        .sse_customer_algorithm("AES256")
+        .sse_customer_key(&customer_key)
+        .sse_customer_key_md5(&customer_key_md5)
+        .send()
+        .await?;
+
+    let multipart_key = "ssec-compressed-multipart.txt";
+    let multipart_parts = [text(PART_SIZE, 2), text(1024 * 1024 + 4096, 3)];
+    let multipart_body: Vec<u8> = multipart_parts.concat();
+    let created = source_client
+        .create_multipart_upload()
+        .bucket(source_bucket)
+        .key(multipart_key)
+        .content_type("text/plain")
+        .sse_customer_algorithm("AES256")
+        .sse_customer_key(&customer_key)
+        .sse_customer_key_md5(&customer_key_md5)
+        .send()
+        .await?;
+    let upload_id = created.upload_id().ok_or("missing multipart upload id")?.to_string();
+    let mut completed = Vec::new();
+    for (index, part) in multipart_parts.iter().enumerate() {
+        let part_number = i32::try_from(index + 1)?;
+        let uploaded = source_client
+            .upload_part()
+            .bucket(source_bucket)
+            .key(multipart_key)
+            .upload_id(&upload_id)
+            .part_number(part_number)
+            .body(ByteStream::from(part.clone()))
+            .sse_customer_algorithm("AES256")
+            .sse_customer_key(&customer_key)
+            .sse_customer_key_md5(&customer_key_md5)
+            .send()
+            .await?;
+        completed.push(
+            CompletedPart::builder()
+                .part_number(part_number)
+                .set_e_tag(uploaded.e_tag().map(str::to_string))
+                .build(),
+        );
+    }
+    source_client
+        .complete_multipart_upload()
+        .bucket(source_bucket)
+        .key(multipart_key)
+        .upload_id(&upload_id)
+        .multipart_upload(CompletedMultipartUpload::builder().set_parts(Some(completed)).build())
+        .sse_customer_algorithm("AES256")
+        .sse_customer_key(&customer_key)
+        .sse_customer_key_md5(&customer_key_md5)
+        .send()
+        .await?;
+
+    let mut failures = Vec::new();
+    for (key, body) in [(single_key, &single_body), (multipart_key, &multipart_body)] {
+        let status = wait_terminal_replication_status(&source_client, source_bucket, key, true, Duration::from_secs(120)).await?;
+        if status != "COMPLETED" {
+            failures.push(format!("{key}: source reports {status}"));
+            continue;
+        }
+        let replica = target_client
+            .get_object()
+            .bucket(target_bucket)
+            .key(key)
+            .sse_customer_algorithm("AES256")
+            .sse_customer_key(&customer_key)
+            .sse_customer_key_md5(&customer_key_md5)
+            .send()
+            .await;
+        match replica {
+            Ok(replica) => {
+                let content_length = replica.content_length();
+                match replica.body.collect().await {
+                    Ok(collected) => {
+                        let bytes = collected.into_bytes();
+                        if bytes.as_ref() != body.as_slice() {
+                            failures.push(format!(
+                                "{key}: replica bytes differ (content_length={content_length:?}, got {} bytes, want {})",
+                                bytes.len(),
+                                body.len()
+                            ));
+                        }
+                    }
+                    Err(err) => failures.push(format!("{key}: replica body read failed: {err}")),
+                }
+            }
+            Err(err) => failures.push(format!("{key}: replica GET failed: {err}")),
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "SSE-C compressed passthrough replicas must decrypt to the source bytes: {failures:?}"
+    );
+    Ok(())
+}

--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -4815,6 +4815,17 @@ async fn replicate_multipart_parts_and_complete<S: ReplicationObjectIO>(
         };
         header_size = 0;
 
+        // Passthrough parts are the stored bytes; the replica learns each
+        // part's plaintext length from this header (backlog#2363).
+        let mut part_options = PutObjectPartOptions::default();
+        if obj_opts.raw_data_movement_read && part_info.actual_size > 0 {
+            rustfs_utils::http::insert_header(
+                &mut part_options.custom_header,
+                rustfs_utils::http::SUFFIX_REPLICATION_PART_ACTUAL_SIZE,
+                part_info.actual_size.to_string(),
+            );
+        }
+
         let object_part = cli
             .put_object_part(
                 dst_bucket,
@@ -4823,7 +4834,7 @@ async fn replicate_multipart_parts_and_complete<S: ReplicationObjectIO>(
                 part_plan.part_number,
                 part_plan.part_size,
                 byte_stream,
-                &PutObjectPartOptions { ..Default::default() },
+                &part_options,
             )
             .await
             .map_err(|e| std::io::Error::other(e.to_string()))?;
@@ -6871,47 +6882,77 @@ mod tests {
 
         #[tokio::test]
         async fn multipart_transport_preserves_legacy_zero_actual_sizes() {
-            run_transport(4096, None).await;
+            run_transport(4096, None, false).await;
         }
 
         #[tokio::test]
         async fn multipart_transport_uploads_an_empty_last_part_without_reading_a_range() {
-            run_transport(0, None).await;
+            run_transport(0, None, false).await;
         }
 
         #[tokio::test]
         async fn multipart_transport_preserves_transformed_unknown_nonempty_parts() {
             for unknown_part in [(0, 0), (1, 0), (0, -1), (1, -1)] {
-                run_transport(4096, Some(unknown_part)).await;
+                run_transport(4096, Some(unknown_part), false).await;
             }
         }
 
         #[tokio::test]
         async fn multipart_transport_preserves_transformed_empty_tail() {
-            run_transport(0, Some((1, 0))).await;
+            run_transport(0, Some((1, 0)), false).await;
         }
 
-        async fn run_transport(tail_size: usize, unknown_part: Option<(usize, i64)>) {
+        /// SSE-C passthrough of a compressed object: the stored bytes go out
+        /// as-is and every UploadPart declares the part's plaintext length
+        /// (backlog#2363).
+        #[tokio::test]
+        async fn multipart_transport_declares_passthrough_part_lengths() {
+            run_transport(4096, None, true).await;
+        }
+
+        async fn run_transport(tail_size: usize, unknown_part: Option<(usize, i64)>, passthrough: bool) {
             const FIRST_SIZE: usize = 5 * 1024 * 1024;
+            // The stored (compressed ciphertext) bytes of a passthrough part
+            // are shorter than the plaintext they represent.
+            const PASSTHROUGH_PLAINTEXT_FACTOR: usize = 4;
             let body = Bytes::from([vec![0x35; FIRST_SIZE], vec![0xa7; tail_size]].concat());
             let etag = faster_hex::hex_string(rustfs_utils::hash::HashAlgorithm::Md5.hash_encode(&body).as_ref());
+            let mut user_defined = if unknown_part.is_some() {
+                HashMap::from([("x-amz-server-side-encryption".to_string(), "AES256".to_string())])
+            } else {
+                HashMap::new()
+            };
+            if passthrough {
+                user_defined.insert(rustfs_utils::http::SSEC_ALGORITHM_HEADER.to_string(), "AES256".to_string());
+                rustfs_utils::http::insert_str(
+                    &mut user_defined,
+                    rustfs_utils::http::SUFFIX_COMPRESSION,
+                    "klauspost/compress/s2".to_string(),
+                );
+            }
+            let plaintext_len = |stored: usize| {
+                i64::try_from(if passthrough {
+                    stored * PASSTHROUGH_PLAINTEXT_FACTOR
+                } else {
+                    stored
+                })
+                .expect("plaintext size")
+            };
             let source = Arc::new(Source {
                 info: ObjectInfo {
                     size: i64::try_from(body.len() + if unknown_part.is_some() { 16 } else { 0 }).expect("stored size"),
-                    actual_size: i64::try_from(body.len()).expect("body size"),
+                    actual_size: plaintext_len(body.len()),
                     etag: Some(etag.clone()),
                     version_id: Some(Uuid::new_v4()),
-                    user_defined: Arc::new(if unknown_part.is_some() {
-                        HashMap::from([("x-amz-server-side-encryption".to_string(), "AES256".to_string())])
-                    } else {
-                        HashMap::new()
-                    }),
+                    user_defined: Arc::new(user_defined),
                     parts: Arc::new(vec![
                         ObjectPartInfo {
                             number: 1,
                             size: FIRST_SIZE + if unknown_part.is_some() { 8 } else { 0 },
                             actual_size: if let Some((0, size)) = unknown_part {
                                 size
+                            } else if passthrough {
+                                plaintext_len(FIRST_SIZE)
                             } else if unknown_part.is_some() || tail_size == 0 {
                                 i64::try_from(FIRST_SIZE).expect("first part size")
                             } else {
@@ -6924,6 +6965,8 @@ mod tests {
                             size: tail_size + if unknown_part.is_some() { 8 } else { 0 },
                             actual_size: if let Some((1, size)) = unknown_part {
                                 size
+                            } else if passthrough {
+                                plaintext_len(tail_size)
                             } else if unknown_part.is_some() {
                                 i64::try_from(tail_size).expect("tail logical size")
                             } else {
@@ -7002,6 +7045,7 @@ mod tests {
             let (put_opts, is_multipart) = replication_put_object_options("STANDARD", &source.info).expect("replication options");
             let opts = ObjectOptions {
                 version_id: source.info.version_id.map(|id| id.to_string()),
+                raw_data_movement_read: passthrough,
                 ..Default::default()
             };
             let reader = source
@@ -7083,6 +7127,36 @@ mod tests {
                 assert_eq!(
                     requests[index].headers.get("content-length").expect("part content length"),
                     expected.len().to_string().as_str()
+                );
+                let declared = rustfs_utils::http::get_header(
+                    &requests[index].headers,
+                    rustfs_utils::http::SUFFIX_REPLICATION_PART_ACTUAL_SIZE,
+                );
+                if passthrough {
+                    assert_eq!(
+                        declared.as_deref(),
+                        Some(plaintext_len(expected.len()).to_string().as_str()),
+                        "passthrough parts declare their plaintext length"
+                    );
+                } else {
+                    assert!(declared.is_none(), "decrypted transport carries no passthrough part length");
+                }
+            }
+            if passthrough {
+                let create = &requests[0];
+                assert_eq!(
+                    rustfs_utils::http::get_header(&create.headers, rustfs_utils::http::SUFFIX_REPLICATION_COMPRESSION)
+                        .as_deref(),
+                    Some("klauspost/compress/s2"),
+                    "the session carries the source's compression scheme"
+                );
+                assert_eq!(
+                    rustfs_utils::http::get_header(
+                        &create.headers,
+                        rustfs_utils::http::SUFFIX_REPLICATION_COMPRESSION_ACTUAL_SIZE
+                    )
+                    .as_deref(),
+                    Some(plaintext_len(body.len()).to_string().as_str())
                 );
             }
             let complete = &requests[3];

--- a/crates/ecstore/src/bucket/replication/replication_target_boundary.rs
+++ b/crates/ecstore/src/bucket/replication/replication_target_boundary.rs
@@ -247,6 +247,23 @@ pub(crate) fn replication_put_object_options(sc: &str, object_info: &ObjectInfo)
         meta.insert(key.to_string(), value.to_string());
     }
 
+    // A compressed SSE-C object passes through as its stored bytes. The target
+    // cannot infer the compression layout from ciphertext, so the scheme and
+    // the plaintext size travel as transport headers; each UploadPart carries
+    // its own plaintext length (backlog#2363).
+    if is_ssec && let Some(scheme) = get_str(&object_info.user_defined, rustfs_utils::http::SUFFIX_COMPRESSION) {
+        insert_header_map(&mut meta, rustfs_utils::http::SUFFIX_REPLICATION_COMPRESSION, scheme);
+        if let Ok(actual_size) = object_info.get_actual_size()
+            && actual_size >= 0
+        {
+            insert_header_map(
+                &mut meta,
+                rustfs_utils::http::SUFFIX_REPLICATION_COMPRESSION_ACTUAL_SIZE,
+                actual_size.to_string(),
+            );
+        }
+    }
+
     // Managed SSE replicates as plaintext (the replication reader decrypts via
     // the object-encryption resolver) and re-encrypts on the target with the
     // target's own KMS. Send only the encryption intent — never the source
@@ -624,6 +641,59 @@ mod tests {
             ),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn compressed_ssec_objects_declare_their_compression_layout_on_the_wire() {
+        use rustfs_utils::http::{
+            SUFFIX_ACTUAL_SIZE, SUFFIX_COMPRESSION, SUFFIX_REPLICATION_COMPRESSION, SUFFIX_REPLICATION_COMPRESSION_ACTUAL_SIZE,
+            insert_str,
+        };
+
+        let mut ssec_compressed = HashMap::from([(SSEC_ALGORITHM_HEADER.to_string(), "AES256".to_string())]);
+        insert_str(&mut ssec_compressed, SUFFIX_COMPRESSION, "klauspost/compress/s2".to_string());
+        insert_str(&mut ssec_compressed, SUFFIX_ACTUAL_SIZE, "6295552".to_string());
+        let object_info = ObjectInfo {
+            etag: Some("0123456789abcdef0123456789abcdef-2".to_string()),
+            size: 4321,
+            actual_size: 6295552,
+            user_defined: Arc::new(ssec_compressed),
+            ..Default::default()
+        };
+
+        // SSE-C passthrough sends stored bytes: the scheme and the plaintext
+        // size travel as transport headers, never as the internal key
+        // (backlog#2363).
+        let (options, _) = replication_put_object_options("STANDARD", &object_info).expect("ssec put options");
+        assert_eq!(
+            get_header_map(&options.user_metadata, SUFFIX_REPLICATION_COMPRESSION).as_deref(),
+            Some("klauspost/compress/s2")
+        );
+        assert_eq!(
+            get_header_map(&options.user_metadata, SUFFIX_REPLICATION_COMPRESSION_ACTUAL_SIZE).as_deref(),
+            Some("6295552")
+        );
+        assert!(
+            !options
+                .user_metadata
+                .keys()
+                .any(|key| rustfs_utils::http::is_internal_key(key)),
+            "internal metadata never leaves the source as plain metadata: {:?}",
+            options.user_metadata
+        );
+
+        // A compressed object that is not SSE-C is decompressed by the
+        // replication reader and travels as plaintext: no layout headers.
+        let mut plain_compressed = HashMap::new();
+        insert_str(&mut plain_compressed, SUFFIX_COMPRESSION, "klauspost/compress/s2".to_string());
+        insert_str(&mut plain_compressed, SUFFIX_ACTUAL_SIZE, "6295552".to_string());
+        let plain = ObjectInfo {
+            user_defined: Arc::new(plain_compressed),
+            ..object_info
+        };
+        let (options, _) = replication_put_object_options("STANDARD", &plain).expect("plain put options");
+        assert!(get_header_map(&options.user_metadata, SUFFIX_REPLICATION_COMPRESSION).is_none());
+        assert!(get_header_map(&options.user_metadata, SUFFIX_REPLICATION_COMPRESSION_ACTUAL_SIZE).is_none());
     }
 
     #[test]

--- a/crates/utils/src/http/header_compat.rs
+++ b/crates/utils/src/http/header_compat.rs
@@ -43,6 +43,16 @@ pub const SUFFIX_FORCE_DELETE: &str = "force-delete";
 pub const SUFFIX_INCLUDE_DELETED: &str = "include-deleted";
 pub const SUFFIX_REPLICATION_RESET_STATUS: &str = "replication-reset-status";
 pub const SUFFIX_REPLICATION_ACTUAL_OBJECT_SIZE: &str = "replication-actual-object-size";
+/// SSE-C ciphertext passthrough of an object the source stored compressed:
+/// the stored compression scheme travels under this name so the replica
+/// decompresses after decrypting (backlog#2363).
+pub const SUFFIX_REPLICATION_COMPRESSION: &str = "replication-compression";
+/// Plaintext size of a compressed passthrough object (backlog#2363).
+pub const SUFFIX_REPLICATION_COMPRESSION_ACTUAL_SIZE: &str = "replication-compression-actual-size";
+/// Plaintext length of one passthrough multipart part, sent on UploadPart so
+/// the replica records the logical part size and checks the 5 MiB minimum
+/// against it rather than against the stored bytes (backlog#2363).
+pub const SUFFIX_REPLICATION_PART_ACTUAL_SIZE: &str = "replication-part-actual-size";
 pub const SUFFIX_SOURCE_VERSION_ID: &str = "source-version-id";
 pub const SUFFIX_SOURCE_MTIME: &str = "source-mtime";
 pub const SUFFIX_SOURCE_ETAG: &str = "source-etag";

--- a/rustfs/src/app/multipart_usecase.rs
+++ b/rustfs/src/app/multipart_usecase.rs
@@ -1247,9 +1247,19 @@ impl DefaultMultipartUsecase {
             StreamReader::new(body_stream.map(|f| f.map_err(s3s_body_error_to_io))),
         );
 
-        let is_disk_compressed = rustfs_utils::http::contains_key_str(&fi.user_defined, rustfs_utils::http::SUFFIX_COMPRESSION);
+        // An SSE-C passthrough session stores ciphertext parts verbatim: a
+        // compression key restored on the session describes those stored
+        // bytes and must not add a second compression layer, and each part's
+        // plaintext length comes from the sender (backlog#2363).
+        let preserve_ciphertext = contains_key_str(&fi.user_defined, SUFFIX_REPLICATION_PRESERVE_CIPHERTEXT);
+        let is_disk_compressed = !preserve_ciphertext
+            && rustfs_utils::http::contains_key_str(&fi.user_defined, rustfs_utils::http::SUFFIX_COMPRESSION);
 
-        let actual_size = size;
+        let actual_size = if preserve_ciphertext {
+            passthrough_part_actual_size(&req.headers).unwrap_or(size)
+        } else {
+            size
+        };
 
         let mut md5hex = if let Some(base64_md5) = input.content_md5 {
             let md5 = base64_simd::STANDARD
@@ -1286,7 +1296,6 @@ impl DefaultMultipartUsecase {
 
         // An SSE-C passthrough session stores ciphertext parts verbatim: no
         // material recovery, no validation against the (absent) customer key.
-        let preserve_ciphertext = contains_key_str(&fi.user_defined, SUFFIX_REPLICATION_PRESERVE_CIPHERTEXT);
         let has_ssec = !preserve_ciphertext
             && fi
                 .user_defined
@@ -1901,6 +1910,15 @@ impl DefaultMultipartUsecase {
 
         Ok(S3Response::new(output))
     }
+}
+
+/// Plaintext length of one SSE-C passthrough part, declared by the sender on
+/// UploadPart (backlog#2363).
+fn passthrough_part_actual_size(headers: &HeaderMap) -> Option<i64> {
+    get_header(headers, rustfs_utils::http::SUFFIX_REPLICATION_PART_ACTUAL_SIZE)?
+        .parse::<i64>()
+        .ok()
+        .filter(|size| *size > 0)
 }
 
 #[cfg(test)]

--- a/rustfs/src/app/object/put.rs
+++ b/rustfs/src/app/object/put.rs
@@ -1681,7 +1681,16 @@ impl DefaultObjectUsecase {
         };
         rustfs_io_metrics::record_put_object_stage_duration_from("app_prelookup", prelookup_stage_start);
 
-        let actual_size = size;
+        // A compressed SSE-C passthrough body is the source's stored bytes:
+        // its logical length is the plaintext size restored from the
+        // transport headers (backlog#2363). The body itself is still read
+        // at its wire size.
+        let body_size = size;
+        let actual_size = if ciphertext_passthrough {
+            passthrough_compressed_actual_size(&opts.user_defined).unwrap_or(size)
+        } else {
+            size
+        };
         if !ciphertext_passthrough && let Some(quota_check) = quota_check.as_ref() {
             ensure_object_size_within_quota(
                 quota_check,
@@ -1733,17 +1742,17 @@ impl DefaultObjectUsecase {
         } else {
             if use_zero_copy_eager_put_path {
                 let zero_copy_start = std::time::Instant::now();
-                let eager_body = read_zero_copy_put_body_exact(body, actual_size as usize).await?;
-                rustfs_io_metrics::record_zero_copy_write(actual_size as usize, zero_copy_start.elapsed().as_secs_f64() * 1000.0);
+                let eager_body = read_zero_copy_put_body_exact(body, body_size as usize).await?;
+                rustfs_io_metrics::record_zero_copy_write(body_size as usize, zero_copy_start.elapsed().as_secs_f64() * 1000.0);
                 HashReader::from_stream(eager_body, size, actual_size, md5hex, sha256hex, false).map_err(ApiError::from)?
             } else if use_empty_or_small_eager_put_path {
-                if (actual_size as usize) <= POOL_BYPASS_MAX_SIZE {
+                if (body_size as usize) <= POOL_BYPASS_MAX_SIZE {
                     // Bypass BytesPool for very small objects to avoid Small-tier
                     // Mutex contention under high concurrency. Direct allocation
                     // for ≤4KiB is negligible cost.
                     let eager_body = read_small_put_body_exact_direct(
                         StreamReader::new(body.map(|f| f.map_err(s3s_body_error_to_io))),
-                        actual_size as usize,
+                        body_size as usize,
                     )
                     .await?;
                     HashReader::from_stream(eager_body, size, actual_size, md5hex, sha256hex, false).map_err(ApiError::from)?
@@ -1751,11 +1760,11 @@ impl DefaultObjectUsecase {
                     let pool = get_concurrency_manager().bytes_pool();
                     let eager_body = read_small_put_body_exact_pooled(
                         StreamReader::new(body.map(|f| f.map_err(s3s_body_error_to_io))),
-                        actual_size as usize,
+                        body_size as usize,
                         pool.as_ref(),
                     )
                     .await?;
-                    let eager_reader = PooledBufferReader::new(eager_body, actual_size as usize);
+                    let eager_reader = PooledBufferReader::new(eager_body, body_size as usize);
                     HashReader::from_stream(eager_reader, size, actual_size, md5hex, sha256hex, false).map_err(ApiError::from)?
                 }
             } else {
@@ -2103,6 +2112,18 @@ pub(super) fn previous_current_size_from_backfill(backfill: Option<OldCurrentSiz
         OldCurrentSize::Present(size) => Some(size.max(0) as u64),
         OldCurrentSize::Absent => None,
     })
+}
+
+/// Plaintext size of a compressed SSE-C passthrough body, restored from the
+/// replication transport headers into the object metadata (backlog#2363).
+fn passthrough_compressed_actual_size(user_defined: &HashMap<String, String>) -> Option<i64> {
+    if !rustfs_utils::http::contains_key_str(user_defined, SUFFIX_COMPRESSION) {
+        return None;
+    }
+    rustfs_utils::http::get_str(user_defined, SUFFIX_ACTUAL_SIZE)?
+        .parse::<i64>()
+        .ok()
+        .filter(|size| *size >= 0)
 }
 
 #[cfg(test)]

--- a/rustfs/src/storage/options.rs
+++ b/rustfs/src/storage/options.rs
@@ -500,6 +500,25 @@ pub fn put_opts_from_headers_with_replication_authorization(
         if let Some(restored) = rustfs_utils::http::ssec_transport_to_stored_metadata(headers) {
             opts.user_defined.extend(restored);
             opts.preserve_ciphertext = true;
+            // A compressed passthrough object restores its compression
+            // layout as well, so the replica decompresses after decrypting
+            // (backlog#2363). The value is validated when the object is read.
+            if let Some(scheme) = get_header(headers, rustfs_utils::http::SUFFIX_REPLICATION_COMPRESSION) {
+                rustfs_utils::http::insert_str(
+                    &mut opts.user_defined,
+                    rustfs_utils::http::SUFFIX_COMPRESSION,
+                    scheme.into_owned(),
+                );
+                if let Some(actual_size) = get_header(headers, rustfs_utils::http::SUFFIX_REPLICATION_COMPRESSION_ACTUAL_SIZE)
+                    && actual_size.parse::<i64>().is_ok_and(|size| size >= 0)
+                {
+                    rustfs_utils::http::insert_str(
+                        &mut opts.user_defined,
+                        rustfs_utils::http::SUFFIX_ACTUAL_SIZE,
+                        actual_size.into_owned(),
+                    );
+                }
+            }
         }
         if let Some(crc) = get_header(headers, SUFFIX_REPLICATION_SSEC_CRC) {
             insert_header_map(&mut opts.user_defined, SUFFIX_REPLICATION_SSEC_CRC, crc.into_owned());
@@ -1586,6 +1605,59 @@ mod tests {
             "2026-01-01T00:00:00Z",
         );
         assert!(!has_replication_retention_update(&missing_request, true));
+    }
+
+    #[test]
+    fn put_opts_from_headers_restores_the_compression_layout_only_for_ssec_passthrough() {
+        use rustfs_utils::http::object_encryption_keys::REPLICATION_SSEC_ALGORITHM_HEADER;
+        use rustfs_utils::http::{
+            SUFFIX_ACTUAL_SIZE, SUFFIX_COMPRESSION, SUFFIX_REPLICATION_COMPRESSION, SUFFIX_REPLICATION_COMPRESSION_ACTUAL_SIZE,
+            get_str,
+        };
+
+        let mut headers = HeaderMap::new();
+        insert_header(&mut headers, SUFFIX_SOURCE_REPLICATION_REQUEST, "true");
+        insert_header(&mut headers, SUFFIX_REPLICATION_COMPRESSION, "klauspost/compress/s2");
+        insert_header(&mut headers, SUFFIX_REPLICATION_COMPRESSION_ACTUAL_SIZE, "6295552");
+
+        // Without SSE-C transport headers the request is not a passthrough:
+        // the target compresses (or not) by its own policy and must not adopt
+        // a layout the body does not have.
+        let plain = put_opts_from_headers_with_replication_authorization(&headers, HashMap::new(), true)
+            .expect("authorized replication request should parse");
+        assert!(!plain.preserve_ciphertext);
+        assert!(get_str(&plain.user_defined, SUFFIX_COMPRESSION).is_none());
+        assert!(get_str(&plain.user_defined, SUFFIX_ACTUAL_SIZE).is_none());
+
+        headers.insert(
+            REPLICATION_SSEC_ALGORITHM_HEADER.parse::<http::HeaderName>().unwrap(),
+            HeaderValue::from_static("AES256"),
+        );
+
+        // Unauthorized: inert, like the SSE-C transport itself.
+        let untrusted = put_opts_from_headers(&headers, HashMap::new()).expect("ordinary PUT options should be created");
+        assert!(!untrusted.preserve_ciphertext);
+        assert!(get_str(&untrusted.user_defined, SUFFIX_COMPRESSION).is_none());
+
+        // Authorized passthrough: the stored bytes are compressed ciphertext,
+        // so the replica records the scheme and the plaintext size
+        // (backlog#2363).
+        let trusted = put_opts_from_headers_with_replication_authorization(&headers, HashMap::new(), true)
+            .expect("authorized replication request should parse");
+        assert!(trusted.preserve_ciphertext);
+        assert_eq!(
+            get_str(&trusted.user_defined, SUFFIX_COMPRESSION).as_deref(),
+            Some("klauspost/compress/s2")
+        );
+        assert_eq!(get_str(&trusted.user_defined, SUFFIX_ACTUAL_SIZE).as_deref(), Some("6295552"));
+
+        // A malformed plaintext size is dropped; the scheme alone still lets
+        // the read path derive the size from the parts.
+        insert_header(&mut headers, SUFFIX_REPLICATION_COMPRESSION_ACTUAL_SIZE, "-5");
+        let malformed = put_opts_from_headers_with_replication_authorization(&headers, HashMap::new(), true)
+            .expect("authorized replication request should parse");
+        assert!(get_str(&malformed.user_defined, SUFFIX_COMPRESSION).is_some());
+        assert!(get_str(&malformed.user_defined, SUFFIX_ACTUAL_SIZE).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#2363. Refs rustfs/backlog#2147 and rustfs/rustfs#7334.

## Summary of Changes

SSE-C ciphertext passthrough replicates an object's stored bytes verbatim, but the sender stripped every `x-rustfs-internal-*` key, so a target never learned that those bytes were compressed. Against a real RustFS target a compressed single-PUT SSE-C object replicated `COMPLETED` and then failed to read back (the replica waited for the plaintext length while holding only the compressed ciphertext), and a compressed SSE-C multipart object was rejected at CompleteMultipartUpload with `EntityTooSmall` because the target validated the 5 MiB minimum against the stored bytes of the first part. rc.5 fails the same way as a sender.

- Sender: for an SSE-C object stored compressed, `replication_put_object_options` adds `x-rustfs-replication-compression` (the stored scheme) and `x-rustfs-replication-compression-actual-size` (the plaintext size) to the PutObject and CreateMultipartUpload requests, and the multipart transport adds `x-rustfs-replication-part-actual-size` to every UploadPart of a passthrough object. Internal keys still never leave the source as plain metadata; the compression headers travel only with SSE-C passthrough.
- Target: an authorized passthrough request restores the scheme and plaintext size into the stored metadata; the single-PUT path records the plaintext size as the part's logical length while still reading the body at its wire size; UploadPart on a passthrough session takes the part's logical length from the header and no longer adds a second compression layer on top of ciphertext; CompleteMultipartUpload therefore validates the 5 MiB minimum against the plaintext length.
- The fake S3 target honours the per-part header the same way RustFS does.
- Headers are additive. An older target ignores them and behaves as before; a non-passthrough replication request never carries them.

## Verification

Tested commit: the PR head, which is `main` c9c6bb7a2 plus rustfs/rustfs#7366 (the one-line scanner lint fix `main` currently needs to pass `-D warnings`) plus this change.

- Failing-before: `replication_extension_test::test_bucket_replication_sse_c_compressed_passthrough` replicates a compressed SSE-C single PUT and a two-part multipart object to a second RustFS instance and reads both replicas back with the customer key. Against the unfixed server binary it fails with `replica body read failed: streaming error` for the single PUT and `source reports FAILED` (EntityTooSmall) for the multipart object; with this change both replicas are byte-identical.
- Unit: `put_opts_from_headers_restores_the_compression_layout_only_for_ssec_passthrough` (target restore is gated on SSE-C passthrough and authorization, malformed sizes are dropped), `compressed_ssec_objects_declare_their_compression_layout_on_the_wire` (sender emits the headers only for SSE-C, never an internal key), and `multipart_transport_declares_passthrough_part_lengths` (a hyper fixture target observes the per-part length on every UploadPart and the scheme on CreateMultipartUpload; the decrypted transport carries neither).
- `cargo nextest run -p e2e_test -E 'test(/^replication_extension_test::(test_bucket_replication_sse_c_compressed_passthrough|test_bucket_replication_sse_c_multipart_passthrough|test_bucket_replication_sse_c_contract)$/)'`: 3 passed, so uncompressed SSE-C passthrough is unchanged.
- With the pinned rc.5 binary, `upgrade_compatibility_test::direct_upgrade_from_rc5_preserves_multipart_layouts` (rustfs/rustfs#7334) replicates the rc.5-written compressed SSE-C multipart object `COMPLETED` with parts 1 and 2; `rc5_baseline_replicates_multipart_layouts` still records `FAILED` for the same layout when rc.5 is the sender, which is the expected pre-fix behaviour.
- `cargo clippy -p rustfs-utils -p rustfs-ecstore -p rustfs -p e2e_test --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean; the six architecture guard scripts pass.

Not run: the full unit suite, the nightly replication lane, and a mixed-version pair where only one side has this change (an old target still rejects or misreads compressed passthrough replicas, as today). Remaining risk: the passthrough part length is trusted from an authorized replication sender; it only affects the logical length recorded for the part and the minimum-size check, never the stored bytes.

## Impact

Compressed SSE-C objects now replicate to RustFS targets on the current build and the replicas decrypt and decompress to the source bytes. Three additive replication transport headers are introduced; no configuration or on-disk format change.

## Additional Notes

Based on rustfs/rustfs#7366 so the lint lanes can pass; it carries no other change from that PR. The backlog#2362 fix (in-flight dedupe) is stacked on top of this PR because its regression test needs both fixes.
