### PR TITLE
fix(kms): distinguish key directory outages from missing keys

### DIFF
--- a/crates/e2e_test/src/kms/kms_fault_recovery_test.rs
+++ b/crates/e2e_test/src/kms/kms_fault_recovery_test.rs
@@ -59,6 +59,36 @@ async fn test_kms_key_directory_unavailable() -> Result<(), Box<dyn std::error::
 
     assert_eq!(put_response.server_side_encryption(), Some(&ServerSideEncryption::Aes256));
 
+    // A missing key in the healthy store is a client error, unlike a store outage.
+    let missing_key_object = "test-missing-kms-key";
+    let missing_key_error = s3_client
+        .put_object()
+        .bucket(TEST_BUCKET)
+        .key(missing_key_object)
+        .body(aws_sdk_s3::primitives::ByteStream::from_static(b"must not be published"))
+        .server_side_encryption(ServerSideEncryption::AwsKms)
+        .ssekms_key_id("rustfs-e2e-test-missing-key")
+        .send()
+        .await
+        .expect_err("an unknown key in a healthy Local KMS store must reject the write");
+    assert_eq!(missing_key_error.raw_response().map(|response| response.status().as_u16()), Some(400));
+    assert_eq!(
+        missing_key_error.as_service_error().and_then(ProvideErrorMetadata::code),
+        Some("KMS.NotFoundException")
+    );
+    let missing_key_absence = s3_client
+        .get_object()
+        .bucket(TEST_BUCKET)
+        .key(missing_key_object)
+        .send()
+        .await
+        .expect_err("a write rejected by a missing KMS key must not publish an object");
+    assert_eq!(missing_key_absence.raw_response().map(|response| response.status().as_u16()), Some(404));
+    assert_eq!(
+        missing_key_absence.as_service_error().and_then(ProvideErrorMetadata::code),
+        Some("NoSuchKey")
+    );
+
     // Temporarily rename the key directory to simulate unavailability
     info!("🔧 Simulating key directory unavailability");
     let backup_dir = format!("{}.backup", kms_env.kms_keys_dir);

--- a/crates/kms/src/backends/local.rs
+++ b/crates/kms/src/backends/local.rs
@@ -2387,6 +2387,76 @@ mod tests {
         (client, temp_dir)
     }
 
+    #[tokio::test]
+    async fn local_key_directory_outage_is_io_error_and_recovers_original_key() {
+        let root = TempDir::new().expect("create isolated key store");
+        let key_dir = root.path().join("keys");
+        let unavailable_dir = root.path().join("keys-unavailable");
+        let config = KmsConfig::local(key_dir.clone()).with_insecure_development_defaults();
+        let backend = LocalKmsBackend::new(config).await.expect("start Local KMS");
+        let key_id = "directory-outage-key";
+        backend
+            .create_key(CreateKeyRequest {
+                key_name: Some(key_id.to_string()),
+                ..Default::default()
+            })
+            .await
+            .expect("create the original key");
+        let request = |key_id: &str| GenerateDataKeyRequest {
+            key_id: key_id.to_string(),
+            key_spec: KeySpec::Aes256,
+            encryption_context: HashMap::new(),
+        };
+        let before = backend
+            .generate_data_key(request(key_id))
+            .await
+            .expect("generate a data key before the outage");
+        let missing_key = backend.generate_data_key(request("no-such-key")).await;
+        let key_path = key_dir.join(format!("{key_id}.key"));
+        let original_record = fs::read(&key_path).await.expect("read the original key record");
+
+        fs::rename(&key_dir, &unavailable_dir)
+            .await
+            .expect("make the key directory unavailable");
+        let unavailable = backend.generate_data_key(request(key_id)).await;
+        // Restore before checking the error so the failing regression leaves no
+        // orphaned key store; both paths also belong to the same temporary root.
+        fs::rename(&unavailable_dir, &key_dir)
+            .await
+            .expect("restore the original key directory");
+
+        let after = backend
+            .generate_data_key(request(key_id))
+            .await
+            .expect("generate a data key after directory restoration");
+        for data_key in [&before, &after] {
+            let decrypted = backend
+                .decrypt(DecryptRequest {
+                    ciphertext: data_key.ciphertext_blob.clone(),
+                    encryption_context: HashMap::new(),
+                    grant_tokens: Vec::new(),
+                })
+                .await
+                .expect("the original master key must decrypt both data keys");
+            assert!(
+                decrypted.plaintext == data_key.plaintext_key,
+                "directory restoration must preserve the original key material"
+            );
+        }
+        assert!(
+            fs::read(&key_path).await.expect("read the restored key record") == original_record,
+            "reads and recovery must not rewrite the key record"
+        );
+        assert!(
+            matches!(missing_key, Err(KmsError::KeyNotFound { key_id }) if key_id == "no-such-key"),
+            "a missing key in a readable directory must remain KeyNotFound"
+        );
+        assert!(
+            matches!(unavailable, Err(KmsError::IoError { .. })),
+            "an unavailable key directory must remain an I/O error, not KeyNotFound"
+        );
+    }
+
     /// With the AAD write switch on, the Local backend seals the stored
     /// encryption context into the wrap exactly like KV2: the bound envelope
     /// round-trips, a rewritten stored context fails authentication even with

--- a/crates/kms/src/backends/local.rs
+++ b/crates/kms/src/backends/local.rs
@@ -1233,6 +1233,9 @@ impl LocalKmsClient {
     async fn decode_stored_key(&self, key_id: &str) -> Result<(StoredMasterKey, Vec<u8>)> {
         let key_path = self.master_key_path(key_id)?;
         if !fs::try_exists(&key_path).await? {
+            // Only an accessible key store can establish that a single key is
+            // missing; a directory outage must retain its filesystem error.
+            let _ = fs::read_dir(&self.config.key_dir).await?;
             return Err(KmsError::key_not_found(key_id));
         }
 


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#2382.

## Summary of Changes

When the Local KMS key directory disappears, an existing key lookup currently returns `KeyNotFound`, which the S3 encryption path maps to HTTP 400. Check that the configured directory can be opened before classifying an absent key. Directory I/O failures then reach the existing 500/InternalError mapping; an unknown key in a readable directory keeps 400/KMS.NotFoundException.

Add a real backend outage/recovery regression in `crates/kms/src/backends/local.rs`. Extend the existing HTTP recovery test in `crates/e2e_test/src/kms/kms_fault_recovery_test.rs` with a healthy-directory missing-key request and a GET proving that its rejected PUT did not publish an object. Keep the original outage, restoration and body assertions.

## Verification

- On test-only `8fc1f0c41df4`, the backend regression failed at the intended IoError assertion after restoring the directory, decrypting both data keys, checking the original key record and passing the healthy missing-key control. The identical test passed on `c2a8e476f77e`.
- On `c2a8e476f77e`, all seven selected backend, missing-key behavior, mapper/provider and HTTP tests passed on aarch64 macOS with package defaults and zero retries. Original JUnit reports were checked against the recorded heads and test binaries. `cargo fmt --all --check` and `git diff --check` passed.
- The HTTP test passed in 10.045s using the ordinary server built from `c2a8e476f77e` (SHA256 `e630448c471e91e36ba3d94ce956d891f292dc9664be35c3be72fe704501b495`). It verified healthy missing-key 400/KMS.NotFoundException, rejected-object 404/NoSuchKey, outage 500/InternalError, and new/old encrypted bodies after restoration. JUnit `73f256c1-8074-481f-a999-29255cdac42b` and all 145 artifact hashes were independently checked. These are targeted macOS results; Linux CI remains pending. No extra local Clippy run was needed for targets already compiled by these tests and the server build.

Final head `6ec3534d202b` preserves main `72e85210f136`, including the already merged ILM fixture fix in #7463. Its complete two-file KMS patch is byte-for-byte identical to the reviewed and tested c2a patch; every other tracked entry matches main. Formatting and diff checks passed on this final head. The seven native results above remain attributed to c2a; CI will verify the final combination.

<details>
<summary>Executed native commands</summary>

The first test command ran on both the RED and GREEN heads; the remaining commands ran on GREEN. Tests used an isolated build directory, package defaults, no live Vault token and localhost proxy bypass. The HTTP run explicitly selected the private server binary built below.

```sh
cargo nextest run --locked --offline --build-jobs 2 -p rustfs-kms --lib -E 'test(=backends::local::tests::local_key_directory_outage_is_io_error_and_recovers_original_key)' --profile ci --retries 0 --test-threads 1 --no-tests fail --no-fail-fast --success-output immediate
cargo nextest run --locked --offline --build-jobs 2 -p rustfs-kms --test behavior_keys -E 'test(=describing_an_unknown_key_reports_key_not_found)' --profile ci --retries 0 --test-threads 1 --no-tests fail --no-fail-fast --success-output immediate
cargo nextest run --locked --offline --build-jobs 2 -p rustfs --lib -E 'test(=error::tests::test_kms_key_not_found_maps_to_bad_request_kms_not_found_exception) | test(=error::tests::test_generated_error_codes_keep_their_own_status) | test(=storage::sse::tests::kms_operation_errors_preserve_retryability_classification) | test(=storage::sse::tests::kms_provider_reports_an_unknown_key_as_kms_not_found)' --profile ci --retries 0 --test-threads 1 --no-tests fail --no-fail-fast --success-output immediate
cargo build --locked --offline --jobs 2 -p rustfs --bin rustfs
cargo nextest run --locked --offline --build-jobs 2 -p e2e_test --lib -E 'test(=kms::kms_fault_recovery_test::test_kms_key_directory_unavailable)' --profile e2e-full --retries 0 --test-threads 1 --no-tests fail --no-fail-fast --success-output immediate
cargo fmt --all --check
git diff --check
```

</details>

## Impact

The change is limited to the Local backend's absent-record path. Successful key reads add no filesystem call; an absent record adds one directory-open operation. Key validation, encryption, stored formats, caches, salt handling, configuration and authorization stay unchanged. Existing admin endpoint mappings also remain unchanged; the S3 400/500 contract does not describe every admin response. Remote KMS backends and rotation/versioning are outside this change.

This improves error classification at the time of the check. It does not prove directory identity or make the key lookup atomic: concurrent removal, replacement or key creation can still race the observations. No migration or configuration change is needed.

## Additional Notes

Two independent reviews and their follow-ups found no remaining source blocker. The following conclusions cover the final source diff and the completed targeted validation:

| Lens | Conclusion |
| --- | --- |
| Correctness | The real directory outage propagates IoError; healthy single-key absence keeps KeyNotFound. |
| Simplicity | One existing filesystem operation in the failed-lookup branch; no new helper or policy. |
| Test coverage | The backend regression failed before the fix; all seven targeted checks, including full HTTP recovery, passed after it. |
| Security | Validated key paths, key material handling and authorization are unchanged. |
| Concurrency/durability | The added read creates no persistent state or lock ordering change; it is not an atomic identity check. |
| Compatibility | Existing error mappings and consumer routes are retained; key bytes and formats do not change. |
| Performance | Only failed lookups gain directory-open I/O; no performance measurement is claimed. |
