### PR TITLE
fix(scanner): require segment producer identities

### DIFF
--- a/crates/scanner/src/scanner_folder/tests/checkpoint_fixture/segment_observation.rs
+++ b/crates/scanner/src/scanner_folder/tests/checkpoint_fixture/segment_observation.rs
@@ -3,7 +3,8 @@
 use super::*;
 use crate::segment_invalidation::{
     MAX_SEGMENT_INVALIDATION_BYTES, MAX_SEGMENT_INVALIDATION_ENTRIES, SegmentInvalidationDomain, SegmentInvalidationEnvelope,
-    SegmentInvalidationError, SegmentInvalidationProducer, SegmentInvalidationProof, admit_segment_invalidation,
+    SegmentInvalidationError, SegmentInvalidationProducer, SegmentInvalidationProducerIdentity, SegmentInvalidationProof,
+    admit_segment_invalidation, complete_segment_invalidation_producers,
 };
 use std::collections::BTreeSet;
 
@@ -11,7 +12,8 @@ const MAX_WALK_SAMPLES: usize = 32;
 const MAX_WALK_BYTES: usize = 1024;
 
 fn segment_producers() -> BTreeSet<SegmentInvalidationProducer> {
-    SegmentInvalidationProducer::REQUIRED.into_iter().collect()
+    complete_segment_invalidation_producers(SegmentInvalidationProducerIdentity::REQUIRED_PRODUCTION)
+        .expect("fixture should enumerate the complete production producer matrix")
 }
 
 fn segment_envelope() -> SegmentInvalidationEnvelope {

--- a/crates/scanner/src/segment_invalidation.rs
+++ b/crates/scanner/src/segment_invalidation.rs
@@ -25,6 +25,7 @@ pub enum SegmentInvalidationError {
     ByteLimit,
     InvalidProof,
     InvalidKey,
+    UnknownProducer,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -48,6 +49,74 @@ impl SegmentInvalidationProducer {
         Self::Tier,
         Self::DirectoryObject,
     ];
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SegmentInvalidationProducerIdentity {
+    PutObject,
+    DeleteObject,
+    DeleteMarker,
+    CompleteMultipartUpload,
+    Replication,
+    TierTransition,
+    TierExpiration,
+    DirectoryObject,
+    Unknown,
+    TestFixture,
+}
+
+impl SegmentInvalidationProducerIdentity {
+    pub const REQUIRED_PRODUCTION: [Self; 8] = [
+        Self::PutObject,
+        Self::DeleteObject,
+        Self::DeleteMarker,
+        Self::CompleteMultipartUpload,
+        Self::Replication,
+        Self::TierTransition,
+        Self::TierExpiration,
+        Self::DirectoryObject,
+    ];
+
+    pub fn producer(self) -> Option<SegmentInvalidationProducer> {
+        match self {
+            Self::PutObject => Some(SegmentInvalidationProducer::Put),
+            Self::DeleteObject => Some(SegmentInvalidationProducer::Delete),
+            Self::DeleteMarker => Some(SegmentInvalidationProducer::DeleteMarker),
+            Self::CompleteMultipartUpload => Some(SegmentInvalidationProducer::Multipart),
+            Self::Replication => Some(SegmentInvalidationProducer::Replication),
+            Self::TierTransition | Self::TierExpiration => Some(SegmentInvalidationProducer::Tier),
+            Self::DirectoryObject => Some(SegmentInvalidationProducer::DirectoryObject),
+            Self::Unknown | Self::TestFixture => None,
+        }
+    }
+}
+
+pub fn complete_segment_invalidation_producers<I>(
+    identities: I,
+) -> Result<BTreeSet<SegmentInvalidationProducer>, SegmentInvalidationError>
+where
+    I: IntoIterator<Item = SegmentInvalidationProducerIdentity>,
+{
+    let mut covered_identities = BTreeSet::new();
+    let mut producers = BTreeSet::new();
+    for identity in identities {
+        let Some(producer) = identity.producer() else {
+            return Err(SegmentInvalidationError::UnknownProducer);
+        };
+        covered_identities.insert(identity);
+        producers.insert(producer);
+    }
+    if SegmentInvalidationProducerIdentity::REQUIRED_PRODUCTION
+        .iter()
+        .all(|identity| covered_identities.contains(identity))
+        && SegmentInvalidationProducer::REQUIRED
+            .iter()
+            .all(|producer| producers.contains(producer))
+    {
+        Ok(producers)
+    } else {
+        Err(SegmentInvalidationError::InvalidProof)
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -170,7 +239,8 @@ mod tests {
     use super::*;
 
     fn producers() -> BTreeSet<SegmentInvalidationProducer> {
-        SegmentInvalidationProducer::REQUIRED.into_iter().collect()
+        complete_segment_invalidation_producers(SegmentInvalidationProducerIdentity::REQUIRED_PRODUCTION)
+            .expect("production producer matrix should be complete")
     }
 
     fn envelope() -> SegmentInvalidationEnvelope {
@@ -317,6 +387,63 @@ mod tests {
         assert_eq!(
             admit_segment_invalidation(&envelope, &distributed_with_invalidation, ["hot/one"]),
             Ok(BTreeSet::from(["hot".to_string()]))
+        );
+    }
+
+    #[test]
+    fn segment_invalidation_producer_identities_must_be_known_and_complete() {
+        assert_eq!(
+            complete_segment_invalidation_producers(SegmentInvalidationProducerIdentity::REQUIRED_PRODUCTION),
+            Ok(SegmentInvalidationProducer::REQUIRED.into_iter().collect())
+        );
+        assert_eq!(
+            complete_segment_invalidation_producers([
+                SegmentInvalidationProducerIdentity::PutObject,
+                SegmentInvalidationProducerIdentity::DeleteObject,
+                SegmentInvalidationProducerIdentity::DeleteMarker,
+                SegmentInvalidationProducerIdentity::CompleteMultipartUpload,
+                SegmentInvalidationProducerIdentity::Replication,
+                SegmentInvalidationProducerIdentity::TierTransition,
+                SegmentInvalidationProducerIdentity::DirectoryObject,
+                SegmentInvalidationProducerIdentity::Unknown,
+            ]),
+            Err(SegmentInvalidationError::UnknownProducer)
+        );
+        assert_eq!(
+            complete_segment_invalidation_producers([
+                SegmentInvalidationProducerIdentity::PutObject,
+                SegmentInvalidationProducerIdentity::DeleteObject,
+                SegmentInvalidationProducerIdentity::DeleteMarker,
+                SegmentInvalidationProducerIdentity::CompleteMultipartUpload,
+                SegmentInvalidationProducerIdentity::Replication,
+                SegmentInvalidationProducerIdentity::TierTransition,
+                SegmentInvalidationProducerIdentity::DirectoryObject,
+                SegmentInvalidationProducerIdentity::TestFixture,
+            ]),
+            Err(SegmentInvalidationError::UnknownProducer)
+        );
+        assert_eq!(
+            complete_segment_invalidation_producers([
+                SegmentInvalidationProducerIdentity::PutObject,
+                SegmentInvalidationProducerIdentity::DeleteObject,
+                SegmentInvalidationProducerIdentity::DeleteMarker,
+                SegmentInvalidationProducerIdentity::Replication,
+                SegmentInvalidationProducerIdentity::TierTransition,
+                SegmentInvalidationProducerIdentity::DirectoryObject,
+            ]),
+            Err(SegmentInvalidationError::InvalidProof)
+        );
+        assert_eq!(
+            complete_segment_invalidation_producers([
+                SegmentInvalidationProducerIdentity::PutObject,
+                SegmentInvalidationProducerIdentity::DeleteObject,
+                SegmentInvalidationProducerIdentity::DeleteMarker,
+                SegmentInvalidationProducerIdentity::CompleteMultipartUpload,
+                SegmentInvalidationProducerIdentity::Replication,
+                SegmentInvalidationProducerIdentity::TierTransition,
+                SegmentInvalidationProducerIdentity::DirectoryObject,
+            ]),
+            Err(SegmentInvalidationError::InvalidProof)
         );
     }
 


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#2272, rustfs/backlog#2280, and rustfs/backlog#2240.

## Summary of Changes

Adds a production-facing identity contract for scanner segment invalidation producers.

- Introduce `SegmentInvalidationProducerIdentity` for the mutation producer matrix.
- Require trusted coverage to include known identities for PUT, DELETE, delete marker, multipart, replication, tier transition, tier expiration, and directory-object mutation sources.
- Reject unknown or test-fixture producers before a trusted producer set can be constructed.
- Reuse the production identity constructor from the segment observation fixture so tests no longer maintain a separate required-producer list.

This keeps production segment reuse disabled. It does not enable cold segment skipping or production segment selector reuse.

## Verification

Tested commit: `ffe8e37b6`.

- `cargo test -p rustfs-scanner --lib segment`: PASS, 8 tests.
- `cargo fmt --all --check`: PASS.
- `git diff --check HEAD~1..HEAD`: PASS.
- `cargo clippy -p rustfs-scanner --lib --tests -- -D warnings`: PASS.

Not run: distributed EC invalidation E2E, restart-gap/overflow durable tests, ABBA/profile/performance lanes, or full release gate. This PR only tightens the producer identity contract and keeps fail-closed fallback.

## Impact

No production segment reuse activation. Future segment reuse wiring must provide the complete known producer identity matrix before it can build trusted invalidation coverage.

## Additional Notes

The local macOS scanner test emitted the existing non-fatal `__eh_frame section too large` linker warning.
