### PR TITLE
fix(replication): queue an in-flight version only once

### DIFF
--- a/crates/e2e_test/src/upgrade_compatibility_test.rs
+++ b/crates/e2e_test/src/upgrade_compatibility_test.rs
@@ -1473,20 +1473,17 @@ fn layout_cases() -> Vec<LayoutCase> {
             true,
         ),
         // SSE-C passthrough replicates the stored ciphertext part by part; a
-        // compressible first part is stored well below 5 MiB and a standard
-        // target rejects it with EntityTooSmall. rc.5 fails the same way (see
-        // `rc5_baseline_replicates_multipart_layouts`), so the outcome is
-        // recorded rather than asserted here; tracked as rustfs/backlog#2363.
-        LayoutCase {
-            assert_replication: false,
-            ..case(
-                LAYOUT_PLAIN_BUCKET,
-                "plain/ssec-compressed-multipart-2.txt",
-                two.clone(),
-                layout_text(total(&two), 7),
-                true,
-            )
-        },
+        // compressible first part is stored well below 5 MiB, so the sender
+        // declares each part's plaintext length and the target validates the
+        // 5 MiB minimum against it (rustfs/backlog#2363). rc.5 as the sender
+        // still fails this layout (see `rc5_baseline_replicates_multipart_layouts`).
+        case(
+            LAYOUT_PLAIN_BUCKET,
+            "plain/ssec-compressed-multipart-2.txt",
+            two.clone(),
+            layout_text(total(&two), 7),
+            true,
+        ),
         case(
             LAYOUT_ENCRYPTED_BUCKET,
             "encrypted/single.bin",
@@ -1838,27 +1835,20 @@ async fn direct_upgrade_from_rc5_preserves_multipart_layouts() -> TestResult {
                 transport.uploaded_parts, expected,
                 "{label}: stored parts must replicate as the same multipart layout"
             );
-            // The current build can drive an existing object twice (two
-            // full CreateMultipartUpload/UploadPart/Complete rounds with
-            // distinct upload ids) while its status is still PENDING; the
-            // rc.5 baseline drives once. That is a scheduling difference,
-            // not a layout one, tracked as rustfs/backlog#2362.
-            assert!(transport.completes >= 1, "{label}: at least one CompleteMultipartUpload");
-            if transport.completes > 1 {
-                tracing::warn!(
-                    target: "e2e_test::upgrade_compatibility_test",
-                    object = %label,
-                    completes = transport.completes,
-                    journal = ?transport.journal,
-                    "existing-object replication drove the same object more than once (rustfs/backlog#2362)"
-                );
-            }
+            // An object still PENDING when the next scanner cycle arrives is
+            // not driven a second time (rustfs/backlog#2362); the journal is
+            // logged so a duplicate round is visible if this ever regresses.
+            assert_eq!(
+                transport.completes, 1,
+                "{label}: exactly one CompleteMultipartUpload; journal {:?}",
+                transport.journal
+            );
             assert_eq!(
                 transport.single_puts, 0,
                 "{label}: a multipart layout must not go out as a single PutObject"
             );
         } else {
-            assert!(transport.single_puts >= 1, "{label}: a single PUT replicates as PutObject");
+            assert_eq!(transport.single_puts, 1, "{label}: a single PUT replicates as exactly one PutObject");
             assert!(transport.uploaded_parts.is_empty(), "{label}: a single PUT must not go out as multipart");
         }
         if !case.ssec {
@@ -1926,5 +1916,61 @@ async fn rc5_baseline_replicates_multipart_layouts() -> TestResult {
         })
         .collect();
     tracing::info!(target: "e2e_test::upgrade_compatibility_test", ?summary, "rc.5 baseline replication outcomes");
+    Ok(())
+}
+
+/// backlog#2362 under the same conditions that reproduced it with the rc.5
+/// writer, but with the workspace build on both sides so it runs in the
+/// ordinary lane: every pre-existing layout is driven through exactly one
+/// upload round even though the scanner re-scans it every second while the
+/// first round is still in flight.
+#[tokio::test]
+async fn existing_object_replication_drives_each_layout_once() -> TestResult {
+    init_logging();
+    let server_env = layout_server_env();
+
+    let mut env = RustFSTestEnvironment::new().await?;
+    env.start_rustfs_server_with_env(vec![], &server_env).await?;
+    let writer = env.create_s3_client();
+    env.create_test_bucket(LAYOUT_PLAIN_BUCKET).await?;
+    env.create_test_bucket(LAYOUT_ENCRYPTED_BUCKET).await?;
+    enable_versioning(&writer, LAYOUT_PLAIN_BUCKET).await?;
+    enable_versioning(&writer, LAYOUT_ENCRYPTED_BUCKET).await?;
+    put_default_sse_s3_encryption(&writer, LAYOUT_ENCRYPTED_BUCKET).await?;
+
+    let mut cases = layout_cases();
+    for case in cases.iter_mut() {
+        layout_write(&writer, case).await?;
+        let head = layout_head(&writer, case).await?;
+        case.rc5_etag = head
+            .e_tag()
+            .ok_or_else(|| format!("{}: HEAD omitted the ETag", case.label()))?
+            .trim_matches('"')
+            .to_string();
+    }
+
+    // The objects come from an earlier process lifetime: the scanner starts
+    // cold and every object is a candidate at once.
+    env.restart_server_preserving_data(vec![], &server_env).await?;
+    let client = env.create_s3_client();
+    let (_target, transports) = replicate_layouts(&env, &client, &cases).await?;
+    let mut duplicates = Vec::new();
+    for (case, transport) in cases.iter().zip(&transports) {
+        assert_eq!(
+            transport.status,
+            "COMPLETED",
+            "{}: existing-object replication must complete",
+            case.label()
+        );
+        let rounds = if case.is_multipart_layout() {
+            transport.completes
+        } else {
+            transport.single_puts
+        };
+        if rounds != 1 {
+            duplicates.push(format!("{}: {rounds} upload rounds; journal {:?}", case.label(), transport.journal));
+        }
+    }
+    assert!(duplicates.is_empty(), "each existing object must be driven exactly once: {duplicates:?}");
     Ok(())
 }

--- a/crates/ecstore/src/bucket/replication/replication_pool.rs
+++ b/crates/ecstore/src/bucket/replication/replication_pool.rs
@@ -75,6 +75,7 @@ use tracing::{debug, info, instrument, warn};
 const EVENT_REPLICATION_WORKER_RESIZE_SKIPPED: &str = "replication_worker_resize_skipped";
 const EVENT_REPLICATION_WORKER_RESIZED: &str = "replication_worker_resized";
 const EVENT_REPLICATION_BACKPRESSURE: &str = "replication_backpressure";
+const EVENT_REPLICATION_IN_FLIGHT_SKIPPED: &str = "replication_in_flight_skipped";
 const EVENT_REPLICATION_RESYNC_LOAD_SKIPPED: &str = "replication_resync_load_skipped";
 const EVENT_REPLICATION_RESYNC_RECOVERED: &str = "replication_resync_recovered";
 const EVENT_REPLICATION_MRF_QUEUE_UNAVAILABLE: &str = "replication_mrf_queue_unavailable";
@@ -1089,6 +1090,9 @@ pub struct ReplicationPool<S: ReplicationStorage> {
     workers: RwLock<Vec<Sender<ReplicationOperation>>>,
     lrg_workers: RwLock<Vec<Sender<ReplicationOperation>>>,
 
+    /// Object versions queued or being replicated right now (backlog#2362).
+    in_flight: Arc<ReplicationInFlight>,
+
     // MRF (Most Recent Failures) channels
     mrf_replica_tx: Sender<ReplicationOperation>,
     // Shared among N MRF workers; Arc allows spawning more than one worker.
@@ -1147,6 +1151,7 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
             storage,
             workers: RwLock::new(Vec::new()),
             lrg_workers: RwLock::new(Vec::new()),
+            in_flight: Arc::new(ReplicationInFlight::default()),
             mrf_replica_tx,
             mrf_replica_rx: Arc::new(Mutex::new(mrf_replica_rx)),
             mrf_save_tx,
@@ -1202,12 +1207,13 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
             let active_counter = self.active_lrg_workers.clone();
             let storage = self.storage.clone();
             let stats = self.stats.clone();
+            let in_flight = self.in_flight.clone();
 
             let handle = tokio::spawn(async move {
                 let mut rx = rx;
                 while let Some(operation) = rx.recv().await {
                     let _active = ActiveWorkerGuard::new(active_counter.clone());
-                    process_replication_operation(operation, stats.clone(), storage.clone()).await;
+                    process_replication_operation(operation, stats.clone(), storage.clone(), in_flight.clone()).await;
                 }
             });
 
@@ -1261,12 +1267,13 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
             let active_counter = self.active_workers.clone();
             let stats = self.stats.clone();
             let storage = self.storage.clone();
+            let in_flight = self.in_flight.clone();
 
             let handle = tokio::spawn(async move {
                 let mut rx = rx;
                 while let Some(operation) = rx.recv().await {
                     let _active = ActiveWorkerGuard::new(active_counter.clone());
-                    process_replication_operation(operation, stats.clone(), storage.clone()).await;
+                    process_replication_operation(operation, stats.clone(), storage.clone(), in_flight.clone()).await;
                 }
             });
 
@@ -1305,6 +1312,7 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
             let active_counter = self.active_mrf_workers.clone();
             let stats = self.stats.clone();
             let storage = self.storage.clone();
+            let in_flight = self.in_flight.clone();
             let mrf_rx = Arc::clone(&self.mrf_replica_rx);
 
             let handle = tokio::spawn(async move {
@@ -1324,7 +1332,7 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
                     let Some(operation) = operation else { break };
 
                     let _active = ActiveWorkerGuard::new(active_counter.clone());
-                    process_replication_operation(operation, stats.clone(), storage.clone()).await;
+                    process_replication_operation(operation, stats.clone(), storage.clone(), in_flight.clone()).await;
                 }
             });
             self.task_handles.lock().await.push(handle);
@@ -1454,6 +1462,24 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
 
     /// Queues a replica task
     pub async fn queue_replica_task(&self, ri: ReplicateObjectInfo) -> ReplicationQueueAdmission {
+        // A version that is already queued or being uploaded is not driven a
+        // second time: the scanner heal pass sees it as PENDING until the
+        // first upload lands and would otherwise re-queue it every cycle
+        // (backlog#2362). The key is released when the worker finishes, or
+        // below when no worker accepts the task.
+        if !self.in_flight.try_begin(&ri) {
+            debug!(
+                event = EVENT_REPLICATION_IN_FLIGHT_SKIPPED,
+                component = LOG_COMPONENT_ECSTORE,
+                subsystem = LOG_SUBSYSTEM_REPLICATION,
+                bucket = %ri.bucket,
+                object = %ri.name,
+                version_id = ?ri.version_id,
+                op_type = ?ri.op_type,
+                "Replication task already in flight; not queued again"
+            );
+            return ReplicationQueueAdmission::Skipped;
+        }
         let target_arns = ri.dsc.replicate_target_arns();
         // If object is large, queue it to a static set of large workers
         if should_queue_large_object(ri.size) {
@@ -1484,7 +1510,9 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
                     let resize = large_worker_backpressure_resize(existing, self.active_lrg_workers(), max_l_workers);
                     drop(lrg_workers);
 
-                    // Queue to MRF if worker is busy.
+                    // Queue to MRF if worker is busy. The MRF replay re-enters
+                    // this function, so the version is no longer in flight.
+                    self.in_flight.finish(&ri);
                     let admission = self.queue_mrf_save_admission(ri.to_mrf_entry(), "large_object").await;
 
                     if let Some(resize) = resize {
@@ -1493,6 +1521,7 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
                     return admission;
                 }
             }
+            self.in_flight.finish(&ri);
             return ReplicationQueueAdmission::Missed;
         }
 
@@ -1501,6 +1530,7 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
         let ch = self.worker_queue_channel(&ri.op_type, &ri.bucket, &ri.name, ri.size).await;
 
         let Some(channel) = ch else {
+            self.in_flight.finish(&ri);
             return ReplicationQueueAdmission::Missed;
         };
 
@@ -1512,7 +1542,9 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
         self.stats.dec_q(&ri.bucket, ri.size, ri.delete_marker, ri.op_type);
         self.stats.dec_target_q(&ri.bucket, &target_arns, ri.size);
 
-        // Queue to MRF if all workers are busy.
+        // Queue to MRF if all workers are busy. The MRF replay re-enters this
+        // function, so the version is no longer in flight.
+        self.in_flight.finish(&ri);
         let admission = self.queue_mrf_save_admission(ri.to_mrf_entry(), "object").await;
 
         // Try to scale up workers based on priority
@@ -1811,7 +1843,7 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
     ) {
         while let Some(operation) = rx.recv().await {
             let _active = ActiveWorkerGuard::new(active_counter.clone());
-            process_replication_operation(operation, stats.clone(), self.storage.clone()).await;
+            process_replication_operation(operation, stats.clone(), self.storage.clone(), self.in_flight.clone()).await;
         }
     }
 
@@ -1829,7 +1861,7 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
     ) {
         while let Some(operation) = rx.recv().await {
             let _active = ActiveWorkerGuard::new(active_counter.clone());
-            process_replication_operation(operation, stats.clone(), storage.clone()).await;
+            process_replication_operation(operation, stats.clone(), storage.clone(), self.in_flight.clone()).await;
         }
     }
 
@@ -1846,7 +1878,7 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
     ) {
         while let Some(operation) = rx.recv().await {
             let _active = ActiveWorkerGuard::new(active_counter.clone());
-            process_replication_operation(operation, stats.clone(), self.storage.clone()).await;
+            process_replication_operation(operation, stats.clone(), self.storage.clone(), self.in_flight.clone()).await;
         }
     }
 
@@ -2281,6 +2313,64 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
     }
 }
 
+/// Object versions currently queued or being uploaded, keyed by bucket,
+/// object name and version. `queue_replica_task` admits a version only once
+/// while it is in flight; the scanner heal pass and MRF replays that arrive
+/// in the meantime are `Skipped` instead of driving a second complete upload
+/// (backlog#2362). Entries are removed when the worker finishes the task or
+/// when no worker accepted it.
+#[derive(Debug, Default)]
+pub(crate) struct ReplicationInFlight {
+    keys: std::sync::Mutex<std::collections::HashSet<(String, String, Option<uuid::Uuid>)>>,
+}
+
+impl ReplicationInFlight {
+    fn lock(&self) -> std::sync::MutexGuard<'_, std::collections::HashSet<(String, String, Option<uuid::Uuid>)>> {
+        self.keys.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Claim `ri`; `false` when the same version is already in flight.
+    fn try_begin(&self, ri: &ReplicateObjectInfo) -> bool {
+        self.lock().insert((ri.bucket.clone(), ri.name.clone(), ri.version_id))
+    }
+
+    fn finish(&self, ri: &ReplicateObjectInfo) {
+        self.lock().remove(&(ri.bucket.clone(), ri.name.clone(), ri.version_id));
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.lock().len()
+    }
+}
+
+/// Releases the in-flight claim when the worker is done with the task,
+/// including when replication panics.
+struct ReplicationInFlightGuard {
+    in_flight: Arc<ReplicationInFlight>,
+    key: ReplicateObjectInfo,
+}
+
+impl ReplicationInFlightGuard {
+    fn new(in_flight: Arc<ReplicationInFlight>, ri: &ReplicateObjectInfo) -> Self {
+        Self {
+            in_flight,
+            key: ReplicateObjectInfo {
+                bucket: ri.bucket.clone(),
+                name: ri.name.clone(),
+                version_id: ri.version_id,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl Drop for ReplicationInFlightGuard {
+    fn drop(&mut self) {
+        self.in_flight.finish(&self.key);
+    }
+}
+
 struct ActiveWorkerGuard {
     counter: Arc<AtomicI32>,
 }
@@ -2342,10 +2432,12 @@ async fn process_replication_operation<S: ReplicationStorage>(
     operation: ReplicationOperation,
     stats: Arc<ReplicationStats>,
     storage: Arc<S>,
+    in_flight: Arc<ReplicationInFlight>,
 ) {
     match operation {
         ReplicationOperation::Object(obj_info) => {
             let _backlog = ReplicationBacklogGuard::for_object(stats, obj_info.as_ref());
+            let _in_flight = ReplicationInFlightGuard::new(in_flight, obj_info.as_ref());
             replicate_object(*obj_info, storage).await;
         }
         ReplicationOperation::Delete(del_info) => {
@@ -3707,6 +3799,7 @@ mod tests {
             stats: Arc::new(ReplicationStats::new()),
             workers: RwLock::new(Vec::new()),
             lrg_workers: RwLock::new(Vec::new()),
+            in_flight: Arc::new(ReplicationInFlight::default()),
             mrf_replica_tx,
             mrf_replica_rx: Arc::new(Mutex::new(mrf_replica_rx)),
             mrf_save_tx,
@@ -3771,6 +3864,90 @@ mod tests {
 
         assert_eq!(admission, ReplicationQueueAdmission::Queued);
         assert_eq!(current_queue(&pool, "admission-bucket").await, (1, 4096));
+    }
+
+    #[tokio::test]
+    async fn queue_replica_task_admits_a_version_once_while_it_is_in_flight() {
+        let pool = new_test_replication_pool(Arc::new(LoadResyncNodeStore::new("node-a", empty_resync_shared_state()))).await;
+        let (tx, _rx) = mpsc::channel(4);
+        pool.workers.write().await.push(tx);
+        let ri = ReplicateObjectInfo {
+            bucket: "in-flight-bucket".to_string(),
+            name: "object".to_string(),
+            version_id: Some(uuid::Uuid::new_v4()),
+            size: 4096,
+            op_type: ReplicationType::Object,
+            ..Default::default()
+        };
+
+        assert_eq!(pool.queue_replica_task(ri.clone()).await, ReplicationQueueAdmission::Queued);
+        // backlog#2362: the scanner heal pass sees the version as PENDING
+        // until the worker lands it; a second request must not drive it again.
+        assert_eq!(pool.queue_replica_task(ri.clone()).await, ReplicationQueueAdmission::Skipped);
+        assert_eq!(current_queue(&pool, "in-flight-bucket").await, (1, 4096));
+
+        // Another version of the same key is independent work.
+        let newer = ReplicateObjectInfo {
+            version_id: Some(uuid::Uuid::new_v4()),
+            ..ri.clone()
+        };
+        assert_eq!(pool.queue_replica_task(newer).await, ReplicationQueueAdmission::Queued);
+        assert_eq!(pool.in_flight.len(), 2);
+
+        // Once the worker finishes, the same version may be queued again
+        // (for example after a FAILED status).
+        pool.in_flight.finish(&ri);
+        assert_eq!(pool.queue_replica_task(ri).await, ReplicationQueueAdmission::Queued);
+        assert_eq!(current_queue(&pool, "in-flight-bucket").await, (3, 3 * 4096));
+    }
+
+    #[tokio::test]
+    async fn queue_replica_task_releases_the_version_when_no_worker_accepts_it() {
+        let pool = new_test_replication_pool(Arc::new(LoadResyncNodeStore::new("node-a", empty_resync_shared_state()))).await;
+        let ri = ReplicateObjectInfo {
+            bucket: "no-worker-bucket".to_string(),
+            name: "object".to_string(),
+            version_id: Some(uuid::Uuid::new_v4()),
+            size: 4096,
+            op_type: ReplicationType::Object,
+            ..Default::default()
+        };
+
+        // No worker channel: the task is missed and must not stay claimed.
+        assert_eq!(pool.queue_replica_task(ri.clone()).await, ReplicationQueueAdmission::Missed);
+        assert_eq!(pool.in_flight.len(), 0);
+        assert_eq!(pool.queue_replica_task(ri.clone()).await, ReplicationQueueAdmission::Missed);
+
+        // A full worker channel hands the task to the MRF save path; the MRF
+        // replay re-enters the queue, so the claim is released here too.
+        let (tx, _rx) = mpsc::channel(1);
+        pool.workers.write().await.push(tx);
+        assert_eq!(pool.queue_replica_task(ri.clone()).await, ReplicationQueueAdmission::Queued);
+        let overflow = ReplicateObjectInfo {
+            version_id: Some(uuid::Uuid::new_v4()),
+            ..ri
+        };
+        assert_eq!(pool.queue_replica_task(overflow).await, ReplicationQueueAdmission::Queued);
+        assert_eq!(pool.in_flight.len(), 1, "only the version held by the worker channel stays in flight");
+    }
+
+    #[test]
+    fn in_flight_guard_releases_the_version_on_drop() {
+        let in_flight = Arc::new(ReplicationInFlight::default());
+        let ri = ReplicateObjectInfo {
+            bucket: "guard-bucket".to_string(),
+            name: "object".to_string(),
+            version_id: Some(uuid::Uuid::new_v4()),
+            ..Default::default()
+        };
+        assert!(in_flight.try_begin(&ri));
+        assert!(!in_flight.try_begin(&ri));
+        {
+            let _guard = ReplicationInFlightGuard::new(in_flight.clone(), &ri);
+            assert_eq!(in_flight.len(), 1);
+        }
+        assert_eq!(in_flight.len(), 0);
+        assert!(in_flight.try_begin(&ri));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#2362. Refs rustfs/backlog#2147 and rustfs/backlog#2340.

## Summary of Changes

The scanner heal pass queues every object whose replication status is `PENDING` or `FAILED`. An object whose first upload is still running is `PENDING` at the next cycle, so the pool queued it again and a second worker drove a complete second round (CreateMultipartUpload, UploadPart 1..N, CompleteMultipartUpload with a new upload id). With `RUSTFS_SCANNER_CYCLE=1` this reproduced on two or three of eleven existing objects in every run; on targets that mint their own version ids each round mints another version.

- `ReplicationPool` now keeps an in-flight set keyed by bucket, object and version. `queue_replica_task` admits a version once while it is queued or being uploaded and returns `Skipped` for a repeat; the claim is released by a drop guard when the worker finishes the operation (including on panic), and immediately when no worker channel accepts the task or it is handed to the MRF save path, because the MRF replay re-enters the same queue.
- Delete-marker and version-purge operations are not affected; different versions of the same key are independent claims.

## Verification

Tested commit: the PR head, stacked on rustfs/rustfs#7366 (scanner lint) and the backlog#2363 passthrough fix; the diff of this PR is `replication_pool.rs` plus the upgrade test.

- Failing-before: `upgrade_compatibility_test::existing_object_replication_drives_each_layout_once` (not ignored) writes the eleven layouts of rustfs/rustfs#7334 with the workspace build, restarts the server so the scanner starts cold, enables `ExistingObjectReplication` on both buckets with a one-second scanner cycle, and asserts exactly one upload round per object. Against the unfixed server binary three objects were driven through two complete multipart rounds with distinct upload ids (`plain/multipart-2.bin`, `plain/compressed-multipart-2.txt`, `encrypted/multipart-2.bin`); with this change every object is driven once. A simpler twelve-object variant did not reproduce the race because local uploads finished before the next scanner cycle, so it is not included.
- `cargo nextest run -p rustfs-ecstore --lib -E 'test(/queue_replica_task_|in_flight_guard/)'`: the three new unit tests pass (a repeat of an in-flight version is `Skipped`, another version of the same key is `Queued`, a missed or MRF-saved task releases its claim, the guard releases on drop) together with the existing admission tests.
- With the pinned rc.5 binary, `upgrade_compatibility_test::direct_upgrade_from_rc5_preserves_multipart_layouts` now asserts exactly one upload round per object (the assertion rustfs/rustfs#7334 had to relax) and passes; before this change two or three of the eleven objects were driven twice in every run.
- `cargo clippy -p rustfs-ecstore -p e2e_test --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean; the six architecture guard scripts pass.

Not run: the full unit suite and the nightly replication lane. Remaining risk: an object whose worker task never returns keeps its claim until the process restarts; the in-flight set holds no data, so a restart recovers it, and the scanner re-queues the object on its next cycle as before.

## Impact

Existing-object replication and heal re-drives no longer upload the same version twice while its first upload is in progress. No wire, configuration, or on-disk change. The admission metric counts the repeat as `Skipped`.

## Additional Notes

N/A.
