### PR TITLE
fix(ci): route replication read plan through boundary

### DIFF
--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -8220,7 +8220,7 @@ mod tests {
     }
     mod multipart_transport_tests {
         use super::super::super::replication_filemeta_boundary::ObjectPartInfo;
-        use super::super::super::replication_storage_boundary::ObjectIO as _;
+        use super::super::super::replication_storage_boundary::{ObjectIO as _, ReadPlan};
         use super::*;
         use bytes::Bytes;
         use http_body_util::{BodyExt, Full};
@@ -8264,8 +8264,7 @@ mod tests {
                     } else {
                         self.full_reads.fetch_add(1, Ordering::Relaxed);
                     }
-                    let plan =
-                        crate::object_api::ReadPlan::build_for_request(range, &self.info, opts, &HeaderMap::new(), None).await?;
+                    let plan = ReadPlan::build_for_request(range, &self.info, opts, &HeaderMap::new(), None).await?;
                     let start = plan.storage_offset();
                     let end = start + usize::try_from(plan.storage_length()).expect("nonnegative storage length");
                     return plan.into_object_reader(Box::new(std::io::Cursor::new(stored.slice(start..end))), &self.info);

--- a/crates/ecstore/src/bucket/replication/replication_storage_boundary.rs
+++ b/crates/ecstore/src/bucket/replication/replication_storage_boundary.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::object_api::{
     GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader, ReplicationStatusWritebackCondition, ReplicationStatusWritebackMode,
 };
 #[cfg(test)]
-pub(crate) use crate::object_api::{NamespaceLockFence, NamespaceLockSignalTestFence};
+pub(crate) use crate::object_api::{NamespaceLockFence, NamespaceLockSignalTestFence, ReadPlan};
 pub(crate) use crate::storage_api_contracts::list::{
     ListOperations, StorageListObjectVersionsInfo, StorageListObjectsV2Info, StorageObjectInfoOrErr, StorageWalkOptions,
 };


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Route the multipart replication test fixture's `ReadPlan` access through `replication_storage_boundary` instead of importing `crate::object_api` directly. The boundary re-export is restricted to `#[cfg(test)]`, so the production API and the multipart replication behavior added in #7440 remain unchanged while the architecture migration guard can enforce the intended module boundary.

## Verification

- `./scripts/check_architecture_migration_rules.sh` — failed on the original `main` commit at `replication_resyncer.rs:8268`, then passed with this change.
- `cargo test -p rustfs-ecstore multipart_transport_tests --lib` — passed all 8 multipart transport tests; 0 failed.
- `make pre-commit` — passed all formatting, guard, test-wiring, documentation-path, and workspace compilation checks.

Tested commit: `e241182c1`. The working tree had no additional local changes.

## Impact

No user-facing, compatibility, deployment, configuration, or production API impact is expected. The only exported symbol is crate-visible and compiled only for unit tests; the change restores the `Quick Checks` CI gate on `main`.

## Additional Notes

- Correctness review: the test fixture still invokes the same `ReadPlan` implementation and all transformed multipart byte-coverage tests pass.
- Simplicity review: a test-only boundary re-export is the smallest change that preserves the architecture rule without weakening its scanner or duplicating read-planning logic.
- Test-coverage review: the architecture guard catches a reverted direct import, while the focused multipart test group detects any semantic change in the fixture path.
- Risk is limited to unit-test name resolution. Reverting this commit would restore the original code but also reintroduce the architecture guard failure.
