### PR TITLE
test(heal): preserve MRF replay identity matrix

### DIFF
--- a/crates/heal/tests/mrf_pipeline_test.rs
+++ b/crates/heal/tests/mrf_pipeline_test.rs
@@ -359,6 +359,53 @@ async fn authoritative_journal_is_not_merged_with_legacy_mirror() {
     }));
 }
 
+/// The authoritative journal carries the full replay responsibility identity.
+/// A stale legacy mirror must not collapse same-object records that differ by
+/// kind or erasure-set scope after restart.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn authoritative_journal_replay_preserves_kind_and_scope_identity() {
+    let (disk_paths, storage) = heal_env().await;
+    register_local_disks(&disk_paths, "mrf-authoritative-identity-test").await;
+
+    let mut authoritative = scoped_journal_record(3, "identity-bucket", "same-object", None, 0, 3, 7);
+    authoritative.extend(scoped_journal_record(3, "identity-bucket", "same-object", None, 0, 3, 8));
+    authoritative.extend(journal_record(2, "identity-bucket", "same-object", None, 0));
+    authoritative.extend(journal_record(1, "identity-bucket", "same-object", Some([4u8; 16]), 0));
+    let stale_legacy = journal_record(3, "identity-bucket", "stale-legacy-object", None, 0);
+    write_journal_path_to_disks(&disk_paths, SCOPED_JOURNAL_REL, &authoritative);
+    write_journal_path_to_disks(&disk_paths, JOURNAL_REL, &stale_legacy);
+
+    let manager = make_manager(storage);
+    let replayed = mrf_queue::replay_journal_once(&manager).await;
+    assert_eq!(
+        replayed, 4,
+        "all authoritative kind/scope identities must decode before manager admission"
+    );
+
+    let snapshot = manager.operations_snapshot().await;
+    assert_eq!(
+        snapshot.queued_by_source.mrf, 4,
+        "same-object MRF replay must retain distinct kind and scope responsibilities"
+    );
+    assert_eq!(
+        snapshot.queued_by_priority.normal, 2,
+        "the two scoped partial-write records must remain independently queued"
+    );
+    assert_eq!(
+        snapshot.queued_by_priority.high, 1,
+        "metadata corruption must not merge with object repair responsibility"
+    );
+    assert_eq!(
+        snapshot.queued_by_priority.urgent, 1,
+        "decode-failure repair must not merge with object repair responsibility"
+    );
+    assert!(disk_paths.iter().all(|path| {
+        !Path::new(path).join(META_BUCKET).join(JOURNAL_REL).exists()
+            && !Path::new(path).join(META_BUCKET).join(SCOPED_JOURNAL_REL).exists()
+    }));
+}
+
 /// If replay reaches a full heal-manager queue, the old journal remains the
 /// durable restart anchor until a later consumer flush publishes the pending
 /// successor snapshot.


### PR DESCRIPTION
## Related Issues
Refs rustfs/backlog#2263
Refs rustfs/backlog#2268
Refs rustfs/backlog#2278
Refs rustfs/backlog#2240

## Summary of Changes
Add an MRF restart replay regression that proves the authoritative journal preserves kind and erasure-set scope identity through manager admission.

The new test writes one authoritative scoped journal containing same-bucket and same-object responsibilities that differ by scope and repair kind while also leaving a stale legacy mirror. Replay must choose the authoritative epoch, admit four independent MRF responsibilities, and remove both journal anchors only after successful admission.

## Verification
- PASS `cargo test --locked -q -p rustfs-heal --test mrf_pipeline_test authoritative_journal_replay_preserves_kind_and_scope_identity -j4`: 1/1.
- PASS `cargo test --locked -q -p rustfs-heal --test mrf_pipeline_test -j4`: 13/13.
- PASS `cargo fmt --all --check`.
- PASS `git diff --check origin/main...HEAD`.

Tested commit: 78dea8ae626151d6600fb484e3f5221f6bff874c.

Remaining risk: this is a test-only replay/admission identity oracle. It does not add mixed-version binary replay, durable positive receipt persistence, successor GC/tombstone behavior, disk-full handling, or long-running resource and write-amplification measurements.

## Impact
No runtime behavior change. MRF replay tests now guard against collapsing same-object responsibilities that differ by repair kind or erasure-set scope.

## Additional Notes
Adversarial review of this focused diff found no blocking correctness, durability, compatibility, performance, or test coverage issue.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
