### PR TITLE
ci(star-history): bump repo-visuals-action to v1.4.0

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: overtrue/repo-visuals-action@fd79cba437ecfac933d00a69add17eb95d3939c3 # v1.3.1
+      - uses: overtrue/repo-visuals-action@ee2c632f6ce617e851fb46ea935ee8af762ebb93 # v1.4.0
         with:
           github-token: ${{ github.token }}
           output-branch: star-history


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Bump the pinned commit of `overtrue/repo-visuals-action` in `.github/workflows/star-history.yml` from `fd79cba` (v1.3.1) to `ee2c632f` (v1.4.0). v1.4.0 was released from the action repository's `main` and bundles two changes: a refreshed editorial style for the star chart and contributor wall, and a new optional `chart-layout` input (`editorial` / `glance` / `compact`).

The workflow's own inputs are unchanged. `chart-layout` is not set, so it takes its `editorial` default, which is the layout the refreshed renderer produces anyway.

## Verification

- `actionlint` run from the repo root on the working tree at `d44e86b17`: zero findings. This is the required gate for `.github/workflows/` changes per `.github/AGENTS.md`, since `make pre-pr` does not cover workflow files.
- Verified the new pin resolves to a real published release before pinning: `v1.4.0` and the floating `v1` tag in `overtrue/repo-visuals-action` both point at `ee2c632f6ce617e851fb46ea935ee8af762ebb93`, and that commit is `main` with green CI (`CI | push | success | ee2c632f`).
- Verified the action's committed bundle matches the new source: `dist/index.cjs` at `ee2c632f` contains the `chart-layout` / `glance` code paths, so the pinned artifact actually carries the release's behavior.
- Not run: the `Star History` workflow itself against this branch. It is a `schedule` / `workflow_dispatch` job that pushes to the `star-history` branch, so it does not run on pull requests; the first real exercise of the new pin is the next scheduled run or a manual dispatch after merge. Remaining risk is limited to the generated SVGs' appearance.

## Impact

No user-facing, API, or deployment impact. The only visible effect is on the generated assets on the `star-history` branch: the next run regenerates the chart and contributor wall in the refreshed v1.4.0 style, so those SVGs will look different from the current ones. No workflow inputs were added or removed, and reverting is a one-line pin change back to `fd79cba`.

## Additional Notes

The v1.4.0 release was cut as part of this update, because the action's `main` had two merged but unreleased pull requests and repository policy is to pin third-party actions to a released tag's commit rather than an arbitrary branch head.
