### PR TITLE
fix: continue manual transition past in-flight objects

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -4036,6 +4036,10 @@ impl ManualTransitionRunReport {
             || self.skipped_queue_timeout > 0
     }
 
+    fn has_enqueue_backpressure(&self) -> bool {
+        self.skipped_queue_full > 0 || self.skipped_queue_closed > 0 || self.skipped_queue_timeout > 0
+    }
+
     pub fn was_truncated(&self) -> bool {
         self.truncated_by_limit || self.truncated_by_duration || self.cancelled
     }
@@ -4251,7 +4255,7 @@ pub async fn enqueue_transition_for_existing_objects_scoped(
             }
             report.scanned = report.scanned.saturating_add(1);
             enqueue_transition_with_lifecycle_report(Some(api.clone()), object, &lc, &src, &options, &mut report).await;
-            if report.has_partial_enqueue() {
+            if report.has_enqueue_backpressure() {
                 report.next_marker.clone_from(&previous_marker);
                 report.next_version_idmarker.clone_from(&previous_version_marker);
                 report.continuation_token =
@@ -9950,6 +9954,18 @@ mod tests {
         assert_eq!(report.skipped_queue_closed, 0);
         assert_eq!(report.skipped_queue_timeout, 0);
         assert!(report.has_partial_enqueue());
+        assert!(report.has_enqueue_backpressure());
+    }
+
+    #[test]
+    fn manual_transition_in_flight_skip_does_not_stop_the_scan() {
+        let options = ManualTransitionRunOptions::default();
+        let mut report = ManualTransitionRunReport::new("bucket", &options);
+
+        report.record_enqueue_outcome(TransitionEnqueueOutcome::AlreadyInFlight);
+
+        assert!(report.has_partial_enqueue());
+        assert!(!report.has_enqueue_backpressure());
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

rustfs/backlog#2386

## Summary of Changes

Continue a manual transition scan past objects already claimed by lifecycle backfill. The run remains partial when it observes those objects, while only actual queue backpressure stops the scan and records a continuation cursor.

## Verification

- `cargo fmt --all --check` passed at commit `9a2438964675d32d380d3f1ebc9bd354a95a7bbd`.
- `cargo test -p rustfs-ecstore manual_transition_report_marks_queue_pressure_partial` passed.
- `cargo test -p rustfs-ecstore manual_transition_in_flight_skip_does_not_stop_the_scan` passed.
- `git diff --check` passed.
- The focused native E2E was not rerun locally because the host had only 29 GiB free while other release-gate builds were active. CI remains the integration evidence.

## Impact

Manual transition jobs no longer stop at the first object already owned by an overlapping lifecycle backfill. Existing partial-status reporting and queue-full, closed, and timeout stop behavior are unchanged.

Correctness: no finding; in-flight objects remain counted as partial and real enqueue failures retain the continuation cursor.

Concurrency and durability: no finding; reservation, worker ownership, persistence, and queue behavior are unchanged.

Compatibility: no finding; no API, configuration, metadata, disk, or wire format changes.

Test coverage: no finding; focused unit coverage distinguishes in-flight overlap from queue backpressure, and the existing distributed E2E keeps its per-job queue-full assertion.

## Additional Notes

The failure was triggered when `PutBucketLifecycle` asynchronously backfilled existing objects before the manual job scanned the same prefix.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
