### PR TITLE
fix(replication): keep multipart tests behind storage boundary

### DIFF
--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -8229,7 +8229,6 @@ mod tests {
         #[derive(Debug)]
         struct Source {
             body: Bytes,
-            stored: Option<Bytes>,
             info: ObjectInfo,
             ranges: StdMutex<Vec<(i64, i64)>>,
             full_reads: std::sync::atomic::AtomicUsize,
@@ -8258,18 +8257,6 @@ mod tests {
                     self.info.version_id.map(|id| id.to_string()),
                     "every read retains the selected source version"
                 );
-                if let Some(stored) = &self.stored {
-                    if let Some(range) = &range {
-                        self.ranges.lock().expect("range journal lock").push((range.start, range.end));
-                    } else {
-                        self.full_reads.fetch_add(1, Ordering::Relaxed);
-                    }
-                    let plan =
-                        crate::object_api::ReadPlan::build_for_request(range, &self.info, opts, &HeaderMap::new(), None).await?;
-                    let start = plan.storage_offset();
-                    let end = start + usize::try_from(plan.storage_length()).expect("nonnegative storage length");
-                    return plan.into_object_reader(Box::new(std::io::Cursor::new(stored.slice(start..end))), &self.info);
-                }
                 if range.is_none() {
                     self.full_reads.fetch_add(1, Ordering::Relaxed);
                     return Ok(GetObjectReader {
@@ -8428,7 +8415,6 @@ mod tests {
                     ..Default::default()
                 },
                 body: body.clone(),
-                stored: Some(Bytes::from(stored)),
                 ranges: StdMutex::new(Vec::new()),
                 full_reads: std::sync::atomic::AtomicUsize::new(0),
             });
@@ -8670,7 +8656,6 @@ mod tests {
                     ..Default::default()
                 },
                 body: body.clone(),
-                stored: None,
                 ranges: StdMutex::new(Vec::new()),
                 full_reads: std::sync::atomic::AtomicUsize::new(0),
             });


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Remove the replication test fixture's direct dependency on `crate::object_api::ReadPlan`. The fixture now supplies the already-decoded body through the `ReplicationObjectIO` boundary, matching the production contract and restoring the replication storage architecture guard after #7440.

## Verification

- `./scripts/check_architecture_migration_rules.sh` — passed; the new replication-to-object-api boundary violation is removed.
- `cargo fmt --all --check` and `git diff --check` — passed for commit `7490b7306`.
- `cargo test -p rustfs-ecstore multipart_transport_` — 8 passed, including compressed multipart totals, boundaries, and complete-stream checks.

## Impact

Test-only change. No runtime, API, configuration, or compatibility impact.

## Additional Notes

The focused test emitted only the existing macOS linker compact-unwind size warning.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
