### PR TITLE
ci(upgrade): run rc.5 multipart layout checks

### DIFF
--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -82,6 +82,14 @@ jobs:
             cache_key: e2e-odm-config-rollback
             test: rc5_rollback_requires_restoring_odm_configuration
             artifact: odm-config-rollback
+          - name: Multipart layouts survive the rc.5 upgrade
+            cache_key: e2e-multipart-layout-upgrade
+            test: direct_upgrade_from_rc5_preserves_multipart_layouts
+            artifact: multipart-layout-upgrade
+          - name: rc.5 multipart replication baseline
+            cache_key: e2e-multipart-layout-baseline
+            test: rc5_baseline_replicates_multipart_layouts
+            artifact: multipart-layout-baseline
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:


### PR DESCRIPTION
## Related Issues

Follow-up to #7334 and rustfs/backlog#2147.

## Summary of Changes

The two rc.5 multipart layout tests are ignored by default and were missing from the upgrade workflow. Add both to its existing matrix, using the same pinned rc.5 binary and exact test selection.

## Verification

- `actionlint .github/workflows/e2e-upgrade.yml` and `git diff --check` passed on 84eb7ee8b.
- Checked all seven matrix entries for unique test, cache and artifact names; both new names resolve to existing ignored tests. Correctness and simplicity review found no issues.
- Linux upgrade tests were not run locally. This change only wires existing tests; the baseline records rc.5 behavior and does not assert replication success.

## Impact

Adds two CI jobs. No runtime, test assertion or release-binary changes.

## Additional Notes

The Upgrade Compatibility workflow is currently disabled manually in repository settings. This PR does not enable it, so merging alone will not produce new upgrade results.
