### PR TITLE
test(heal): cover bucket object repair receipts

### DIFF
--- a/crates/heal/src/heal/task/tests.rs
+++ b/crates/heal/src/heal/task/tests.rs
@@ -154,6 +154,126 @@ mod canonical_outcome {
         );
     }
 
+    #[tokio::test]
+    async fn bucket_heal_records_matching_positive_storage_receipts() {
+        let incarnation = Uuid::new_v4();
+        let storage = Arc::new(MockStorage {
+            heal_object_receipts: Mutex::new(HashMap::from([
+                (
+                    "object-a".to_string(),
+                    VecDeque::from([object_receipt("object-a", None, HealObjectDisposition::Repaired, incarnation)]),
+                ),
+                (
+                    "object-b".to_string(),
+                    VecDeque::from([object_receipt("object-b", None, HealObjectDisposition::Repaired, incarnation)]),
+                ),
+            ])),
+            bucket_incarnation_id: Mutex::new(Some(incarnation)),
+            ..Default::default()
+        });
+        let task = bucket_task(storage);
+
+        task.execute()
+            .await
+            .expect("bucket heal should record verified object receipts");
+
+        let outcome = task.get_outcome().await;
+        assert_eq!(outcome.execution, HealExecutionOutcome::Completed);
+        assert_eq!(outcome.counters.healed, 2);
+        assert_eq!(outcome.counters.unknown, 0);
+        assert_eq!(outcome.objects.len(), 2);
+        assert!(outcome.objects.iter().all(|item| {
+            item.identity.bucket_incarnation_id == Some(incarnation) && item.disposition == HealObjectDisposition::Repaired
+        }));
+    }
+
+    #[tokio::test]
+    async fn bucket_heal_keeps_repairing_when_bucket_incarnation_is_unavailable() {
+        let storage = Arc::new(MockStorage {
+            heal_object_receipts: Mutex::new(HashMap::from([(
+                "object-a".to_string(),
+                VecDeque::from([object_receipt(
+                    "object-a",
+                    None,
+                    HealObjectDisposition::Repaired,
+                    Uuid::new_v4(),
+                )]),
+            )])),
+            bucket_incarnation_unavailable: Mutex::new(true),
+            ..Default::default()
+        });
+        let task = bucket_task(storage.clone());
+
+        task.execute()
+            .await
+            .expect("bucket heal should continue when only proof ownership is unavailable");
+
+        let outcome = task.get_outcome().await;
+        assert_eq!(outcome.execution, HealExecutionOutcome::Completed);
+        assert_eq!(outcome.counters.healed, 0);
+        assert_eq!(outcome.counters.unknown, 2);
+        assert!(
+            outcome
+                .objects
+                .iter()
+                .all(|item| item.disposition == HealObjectDisposition::Unknown)
+        );
+        assert_eq!(storage.healed_objects.lock().expect("healed objects").len(), 2);
+    }
+
+    #[tokio::test]
+    async fn bucket_heal_rejects_stale_receipts_without_double_recording() {
+        let expected_incarnation = Uuid::new_v4();
+        let storage = Arc::new(MockStorage {
+            heal_object_receipts: Mutex::new(HashMap::from([
+                (
+                    "object-a".to_string(),
+                    VecDeque::from([object_receipt(
+                        "object-a",
+                        None,
+                        HealObjectDisposition::Repaired,
+                        Uuid::new_v4(),
+                    )]),
+                ),
+                (
+                    "object-b".to_string(),
+                    VecDeque::from([object_receipt(
+                        "object-b",
+                        None,
+                        HealObjectDisposition::Repaired,
+                        expected_incarnation,
+                    )]),
+                ),
+            ])),
+            bucket_incarnation_id: Mutex::new(Some(expected_incarnation)),
+            ..Default::default()
+        });
+        let task = bucket_task(storage);
+
+        task.execute()
+            .await
+            .expect("stale bucket receipt should not fail the legacy heal");
+
+        let outcome = task.get_outcome().await;
+        assert_eq!(outcome.execution, HealExecutionOutcome::Completed);
+        assert_eq!(outcome.counters.healed, 1);
+        assert_eq!(outcome.counters.unknown, 1);
+        assert_eq!(outcome.objects.len(), 2);
+        let object_a = outcome
+            .objects
+            .iter()
+            .find(|item| item.identity.object == "object-a")
+            .expect("stale receipt object outcome");
+        assert_eq!(object_a.disposition, HealObjectDisposition::Unknown);
+        let object_b = outcome
+            .objects
+            .iter()
+            .find(|item| item.identity.object == "object-b")
+            .expect("matching receipt object outcome");
+        assert_eq!(object_b.disposition, HealObjectDisposition::Repaired);
+        assert_eq!(object_b.identity.bucket_incarnation_id, Some(expected_incarnation));
+    }
+
     #[tokio::test(start_paused = true)]
     async fn exhausted_object_does_not_abort_other_objects_or_erase_counts() {
         let storage = Arc::new(MockStorage::default());
@@ -1172,6 +1292,7 @@ struct MockStorage {
     heal_object_receipts: Mutex<HashMap<String, VecDeque<HealObjectReceipt>>>,
     bucket_incarnation_id: Mutex<Option<Uuid>>,
     bucket_incarnation_after_object_heal: Mutex<Option<Uuid>>,
+    bucket_incarnation_unavailable: Mutex<bool>,
     format_no_heal_required: Mutex<bool>,
     format_error: Mutex<Option<Error>>,
     global_format_calls: Mutex<u32>,
@@ -1561,6 +1682,9 @@ impl HealStorageAPI for MockStorage {
     }
 
     async fn bucket_incarnation_id(&self, _bucket: &str) -> Result<Option<Uuid>> {
+        if *self.bucket_incarnation_unavailable.lock().unwrap() {
+            return Err(Error::Other("bucket incarnation unavailable".to_string()));
+        }
         Ok(*self.bucket_incarnation_id.lock().unwrap())
     }
 


### PR DESCRIPTION
## Related Issues

- Refs https://github.com/rustfs/backlog/issues/2240
- Refs https://github.com/rustfs/backlog/issues/2268
- Refs https://github.com/rustfs/backlog/issues/2269
- Refs https://github.com/rustfs/backlog/issues/2278

## Summary of Changes

- Add bucket/root heal regression coverage for authoritative object repair receipts after the committed MRF replay and object-receipt owner changes landed on `release`.
- Verify that matching storage receipts recorded during bucket sweeps become canonical repaired outcomes instead of legacy `Unknown` outcomes.
- Verify that unavailable bucket incarnation proof does not abort the bucket sweep; object repair continues and the outcome remains `Unknown`.
- Verify that stale receipts are rejected without double-recording, while matching receipts in the same sweep still record as repaired.

## Verification

Tested commit: `f57a5600b1fd04f6f377b213cf1cc79449a25978`, based on `origin/release` at `817ad0a6826f589ccaaeac8d100e3d70f61be30f`.

- `cargo fmt --all --check` passed.
- `git diff --check origin/release..HEAD` passed.
- `cargo test --locked -p rustfs-heal heal::task::tests::canonical_outcome -j 4` passed: 17/17.
- `cargo clippy --locked -p rustfs-heal --all-targets -- -D warnings` passed.

Not run: true distributed EC8+4 crash/restart, mixed-version, long-running ABBA, or profiler evidence lanes. This PR protects the canonical outcome proof path that caused the prior EC8+4 run to report unknown proofs, but the real hard gate still needs to be rerun before closing the backlog acceptance items.

## Impact

No production behavior change in this PR beyond test coverage. It locks in the release behavior where bucket/root heal sweeps can report authoritative repaired outcomes only for exact receipt matches while preserving fail-closed `Unknown` outcomes for missing or stale proof.

## Additional Notes

This follows #7465 and #817ad0a on `release`. The prior real EC8+4 crash/restart run should be repeated after this coverage lands to confirm whether the `authoritative storage proof is unavailable` failure is fully resolved in the distributed lane.
