### PR TITLE
fix(ci): enable release branch checks and repair test imports

### DIFF
--- a/.github/workflows/ci-docs-only.yml
+++ b/.github/workflows/ci-docs-only.yml
@@ -22,7 +22,7 @@ name: Continuous Integration (docs only)
 on:
   pull_request:
     types: [ opened, synchronize, reopened ]
-    branches: [ main ]
+    branches: [ main, release ]
     paths:
       - "**.md"
       - "docs/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release ]
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -36,7 +36,7 @@ on:
       - "flake.lock"
   pull_request:
     types: [ opened, synchronize, reopened, closed ]
-    branches: [ main ]
+    branches: [ main, release ]
     # Keep this list in sync with the `paths` list in ci-docs-only.yml, which
     # reports the required "Test and Lint" check for PRs skipped here.
     paths-ignore:
@@ -872,13 +872,14 @@ jobs:
     # Merge gate only (backlog#1149 ci-5): the never-automated user-visible
     # suites — KMS, object_lock, multipart_auth, quota, checksum, encryption,
     # security-boundary, ... — via the e2e-full nextest profile. Too heavy for
-    # every PR, so it is gated to main pushes, the merge queue, and manual
+    # every PR, so it is gated to main/release pushes, the merge queue, and manual
     # dispatch. protocols / the 7 cluster suites / replication / #[ignore] are
     # owned by other lanes (see .config/nextest.toml profile.e2e-full).
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'merge_group' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      (github.event_name == 'push' &&
+        (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release'))
     needs: [ build-rustfs-debug-binary ]
     runs-on: sm-standard-2
     timeout-minutes: 55

--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -8220,7 +8220,7 @@ mod tests {
     }
     mod multipart_transport_tests {
         use super::super::super::replication_filemeta_boundary::ObjectPartInfo;
-        use super::super::super::replication_storage_boundary::ObjectIO as _;
+        use super::super::super::replication_storage_boundary::{ObjectIO as _, ReadPlan};
         use super::*;
         use bytes::Bytes;
         use http_body_util::{BodyExt, Full};
@@ -8264,8 +8264,7 @@ mod tests {
                     } else {
                         self.full_reads.fetch_add(1, Ordering::Relaxed);
                     }
-                    let plan =
-                        crate::object_api::ReadPlan::build_for_request(range, &self.info, opts, &HeaderMap::new(), None).await?;
+                    let plan = ReadPlan::build_for_request(range, &self.info, opts, &HeaderMap::new(), None).await?;
                     let start = plan.storage_offset();
                     let end = start + usize::try_from(plan.storage_length()).expect("nonnegative storage length");
                     return plan.into_object_reader(Box::new(std::io::Cursor::new(stored.slice(start..end))), &self.info);

--- a/crates/ecstore/src/bucket/replication/replication_storage_boundary.rs
+++ b/crates/ecstore/src/bucket/replication/replication_storage_boundary.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::object_api::{
     GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader, ReplicationStatusWritebackCondition, ReplicationStatusWritebackMode,
 };
 #[cfg(test)]
-pub(crate) use crate::object_api::{NamespaceLockFence, NamespaceLockSignalTestFence};
+pub(crate) use crate::object_api::{NamespaceLockFence, NamespaceLockSignalTestFence, ReadPlan};
 pub(crate) use crate::storage_api_contracts::list::{
     ListOperations, StorageListObjectVersionsInfo, StorageListObjectsV2Info, StorageObjectInfoOrErr, StorageWalkOptions,
 };


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

The release branch had no automatic CI runs, and its current commit failed Quick Checks because a multipart test imported `ReadPlan` directly from `object_api` ([failed run](https://github.com/rustfs/rustfs/actions/runs/34171497983)). Route that test import through the existing replication storage boundary.

Enable CI for release pushes and PRs, keep the docs-only companion aligned, and include release pushes in the full E2E gate.

## Verification

Validated commit `f43e7cd87`:

- `check_architecture_migration_rules.sh` reproduced the failure before the patch and passed afterward. All remaining shared Quick Checks guards passed.
- `cargo test -p rustfs-ecstore --lib multipart_transport_tests`: 8 passed, with localhost proxies bypassed and debug info disabled.
- `actionlint`, `cargo fmt --all --check`, `git diff --check`, `make script-tests`, test-wiring checks and their self-tests passed.

Full Linux CI will run on this PR.

## Impact

Release changes receive the same CI coverage as main. The Rust change only adjusts a test import; replication behavior is unchanged. Correctness and simplicity review found no issues.

## Additional Notes

Revert this commit to roll back.
