### PR TITLE
test(scanner): echo measured release evidence in ABBA fake adapter

### DIFF
--- a/scripts/test_scanner_abba.py
+++ b/scripts/test_scanner_abba.py
@@ -49,6 +49,8 @@ def fake_adapter():
         if fault == "measure-exit":
             return 42
         result = {key: request[key] for key in ("evidence", "fixed", "build", "data_dir", "background")}
+        if request["evidence"] == "measured":
+            result["release_evidence"] = copy.deepcopy(request["release_evidence"])
         result.update({"sample_count": 10, "elapsed_seconds": request["duration_seconds"],
                        "metrics": dict.fromkeys(harness.METRICS, 10)})
         baseline = request["comparison"] == "build" and request["leg"].startswith("A")


### PR DESCRIPTION
## Summary

- Keep the ABBA test fake adapter aligned with the measured release evidence contract.
- Echo `release_evidence` in measured results so result validation covers release evidence drift in the harness tests.

## Validation

- `python3 scripts/test_summarize_scanner_heal_perf.py`
- `python3 scripts/test_scanner_abba.py`
- `git diff --check`

## Hard Evidence Scope

- This PR strengthens the local measured-contract test harness only.
- It does not claim that live distributed, mixed-version, crash-restart, durable replay, EC8+4 long ABBA, or profile evidence has been produced.
