### PR TITLE
fix(scanner): defer raw page revalidation until observed

### DIFF
--- a/crates/scanner/src/scanner_folder.rs
+++ b/crates/scanner/src/scanner_folder.rs
@@ -755,6 +755,7 @@ struct RawEnumerationProgress {
     entries_seen: u64,
     digest: Sha256,
     observed_entries: Vec<String>,
+    revalidate_after_entries: usize,
     page_index: Option<RawEnumerationPageIndex>,
 }
 
@@ -762,9 +763,15 @@ impl RawEnumerationProgress {
     fn new(parent: &str, page_index: Option<RawEnumerationPageIndex>) -> Self {
         let mut digest = Sha256::new();
         update_raw_enumeration_digest(&mut digest, b"parent", parent.as_bytes());
+        let mut revalidate_after_entries = 0;
         let page_index = match page_index {
-            Some(index) if index.indexed_entries().is_ok() => Some(index),
-            Some(_) => None,
+            Some(index) => match index.indexed_entries() {
+                Ok(entries) => {
+                    revalidate_after_entries = entries.len();
+                    Some(index)
+                }
+                Err(_) => None,
+            },
             None => RawEnumerationPageIndex::new(parent, SCANNER_RAW_ENUMERATION_PAGE_ENTRY_LIMIT).ok(),
         };
         Self {
@@ -773,6 +780,7 @@ impl RawEnumerationProgress {
             entries_seen: 0,
             digest,
             observed_entries: Vec::new(),
+            revalidate_after_entries,
             page_index,
         }
     }
@@ -783,6 +791,9 @@ impl RawEnumerationProgress {
         self.entries_seen = self.entries_seen.saturating_add(1);
         self.observed_entries.push(entry.to_string());
         if let Some(index) = &mut self.page_index {
+            if self.observed_entries.len() < self.revalidate_after_entries {
+                return;
+            }
             let result = index
                 .generation()
                 .ok_or(RawEnumerationPageIndexError::Unsupported)

--- a/crates/scanner/src/scanner_folder/tests.rs
+++ b/crates/scanner/src/scanner_folder/tests.rs
@@ -3384,3 +3384,48 @@ fn test_should_log_failed_object_samples_after_initial_limit() {
     assert!(!should_log_failed_object(SCANNER_FAILED_OBJECT_LOG_EVERY + 1));
     assert!(should_log_failed_object(SCANNER_FAILED_OBJECT_LOG_EVERY * 2));
 }
+
+#[test]
+fn raw_enumeration_progress_waits_for_resume_index_floor_before_revalidation() {
+    let mut index = RawEnumerationPageIndex::new("bucket", 2).expect("raw page index should initialize");
+    let generation = index.generation().expect("raw page index should expose generation");
+    index
+        .ingest_partial_owner_entries(["entry-a".to_string(), "entry-b".to_string()], 2, generation)
+        .expect("initial entries should build a page");
+    let generation = index.generation().expect("raw page index should expose next generation");
+    index.commit_building_page(generation).expect("initial page should commit");
+
+    let mut progress = RawEnumerationProgress::new("bucket", Some(index));
+    progress.record_entry("entry-b");
+    assert!(
+        progress.page_index.is_some(),
+        "resume index must not be dropped before the current run observes the old index floor"
+    );
+
+    progress.record_entry("entry-a");
+    assert!(
+        progress.page_index.is_some(),
+        "same entry identity after the observation floor should keep the resume index"
+    );
+}
+
+#[test]
+fn raw_enumeration_progress_rejects_resume_index_after_floor_mismatch() {
+    let mut index = RawEnumerationPageIndex::new("bucket", 2).expect("raw page index should initialize");
+    let generation = index.generation().expect("raw page index should expose generation");
+    index
+        .ingest_partial_owner_entries(["entry-a".to_string(), "entry-b".to_string()], 2, generation)
+        .expect("initial entries should build a page");
+    let generation = index.generation().expect("raw page index should expose next generation");
+    index.commit_building_page(generation).expect("initial page should commit");
+
+    let mut progress = RawEnumerationProgress::new("bucket", Some(index));
+    progress.record_entry("entry-a");
+    assert!(progress.page_index.is_some());
+
+    progress.record_entry("entry-c");
+    assert!(
+        progress.page_index.is_none(),
+        "resume index must be discarded once enough current observations prove source drift"
+    );
+}


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#2273.

## Summary of Changes

This is a stacked follow-up for the Scanner/Heal V2 raw page owner resume path.

PR #7382 correctly stopped pre-filling a new raw directory observation pass from the previously persisted page owner index, so stale entries cannot mask source drift. However, that implementation would run the strict owner identity check after the first newly observed entry. If the persisted index already contained multiple entries, a healthy resumed scan could discard the index before the current pass had observed enough entries to prove or disprove the old prefix.

This patch records the persisted index entry floor on `RawEnumerationProgress` initialization. A resumed pass still starts with an empty current observation buffer, but it defers strict page owner revalidation until the current pass has observed at least the old indexed entry count. Once that floor is reached, the existing `RawEnumerationPageIndex` identity checks still fail closed on drift.

## Verification

Tested commit: `e81a03286`.

- `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-scanner --lib raw_enumeration_progress_ -j4`: PASS, 2/2 tests passed. Covers both deferred revalidation for a valid multi-entry resume index and fail-closed rejection after an observed prefix mismatch.
- `cargo +nightly-aarch64-apple-darwin test --locked -q -p rustfs-scanner --lib raw_page_index -j4`: PASS, 13/13 tests passed. Confirms the underlying page owner CAS, digest, terminal, corrupt-state, and drift semantics remain intact.
- `cargo +nightly-aarch64-apple-darwin check --locked -q -p rustfs-scanner --lib -j4`: PASS.
- `cargo +nightly-aarch64-apple-darwin fmt --package rustfs-scanner --check`: PASS.
- `git diff --check origin/houseme/fix/scanner-unused-digest-import...HEAD`: PASS.

Full distributed Scanner/Heal V2 restart, mixed-version, crash/compaction, and performance matrices were not run for this narrow follow-up.

Adversarial review verdicts:

- Correctness/test-coverage: PASS after adding the observed-floor regression tests; the current pass no longer trusts old entries and no longer discards a valid multi-entry index before sufficient evidence exists.
- Durability/compatibility/performance: PASS for this scoped diff; persisted state format is unchanged, corrupt or mismatched owner state still fails closed, and the added comparison is bounded by already indexed raw entry count.

## Impact

Improves Scanner raw enumeration resume correctness in the stacked V2 implementation. No public API, configuration, dependency, or on-disk format change.

## Additional Notes

This remains part of the W05 stacked implementation. It does not by itself complete rustfs/backlog#2273; page-index consumption, fixed-budget real process restart convergence, distributed and mixed-version validation, crash/compaction coverage, performance evidence, and full CI gates remain open.
