### PR TITLE
fix(scanner): reject stale raw page source seeds

### DIFF
--- a/crates/scanner/src/scanner_folder.rs
+++ b/crates/scanner/src/scanner_folder.rs
@@ -762,22 +762,17 @@ impl RawEnumerationProgress {
     fn new(parent: &str, page_index: Option<RawEnumerationPageIndex>) -> Self {
         let mut digest = Sha256::new();
         update_raw_enumeration_digest(&mut digest, b"parent", parent.as_bytes());
-        let (observed_entries, page_index) = match page_index {
-            Some(index) => match index.indexed_entries() {
-                Ok(entries) => (entries, Some(index)),
-                Err(_) => (Vec::new(), None),
-            },
-            None => (
-                Vec::new(),
-                RawEnumerationPageIndex::new(parent, SCANNER_RAW_ENUMERATION_PAGE_ENTRY_LIMIT).ok(),
-            ),
+        let page_index = match page_index {
+            Some(index) if index.indexed_entries().is_ok() => Some(index),
+            Some(_) => None,
+            None => RawEnumerationPageIndex::new(parent, SCANNER_RAW_ENUMERATION_PAGE_ENTRY_LIMIT).ok(),
         };
         Self {
             parent: parent.to_string(),
             last_entry: None,
             entries_seen: 0,
             digest,
-            observed_entries,
+            observed_entries: Vec::new(),
             page_index,
         }
     }


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#2273.
Refs rustfs/backlog#2240.
Depends on rustfs/rustfs#7374.

## Summary

- Tighten the raw page owner resume handoff so a new observation pass does not prefill its source entries from a previously persisted page index.
- Require the scanner to observe the same raw-entry prefix again before a resumed page index can advance.
- Discard the page index fail-closed when the new raw directory source no longer matches the persisted indexed prefix.

## Verification

- PASS: `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-scanner --lib test_scan_data_folder_returns_raw_cursor_on_enumeration_cancel_without_root_progress -j4`
- PASS: `cargo +nightly-aarch64-apple-darwin check --locked -q -p rustfs-scanner --lib -j4`
- PASS: `cargo +nightly-aarch64-apple-darwin fmt --package rustfs-scanner --check`
- PASS: `git diff --check`

## Impact

- One-file follow-up to the #7375/#7379 raw page owner stack.
- Prevents deleted or reordered raw entries from being hidden by stale persisted index entries during the next scanner pass.
- Does not enable page-index consumption or object-skipping behavior.

## Additional Notes

W05 remains open. The consumer path, fixed-budget real process restart convergence, distributed/mixed-version/crash/performance gates, and full main-base CI remain tracked in rustfs/backlog#2273.
