### PR TITLE
test(ecstore): align heal capacity admission regression

### DIFF
--- a/crates/ecstore/src/store/heal.rs
+++ b/crates/ecstore/src/store/heal.rs
@@ -2353,11 +2353,17 @@ mod tests {
             .await
             .expect("quorum boundary heal should return a mapped result");
         *store.pools[0].disk_set[0].disks.write().await = original_quorum_disks;
+        let quorum_err_text = quorum_err.as_ref().map(ToString::to_string);
         assert!(
-            quorum_err.as_ref().is_some_and(|err| err
-                .to_string()
-                .contains("pool metadata writes remain blocked after a recovery-required replica state")),
+            quorum_err_text.as_deref().is_some_and(|err| {
+                err.contains("target capacity admission failed")
+                    && err.contains("pool metadata update cannot overwrite an unreadable replica")
+            }),
             "heal must fail closed when capacity admission cannot verify pool metadata, got {quorum_err:?}"
+        );
+        assert!(
+            store.pool_meta_writes_ready().await,
+            "read-only capacity admission failure must not latch the pool metadata writer"
         );
         shutdown.cancel();
     }


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Align the `unscoped_heal_object_suspended_owner_semantics` regression with the read-only pool metadata admission contract introduced by the latest mainline pool metadata probe behavior.

The quorum-boundary case still verifies that object heal fails closed when capacity admission cannot verify pool metadata. It now expects the current admission probe error and also asserts that the read-only probe does not latch the global pool metadata writer.

## Verification
- Failed before the change: `cargo test -p rustfs-ecstore --lib unscoped_heal_object_suspended_owner_semantics -- --nocapture` at `5211b5627726effe99074573593f74406ead7519`, because the test expected the old sticky writer-gate error.
- Passed after the change at `b29440a6a86af8e8fb50561d766c6bc6f8a2e568`: `cargo test -p rustfs-ecstore --lib unscoped_heal_object_suspended_owner_semantics -- --nocapture` with 1 passed, 0 failed.
- Passed after the change at `b29440a6a86af8e8fb50561d766c6bc6f8a2e568`: `cargo fmt --all --check`.
- Passed after the change at `b29440a6a86af8e8fb50561d766c6bc6f8a2e568`: `git diff --check`.

Not run: full `cargo test -p rustfs-ecstore`; this is a test-only expectation fix scoped to one existing regression.

## Impact
No runtime, API, compatibility, deployment, or configuration impact. This is test-only.

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
