### PR TITLE
test(ilm): isolate manual transition backpressure

### DIFF
--- a/crates/e2e_test/src/inline_fast_path_cluster_test.rs
+++ b/crates/e2e_test/src/inline_fast_path_cluster_test.rs
@@ -2234,7 +2234,6 @@ async fn four_node_manual_transition_distributed_admission_conflict_reports_stat
     let bucket = format!("distributed-admission-{}", Uuid::new_v4().simple());
     let prefix = "transition/distributed-admission/";
     hot_client.create_bucket().bucket(&bucket).send().await?;
-    put_lifecycle_with_transition_retry(&hot_client, &bucket, &tier_name).await?;
     for index in 0u8..64 {
         let key = format!("{prefix}object-{index:02}.bin");
         hot_client
@@ -2245,6 +2244,7 @@ async fn four_node_manual_transition_distributed_admission_conflict_reports_stat
             .send()
             .await?;
     }
+    put_lifecycle_with_transition_retry(&hot_client, &bucket, &tier_name).await?;
 
     let (node0, node1) = tokio::join!(
         start_manual_transition_job_on_node(&hot, 0, &bucket, prefix, &tier_name, false, 64),


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Install the transition lifecycle only after the distributed-admission fixture uploads its objects. Previously, PUT-time lifecycle processing could transition most objects before the manual job started, leaving the global queue counters nonzero while that job's own backpressure report remained zero.

## Verification

- Failing-before evidence: main E2E reported 11 already-transitioned objects, one in-flight object, and zero job-local queue-full skips despite nonzero global queue-full counters.
- `NO_PROXY=127.0.0.1,localhost HTTP_PROXY= HTTPS_PROXY= cargo nextest run --profile ci -p e2e_test -E 'test(four_node_manual_transition_distributed_admission_conflict_reports_status_and_backpressure)'` — 1 passed with the original counter assertion unchanged.
- `cargo fmt --all --check` and `git diff --check` — passed for commit `4f1c6ac86`.

## Impact

Test-only change. The fixture now guarantees that backpressure is produced by the manual transition job whose report it validates. No runtime or API impact.

## Additional Notes

N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
