### PR TITLE
test(scanner): cover scoped ack loss confirmation

### DIFF
--- a/crates/scanner/src/scanner/tests.rs
+++ b/crates/scanner/src/scanner/tests.rs
@@ -7609,6 +7609,81 @@ async fn scanner_cycle_confirms_lost_remote_ack_from_activity_snapshot() {
     );
 }
 
+#[tokio::test]
+async fn scanner_cycle_confirms_lost_scoped_ack_only_after_same_instance_clean_activity() {
+    let acknowledgement = ScannerDirtyUsageAcknowledgement {
+        host: "node-2".to_string(),
+        instance_id: "epoch-a".to_string(),
+        kind: ScannerDirtyUsageAcknowledgementKind::Scoped {
+            owner_id: Uuid::from_u128(0x11111111111111111111111111111111).to_string(),
+            entries: vec![crate::storage_api::EcstoreScannerScopedDirtyUsageAckEntry {
+                bucket: "photos".to_string(),
+                bucket_incarnation: Uuid::from_u128(0x22222222222222222222222222222222),
+                generation: 5,
+            }],
+        },
+    };
+    let attempted_send = Arc::new(AtomicBool::new(false));
+    let attempted_send_for_ack = Arc::clone(&attempted_send);
+    let cleared_activity = BTreeMap::from([("node-2".to_string(), scanner_node_activity("epoch-a", 7, 3))]);
+    let response_lost = remote_dirty_usage_acknowledgement_pending(
+        8,
+        1,
+        std::slice::from_ref(&acknowledgement),
+        async move {
+            attempted_send_for_ack.store(true, Ordering::SeqCst);
+            Err::<bool, _>(std::io::Error::other("scoped ACK transport failed after peer send"))
+        },
+        || async { Ok(cleared_activity) },
+    )
+    .await;
+    assert!(
+        attempted_send.load(Ordering::SeqCst),
+        "the confirmation oracle must run only after the scoped ACK send was attempted"
+    );
+    assert_eq!(
+        scanner_cycle_outcome_with_pending_maintenance(ScannerCycleOutcome::Completed, response_lost),
+        ScannerCycleOutcome::Completed,
+        "a same-instance clean activity snapshot confirms a lost scoped ACK response"
+    );
+
+    let restarted_activity = BTreeMap::from([("node-2".to_string(), scanner_node_activity("epoch-b", 7, 3))]);
+    let peer_restarted = remote_dirty_usage_acknowledgement_pending(
+        8,
+        1,
+        std::slice::from_ref(&acknowledgement),
+        std::future::ready(Err::<bool, _>(std::io::Error::other(
+            "scoped ACK transport failed before peer restart was observed",
+        ))),
+        || async { Ok(restarted_activity) },
+    )
+    .await;
+    assert_eq!(
+        scanner_cycle_outcome_with_pending_maintenance(ScannerCycleOutcome::Completed, peer_restarted),
+        ScannerCycleOutcome::CompletedWithPendingMaintenance,
+        "a restarted peer cannot prove the scoped ACK reached the old scanner instance"
+    );
+
+    let mut written_activity = scanner_node_activity("epoch-a", 7, 3);
+    written_activity.dirty_usage_generation = 6;
+    written_activity.dirty_usage_pending = true;
+    let concurrent_write = remote_dirty_usage_acknowledgement_pending(
+        8,
+        1,
+        &[acknowledgement],
+        std::future::ready(Err::<bool, _>(std::io::Error::other(
+            "scoped ACK transport failed before a concurrent write was observed",
+        ))),
+        || async { Ok(BTreeMap::from([("node-2".to_string(), written_activity)])) },
+    )
+    .await;
+    assert_eq!(
+        scanner_cycle_outcome_with_pending_maintenance(ScannerCycleOutcome::Completed, concurrent_write),
+        ScannerCycleOutcome::CompletedWithPendingMaintenance,
+        "a same-instance concurrent write after scoped ACK send keeps maintenance pending"
+    );
+}
+
 #[test]
 #[serial]
 fn finalizing_an_already_durable_enum_without_proof_keeps_dirty_pending() {


### PR DESCRIPTION
## Related Issues
Refs rustfs/backlog#2281
Refs rustfs/backlog#2240

## Summary of Changes
Add a scanner scoped dirty-usage ACK regression fixture for the case where the coordinator has attempted to send the ACK but the transport response is lost.

The new test confirms the intended acknowledgement boundary:

- a same-instance clean activity snapshot can reconcile the lost response
- a peer restart with a different instance remains pending
- same-instance activity with new dirty usage remains pending

This protects the W18 distributed ACK semantics without changing runtime scanner behavior.

## Verification
- PASS `cargo test --locked -q -p rustfs-scanner --lib scanner_cycle_confirms_lost_scoped_ack_only_after_same_instance_clean_activity -j4`: 1/1.
- PASS `cargo test --locked -q -p rustfs-scanner --lib scanner_cycle_confirms_lost -j4`: 2/2.
- PASS `cargo fmt --all --check`.
- PASS `git diff --check origin/main...HEAD`.

Tested commit: fdac63efa79811535ba78bd0d163d9b864633e0c.

Remaining risk: this is a deterministic unit-level distributed acknowledgement fixture. It does not replace the pending real peer-restart E2E required before closing the related backlog issue.

## Impact
No runtime behavior change. Scanner tests now cover the lost scoped ACK confirmation boundary.

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
