### PR TITLE
feat(scanner): persist raw page owner resume state

### DIFF
--- a/crates/scanner/src/data_usage_define.rs
+++ b/crates/scanner/src/data_usage_define.rs
@@ -38,6 +38,7 @@ use rustfs_utils::path::{SLASH_SEPARATOR, path_join_buf};
 use tokio::time::{Duration, Instant, sleep, timeout};
 use tracing::{debug, warn};
 
+use crate::raw_page_index::{RawEnumerationPageIndex, RawEnumerationPageOwnerStatus};
 use crate::storage_api::owner::HTTPPreconditions;
 use crate::{
     BUCKET_META_PREFIX, EcstoreError as Error, EcstoreResult as StorageResult, RUSTFS_META_BUCKET, ReplicationConfig,
@@ -601,6 +602,8 @@ pub struct DataUsageCacheInfo {
     pub scan_checkpoint: Option<DataUsageScanCheckpoint>,
     #[serde(default)]
     pub scan_raw_enumeration_cursor: Option<DataUsageRawEnumerationCursor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scan_raw_enumeration_page_index: Option<RawEnumerationPageIndex>,
     #[serde(default)]
     pub scan_identity: Option<DataUsageScanIdentity>,
     #[serde(default)]
@@ -661,6 +664,7 @@ impl Serialize for DataUsageCacheInfo {
         // appended by newer scanner versions during rolling upgrades.
         let field_count = 16
             + usize::from(self.scan_raw_enumeration_cursor.is_some())
+            + usize::from(self.scan_raw_enumeration_page_index.is_some())
             + usize::from(self.scan_identity.is_some())
             + usize::from(self.scan_progress.is_some())
             + usize::from(self.scan_coverage_receipt.is_some())
@@ -686,6 +690,9 @@ impl Serialize for DataUsageCacheInfo {
         state.serialize_entry("scan_checkpoint", &self.scan_checkpoint)?;
         if let Some(cursor) = &self.scan_raw_enumeration_cursor {
             state.serialize_entry("scan_raw_enumeration_cursor", cursor)?;
+        }
+        if let Some(index) = &self.scan_raw_enumeration_page_index {
+            state.serialize_entry("scan_raw_enumeration_page_index", index)?;
         }
         if let Some(identity) = self.scan_identity {
             state.serialize_entry("scan_identity", &identity)?;
@@ -895,6 +902,7 @@ impl DataUsageCache {
             && self.info.scan_progress.is_none()
             && self.info.scan_checkpoint.is_none()
             && self.info.scan_raw_enumeration_cursor.is_none()
+            && self.info.scan_raw_enumeration_page_index.is_none()
             && self.info.scan_resume_after.is_none()
             && self.info.scan_coverage_receipt.is_none()
             && self.info.scan_plan_digest == Some(scan_plan_digest)
@@ -922,12 +930,17 @@ impl DataUsageCache {
         if self.validated_raw_enumeration_cursor().is_none() {
             self.info.scan_raw_enumeration_cursor = None;
         }
+        if self.validated_raw_enumeration_page_index().is_none() {
+            self.info.scan_raw_enumeration_page_index = None;
+        }
         let cursor_is_valid = (self.info.scan_checkpoint.is_none()
             && self.info.scan_raw_enumeration_cursor.is_none()
+            && self.info.scan_raw_enumeration_page_index.is_none()
             && self.info.scan_resume_after.is_none()
             && self.info.scan_coverage_receipt.is_none())
             || self.validated_scan_frontier().is_some()
-            || self.info.scan_raw_enumeration_cursor.is_some();
+            || self.info.scan_raw_enumeration_cursor.is_some()
+            || self.info.scan_raw_enumeration_page_index.is_some();
         if !cursor_is_valid {
             self.info.scan_progress = None;
         }
@@ -949,6 +962,7 @@ impl DataUsageCache {
             self.info.scan_resume_after = None;
             self.info.scan_checkpoint = None;
             self.info.scan_raw_enumeration_cursor = None;
+            self.info.scan_raw_enumeration_page_index = None;
             self.info.scan_coverage_receipt = None;
         }
         // Old readers do not understand coverage sweeps. An absent plan makes
@@ -1024,6 +1038,25 @@ impl DataUsageCache {
             && self.info.source.is_some()
             && cursor.is_valid_for_bucket(&self.info.name))
         .then_some(cursor)
+    }
+
+    pub(crate) fn validated_raw_enumeration_page_index(&self) -> Option<&RawEnumerationPageIndex> {
+        let index = self.info.scan_raw_enumeration_page_index.as_ref()?;
+        if self.info.scan_progress.is_none()
+            || !self.info.scan_identity.is_some_and(|identity| identity.is_valid())
+            || self.info.source.is_none()
+            || index.committed_entries().is_err()
+            || index.indexed_entries().is_err()
+        {
+            return None;
+        }
+        let parent = match index.status() {
+            RawEnumerationPageOwnerStatus::Unsupported => return None,
+            RawEnumerationPageOwnerStatus::Building { parent, .. } | RawEnumerationPageOwnerStatus::Ready { parent, .. } => {
+                parent
+            }
+        };
+        path_is_in_bucket_scope(&self.info.name, &parent).then_some(index)
     }
 
     /// Seal only the frontier supplied by completed traversal, never a restored cursor.

--- a/crates/scanner/src/data_usage_define/tests.rs
+++ b/crates/scanner/src/data_usage_define/tests.rs
@@ -1179,6 +1179,7 @@ fn test_new_data_usage_cache_msgpack_round_trips_and_supports_old_reader() {
                 7,
                 [7; 32],
             )),
+            scan_raw_enumeration_page_index: Some(raw_page_index_fixture("bucket/prefix", &["entry-a"], false)),
             snapshot_complete: true,
             scan_plan_digest: Some(TEST_PLAN_DIGEST),
             scan_execution_digest: Some(DataUsageScanPlanDigest([42; 32])),
@@ -1207,6 +1208,7 @@ fn test_new_data_usage_cache_msgpack_round_trips_and_supports_old_reader() {
             .map(|cursor| cursor.last_entry.as_deref()),
         Some(Some("last-object"))
     );
+    assert!(current.info.scan_raw_enumeration_page_index.is_some());
     assert!(current.info.snapshot_complete);
     assert_eq!(current.info.scan_plan_digest, Some(TEST_PLAN_DIGEST));
     assert_eq!(current.info.scan_execution_digest, Some(DataUsageScanPlanDigest([42; 32])));
@@ -1258,6 +1260,24 @@ fn cache_with_raw_cursor(cursor: DataUsageRawEnumerationCursor) -> DataUsageCach
         },
         ..Default::default()
     }
+}
+
+fn raw_page_index_fixture(parent: &str, entries: &[&str], complete: bool) -> RawEnumerationPageIndex {
+    let mut index = RawEnumerationPageIndex::new(parent, 2).expect("raw page index should initialize");
+    let generation = index.generation().expect("raw page index should expose generation");
+    let outcome = if complete {
+        index.ingest_owner_entries(entries.iter().map(|entry| (*entry).to_string()), entries.len().max(1), generation)
+    } else {
+        index.ingest_partial_owner_entries(entries.iter().map(|entry| (*entry).to_string()), entries.len().max(1), generation)
+    }
+    .expect("raw page index fixture should ingest entries");
+    if outcome.ready_to_commit {
+        let generation = index.generation().expect("raw page index should expose commit generation");
+        index
+            .commit_building_page(generation)
+            .expect("raw page index fixture should commit ready page");
+    }
+    index
 }
 
 #[test]
@@ -1343,6 +1363,44 @@ fn prepare_bucket_checkpoint_preserves_only_valid_raw_enumeration_cursor() {
         DataUsageCachePrepareOutcome::Reused
     );
     assert!(cache.info.scan_raw_enumeration_cursor.is_none());
+    assert!(cache.info.scan_progress.is_some());
+}
+
+#[test]
+fn prepare_bucket_checkpoint_preserves_only_valid_raw_page_index() {
+    let identity = valid_scan_identity();
+    let source = DataUsageCacheSource::new(1, 2);
+    let page_index = raw_page_index_fixture("bucket/raw", &["entry-001"], false);
+    let mut cache = DataUsageCache {
+        info: DataUsageCacheInfo {
+            name: "bucket".to_string(),
+            leader_epoch: 1,
+            source: Some(source),
+            cache_key_format: DATA_USAGE_CACHE_KEY_FORMAT,
+            scan_identity: Some(identity),
+            tier_registry_generation: Some(9),
+            scan_progress: Some(DataUsageScanProgress {
+                started_plan: TEST_PLAN_DIGEST,
+                requested_plan: TEST_PLAN_DIGEST,
+            }),
+            scan_raw_enumeration_page_index: Some(page_index.clone()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    assert_eq!(
+        cache.prepare_bucket_checkpoint("bucket", 1, 1, source, TEST_PLAN_DIGEST, identity),
+        DataUsageCachePrepareOutcome::Reused
+    );
+    assert_eq!(cache.info.scan_raw_enumeration_page_index, Some(page_index));
+
+    let invalid = raw_page_index_fixture("other/raw", &["entry-001"], false);
+    cache.info.scan_raw_enumeration_page_index = Some(invalid);
+    assert_eq!(
+        cache.prepare_bucket_checkpoint("bucket", 1, 1, source, TEST_PLAN_DIGEST, identity),
+        DataUsageCachePrepareOutcome::Reused
+    );
+    assert!(cache.info.scan_raw_enumeration_page_index.is_none());
     assert!(cache.info.scan_progress.is_some());
 }
 

--- a/crates/scanner/src/raw_page_index.rs
+++ b/crates/scanner/src/raw_page_index.rs
@@ -161,6 +161,31 @@ impl RawEnumerationPageIndex {
     where
         I: IntoIterator<Item = String>,
     {
+        self.ingest_owner_entries_inner(entries, max_new_entries, expected_generation, true)
+    }
+
+    pub fn ingest_partial_owner_entries<I>(
+        &mut self,
+        entries: I,
+        max_new_entries: usize,
+        expected_generation: u64,
+    ) -> Result<RawEnumerationPageBuildOutcome, RawEnumerationPageIndexError>
+    where
+        I: IntoIterator<Item = String>,
+    {
+        self.ingest_owner_entries_inner(entries, max_new_entries, expected_generation, false)
+    }
+
+    fn ingest_owner_entries_inner<I>(
+        &mut self,
+        entries: I,
+        max_new_entries: usize,
+        expected_generation: u64,
+        source_complete: bool,
+    ) -> Result<RawEnumerationPageBuildOutcome, RawEnumerationPageIndexError>
+    where
+        I: IntoIterator<Item = String>,
+    {
         if max_new_entries == 0 {
             return Err(RawEnumerationPageIndexError::EmptyBudget);
         }
@@ -198,7 +223,7 @@ impl RawEnumerationPageIndex {
             }
             indexed_entries = indexed_entries.saturating_add(building.entries.len());
         }
-        if indexed_entries == entries.len() && inner.building.is_none() {
+        if source_complete && indexed_entries == entries.len() && inner.building.is_none() {
             inner.complete = true;
             inner.generation = inner.generation.saturating_add(1);
             return Ok(RawEnumerationPageBuildOutcome {
@@ -224,7 +249,7 @@ impl RawEnumerationPageIndex {
                     .min(remaining_page_slots)
                     .min(entries.len().saturating_sub(indexed_entries));
                 if append_count == 0 {
-                    if !building.terminal {
+                    if source_complete && !building.terminal {
                         building.terminal = true;
                         inner.generation = inner.generation.saturating_add(1);
                     }
@@ -233,7 +258,7 @@ impl RawEnumerationPageIndex {
                     building
                         .entries
                         .extend(entries.drain(indexed_entries..indexed_entries + append_count));
-                    building.terminal = indexed_entries.saturating_add(append_count) == source_entries;
+                    building.terminal = source_complete && indexed_entries.saturating_add(append_count) == source_entries;
                     inner.generation = inner.generation.saturating_add(1);
                 }
                 !building.entries.is_empty() && (building.terminal || building.entries.len() >= inner.page_entry_limit)
@@ -298,6 +323,13 @@ impl RawEnumerationPageIndex {
             RawEnumerationPageIndexState::Supported(inner) => inner.validated_committed_entries(),
         }
     }
+
+    pub fn indexed_entries(&self) -> Result<Vec<String>, RawEnumerationPageIndexError> {
+        match &self.state {
+            RawEnumerationPageIndexState::Unsupported => Ok(Vec::new()),
+            RawEnumerationPageIndexState::Supported(inner) => inner.validated_indexed_entries(),
+        }
+    }
 }
 
 impl RawEnumerationPageIndexInner {
@@ -337,6 +369,19 @@ impl RawEnumerationPageIndexInner {
         }
         if self.complete && self.pages.last().is_some_and(|page| !page.terminal) {
             return Err(RawEnumerationPageIndexError::CorruptIndex);
+        }
+        Ok(entries)
+    }
+
+    fn validated_indexed_entries(&self) -> Result<Vec<String>, RawEnumerationPageIndexError> {
+        let mut entries = self.validated_committed_entries()?;
+        if let Some(building) = &self.building {
+            building.validate(
+                u64::try_from(self.pages.len()).unwrap_or(u64::MAX),
+                u64::try_from(entries.len()).unwrap_or(u64::MAX),
+                self.page_entry_limit,
+            )?;
+            entries.extend(building.entries.iter().cloned());
         }
         Ok(entries)
     }
@@ -666,6 +711,44 @@ mod tests {
                 .entries(),
             entries(&["entry-a", "entry-b"])
         );
+    }
+
+    #[test]
+    fn partial_owner_source_does_not_mark_terminal_before_completion() {
+        let mut owner = RawEnumerationPageIndex::new("bucket", 2).expect("page owner should initialize");
+        let generation = owner.generation().expect("supported owner should expose generation");
+        let outcome = owner
+            .ingest_partial_owner_entries(entries(&["entry-a"]), 1, generation)
+            .expect("partial source should stage one entry");
+        assert_eq!(
+            outcome.status,
+            RawEnumerationPageOwnerStatus::Building {
+                generation: 1,
+                parent: "bucket".to_string(),
+                page_index: 0,
+                indexed_entries: 1,
+                buffered_entries: 1,
+            }
+        );
+        assert!(!outcome.ready_to_commit);
+        assert_eq!(
+            owner.indexed_entries().expect("building page entries should validate"),
+            entries(&["entry-a"])
+        );
+
+        let encoded = rmp_serde::to_vec(&owner).expect("partial owner should encode");
+        let mut restarted: RawEnumerationPageIndex = rmp_serde::from_slice(&encoded).expect("partial owner should decode");
+        let generation = restarted.generation().expect("restarted owner should expose generation");
+        let outcome = restarted
+            .ingest_owner_entries(entries(&["entry-a", "entry-b"]), 1, generation)
+            .expect("complete source should finish resumed building page");
+        assert!(outcome.ready_to_commit);
+        let generation = restarted.generation().expect("finished owner should expose generation");
+        let page = restarted
+            .commit_building_page(generation)
+            .expect("terminal resumed page should commit");
+        assert!(page.terminal());
+        assert_eq!(page.entries(), entries(&["entry-a", "entry-b"]));
     }
 
     #[test]

--- a/crates/scanner/src/scanner_folder.rs
+++ b/crates/scanner/src/scanner_folder.rs
@@ -25,6 +25,7 @@ use crate::data_usage_define::{
     PendingScannerHealKind, ScannerSizeSummaryExt, SizeReconciliationEntry, SizeSummary, hash_path,
 };
 use crate::error::ScannerError;
+use crate::raw_page_index::{RawEnumerationPageIndex, RawEnumerationPageIndexError};
 use crate::runtime_config::{
     scanner_alert_excess_folders, scanner_alert_excess_version_size, scanner_alert_excess_versions, scanner_yield_every_n_objects,
 };
@@ -90,6 +91,8 @@ const DATA_SCANNER_FORCE_COMPACT_AT_FOLDERS: usize = 250_000;
 const SCANNER_LIST_PATH_RAW_STALL_TIMEOUT: Duration = Duration::from_secs(60);
 const SCANNER_ENTRY_PROGRESS_BATCH: u64 = 32;
 const SCANNER_ENTRY_PROGRESS_INTERVAL: Duration = Duration::from_secs(30);
+const SCANNER_RAW_ENUMERATION_PAGE_ENTRY_LIMIT: usize = 128;
+const SCANNER_RAW_ENUMERATION_PAGE_BUILD_BUDGET: usize = 1;
 // Erasure data directories contain direct part.N files; keep namespace probes bounded.
 const ERASURE_DATA_DIR_PROBE_ENTRY_LIMIT: usize = 64;
 const DEFAULT_HEAL_OBJECT_SELECT_PROB: u32 = 1024;
@@ -751,17 +754,31 @@ struct RawEnumerationProgress {
     last_entry: Option<String>,
     entries_seen: u64,
     digest: Sha256,
+    observed_entries: Vec<String>,
+    page_index: Option<RawEnumerationPageIndex>,
 }
 
 impl RawEnumerationProgress {
-    fn new(parent: &str) -> Self {
+    fn new(parent: &str, page_index: Option<RawEnumerationPageIndex>) -> Self {
         let mut digest = Sha256::new();
         update_raw_enumeration_digest(&mut digest, b"parent", parent.as_bytes());
+        let (observed_entries, page_index) = match page_index {
+            Some(index) => match index.indexed_entries() {
+                Ok(entries) => (entries, Some(index)),
+                Err(_) => (Vec::new(), None),
+            },
+            None => (
+                Vec::new(),
+                RawEnumerationPageIndex::new(parent, SCANNER_RAW_ENUMERATION_PAGE_ENTRY_LIMIT).ok(),
+            ),
+        };
         Self {
             parent: parent.to_string(),
             last_entry: None,
             entries_seen: 0,
             digest,
+            observed_entries,
+            page_index,
         }
     }
 
@@ -769,18 +786,51 @@ impl RawEnumerationProgress {
         update_raw_enumeration_digest(&mut self.digest, b"entry", entry.as_bytes());
         self.last_entry = Some(entry.to_string());
         self.entries_seen = self.entries_seen.saturating_add(1);
+        self.observed_entries.push(entry.to_string());
+        if let Some(index) = &mut self.page_index {
+            let result = index
+                .generation()
+                .ok_or(RawEnumerationPageIndexError::Unsupported)
+                .and_then(|generation| {
+                    index.ingest_partial_owner_entries(
+                        self.observed_entries.clone(),
+                        SCANNER_RAW_ENUMERATION_PAGE_BUILD_BUDGET,
+                        generation,
+                    )
+                });
+            match result {
+                Ok(outcome) if outcome.ready_to_commit => {
+                    if let Some(generation) = index.generation()
+                        && index.commit_building_page(generation).is_err()
+                    {
+                        self.page_index = None;
+                    }
+                }
+                Ok(_) => {}
+                Err(_) => {
+                    self.page_index = None;
+                }
+            }
+        }
     }
 
-    fn into_cursor(self) -> Option<DataUsageRawEnumerationCursor> {
+    fn cursor(&self) -> Option<DataUsageRawEnumerationCursor> {
         if self.entries_seen == 0 {
             return None;
         }
         Some(DataUsageRawEnumerationCursor::new(
-            self.parent,
-            self.last_entry,
+            self.parent.clone(),
+            self.last_entry.clone(),
             self.entries_seen,
-            self.digest.finalize().into(),
+            self.digest.clone().finalize().into(),
         ))
+    }
+
+    fn page_index(&self) -> Option<RawEnumerationPageIndex> {
+        self.page_index.clone().and_then(|index| match index.indexed_entries() {
+            Ok(entries) if !entries.is_empty() => Some(index),
+            _ => None,
+        })
     }
 }
 
@@ -1049,6 +1099,19 @@ impl FolderScanner {
         if self.old_cache.info.scan_progress.is_none() {
             return;
         }
+        let page_index = self
+            .old_cache
+            .validated_raw_enumeration_page_index()
+            .filter(|index| match index.status() {
+                crate::raw_page_index::RawEnumerationPageOwnerStatus::Building {
+                    parent: index_parent, ..
+                }
+                | crate::raw_page_index::RawEnumerationPageOwnerStatus::Ready {
+                    parent: index_parent, ..
+                } => index_parent == parent,
+                crate::raw_page_index::RawEnumerationPageOwnerStatus::Unsupported => false,
+            })
+            .cloned();
         if let Some(position) = self
             .raw_enumeration_progress
             .iter()
@@ -1056,7 +1119,8 @@ impl FolderScanner {
         {
             self.raw_enumeration_progress.truncate(position + 1);
         } else {
-            self.raw_enumeration_progress.push(RawEnumerationProgress::new(parent));
+            self.raw_enumeration_progress
+                .push(RawEnumerationProgress::new(parent, page_index));
         }
         if let Some(progress) = self.raw_enumeration_progress.last_mut() {
             progress.record_entry(entry);
@@ -1073,11 +1137,11 @@ impl FolderScanner {
         });
     }
 
-    fn take_raw_enumeration_cursor(&mut self) -> Option<DataUsageRawEnumerationCursor> {
-        self.raw_enumeration_progress
-            .drain(..)
-            .next()
-            .and_then(RawEnumerationProgress::into_cursor)
+    fn take_raw_enumeration_resume_state(&mut self) -> (Option<DataUsageRawEnumerationCursor>, Option<RawEnumerationPageIndex>) {
+        match self.raw_enumeration_progress.drain(..).next() {
+            Some(progress) => (progress.cursor(), progress.page_index()),
+            None => (None, None),
+        }
     }
 
     fn carry_forward_old_children(&mut self, parent_hash: &DataUsageHash, entry: &mut DataUsageEntry) {
@@ -2686,6 +2750,7 @@ pub(crate) async fn scan_data_folder_scoped(
             new_cache.info.scan_resume_after = None;
             new_cache.info.scan_checkpoint = None;
             new_cache.info.scan_raw_enumeration_cursor = None;
+            new_cache.info.scan_raw_enumeration_page_index = None;
             new_cache.info.scan_coverage_receipt = None;
             if had_scan_checkpoint {
                 global_metrics().record_scanner_checkpoint_cleared();
@@ -2703,9 +2768,10 @@ pub(crate) async fn scan_data_folder_scoped(
                 let root_hash = hash_path(&cache.info.name);
                 let root_has_progress = data_usage_root_has_progress(&root);
                 let pending_heals_changed = scanner.pending_heals_changed;
-                let raw_enumeration_cursor = scanner.take_raw_enumeration_cursor();
-                let carry_forward_cache =
-                    (raw_enumeration_cursor.is_some() && !root_has_progress).then(|| scanner.old_cache.cache.clone());
+                let (raw_enumeration_cursor, raw_enumeration_page_index) = scanner.take_raw_enumeration_resume_state();
+                let carry_forward_cache = ((raw_enumeration_cursor.is_some() || raw_enumeration_page_index.is_some())
+                    && !root_has_progress)
+                    .then(|| scanner.old_cache.cache.clone());
                 if root_has_progress {
                     scanner.carry_forward_old_children(&root_hash, &mut root);
                 }
@@ -2722,8 +2788,15 @@ pub(crate) async fn scan_data_folder_scoped(
                     new_cache.info.scan_resume_after = None;
                     new_cache.info.scan_coverage_receipt = None;
                 }
+                if raw_enumeration_page_index.is_some() {
+                    new_cache.info.scan_raw_enumeration_page_index = raw_enumeration_page_index;
+                    new_cache.info.scan_checkpoint = None;
+                    new_cache.info.scan_resume_after = None;
+                    new_cache.info.scan_coverage_receipt = None;
+                }
                 if partial_cache_is_useful(&root, pending_heals_changed)
                     || new_cache.info.scan_raw_enumeration_cursor.is_some()
+                    || new_cache.info.scan_raw_enumeration_page_index.is_some()
                     || !new_cache.info.size_reconciliation.is_empty()
                 {
                     if new_cache.root().is_some() {

--- a/crates/scanner/src/scanner_folder/tests.rs
+++ b/crates/scanner/src/scanner_folder/tests.rs
@@ -2722,6 +2722,20 @@ async fn test_scan_data_folder_returns_raw_cursor_on_enumeration_cancel_without_
     assert!(raw_cursor.last_entry.is_some());
     assert_ne!(raw_cursor.page_digest, [0; 32]);
     assert_eq!(partial_cache.validated_raw_enumeration_cursor(), Some(raw_cursor));
+    let page_index = partial_cache
+        .validated_raw_enumeration_page_index()
+        .expect("raw enumeration cancellation should persist a validated page index");
+    assert_eq!(
+        page_index
+            .indexed_entries()
+            .expect("persisted raw page index entries should validate")
+            .len(),
+        1
+    );
+    assert_eq!(
+        page_index.committed_entries().expect("uncommitted raw page should validate"),
+        Vec::<String>::new()
+    );
     assert_eq!(budget.reason(), Some(crate::scanner_budget::ScannerCycleBudgetReason::Runtime));
 }
 


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#2273.
Refs rustfs/backlog#2240.
Depends on rustfs/rustfs#7375.

## Summary

- Add a persisted `scan_raw_enumeration_page_index` field to scanner cache metadata with validation during bucket checkpoint preparation.
- Extend the raw page owner index with partial-source ingestion so an interrupted raw directory read does not mark a page terminal before the source is complete.
- Wire the production scanner partial-cache writer to persist validated raw page owner state alongside the existing raw enumeration cursor.

## Verification

- PASS: `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-scanner --lib raw_page_index -j4`
- PASS: `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-scanner --lib raw_page -j4`
- PASS: `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-scanner --lib test_scan_data_folder_returns_raw_cursor_on_enumeration_cancel_without_root_progress -j4`
- PASS: `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-scanner --lib test_new_data_usage_cache_msgpack_round_trips_and_supports_old_reader -j4`
- PASS: `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-scanner --lib prepare_bucket_checkpoint_preserves_only_valid_raw_enumeration_cursor -j4`
- PASS: `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-scanner --lib prepare_bucket_checkpoint_preserves_only_valid_raw_page_index -j4`
- PASS: `cargo +nightly-aarch64-apple-darwin check --locked -q -p rustfs-scanner --lib -j4`
- PASS: `cargo +nightly-aarch64-apple-darwin fmt --package rustfs-scanner --check`
- PASS: `git diff --check HEAD~1..HEAD`

## Impact

- Stacked follow-up on #7375; this PR contains only the production persistence/resume-state wiring for the raw page owner index.
- The scanner still does not use persisted page entries to skip object processing; that is intentionally left for the next consumer PR to avoid unsafe progress claims from unstable `read_dir` ordering.
- Invalid, out-of-bucket, corrupt, or source-drifted page index state is discarded fail-closed during bucket checkpoint preparation.

## Additional Notes

W05 remains open after this PR. Remaining gates include page-index consumption in the raw-list processing path, fixed-budget real process restart convergence, large/small bucket coverage, distributed and mixed-version validation, crash/compaction cases, performance comparison, and full CI.
