### PR TITLE
fix(io-metrics): simplify early eviction check

### DIFF
--- a/crates/io-metrics/src/cache_config.rs
+++ b/crates/io-metrics/src/cache_config.rs
@@ -241,10 +241,7 @@ impl AdaptiveTTL {
         // 1. Item is cold (low access count)
         // 2. Age is significant (> 50% of TTL)
         // 3. No recent accesses
-        if access_count <= self.cold_threshold && age > current_ttl / 2 {
-            return true;
-        }
-        false
+        access_count <= self.cold_threshold && age > current_ttl / 2
     }
 
     /// Calculate priority score for an item.


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#2240.

## Summary

- Simplify `AdaptiveTtlConfig::should_evict_early` to return its predicate directly.
- Clear the `clippy::needless_bool` failure currently blocking scanner-dependent clippy lanes.

## Verification

- `cargo +nightly-aarch64-apple-darwin clippy --locked -q -p rustfs-io-metrics --lib -- -D warnings` PASS.
- `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-io-metrics --lib -j4` PASS, 115/115.
- `cargo +nightly-aarch64-apple-darwin fmt --package rustfs-io-metrics --check` PASS.
- `git diff --check` PASS.

## Impact

- Runtime behavior: none; predicate is equivalent.
- Compatibility: no wire, disk, API, or Cargo dependency changes.
- Performance: no expected change.

## Additional Notes

- This is a standalone CI unblocker for current `main`; it does not close any Scanner/Heal V2 issue by itself.
