### PR TITLE
fix(ci): use test-domain facade in delete-marker regression

### DIFF
--- a/rustfs/src/app/object/delete.rs
+++ b/rustfs/src/app/object/delete.rs
@@ -1237,7 +1237,7 @@ mod tests {
                         store
                             .update_bucket_metadata_config(
                                 &bucket,
-                                crate::app::storage_api::bucket::metadata::BUCKET_VERSIONING_CONFIG,
+                                crate::app::storage_api::test::bucket::metadata::BUCKET_VERSIONING_CONFIG,
                                 b"<VersioningConfiguration><Status>Suspended</Status></VersioningConfiguration>".to_vec(),
                             )
                             .await


### PR DESCRIPTION
## Related Issues

Follow-up to #7411, which was merged with a failing architecture-boundary check.

## Summary of Changes

Use `crate::app::storage_api::test::bucket::metadata::BUCKET_VERSIONING_CONFIG` in the delete-marker regression test instead of accessing the root storage facade directly. The existing test-domain facade re-exports the same bucket module and constant. This is a one-line test-only correction; no CI guard, baseline, assertion, or production behavior is changed.

## Verification

- Before: [main CI run 34133446530](https://github.com/rustfs/rustfs/actions/runs/34133446530) failed the architecture migration rule at `rustfs/src/app/object/delete.rs:1240`. After this change: `./scripts/check_architecture_migration_rules.sh` passed.
- `cargo fmt --all --check` and `git diff --check` passed. Correctness and simplicity review confirmed the existing test-only re-export preserves the exact constant and requires no new abstraction.
- `cargo test --locked -p rustfs --lib app::object::delete::tests -- --quiet --test-threads=1` was started with a 32 MiB test stack and six build jobs, but remained in compilation at PR creation. No passing test result is claimed for this revision. The requester asked to publish this minimal CI fix immediately rather than wait for the full local rebuild; remaining test execution is pending.

Validation above covers the single-line diff on main `e95a0ed6d950df7e1a695a7030fa669bc1d697c0`. No true-machine validation was performed for this test-only correction.

## Impact

Restores the architecture boundary required by Quick Checks so later CI stages can run. No runtime, wire-format, data-migration, or deployment changes. The separate HTTP 504 failure while downloading console build assets is outside this PR and is not fixed by this change.

## Additional Notes

Opened promptly at the requester's direction after the failing guard passed locally. CI results are still pending; this PR must not be interpreted as proof that the full workflow or pool true-machine suite has passed.
