### PR TITLE
test(heal): preserve EC84 restart semantics

### DIFF
--- a/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
+++ b/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
@@ -1567,7 +1567,10 @@ mod tests {
                 "Restored target endpoint forwarding"
             );
         } else {
-            if scenario == InterruptionScenario::BackgroundTargetRestart {
+            if matches!(
+                scenario,
+                InterruptionScenario::BackgroundTargetRestart | InterruptionScenario::BackgroundTargetRestartEc84
+            ) {
                 cluster.stop_node_gracefully(interruption_node).await?;
             } else {
                 cluster.stop_node(interruption_node)?;
@@ -1589,7 +1592,10 @@ mod tests {
             if background_enabled {
                 let marker_exists = unclean_shutdown_marker.is_file();
                 unclean_shutdown_marker_observed = Some(marker_exists);
-                let expected_marker = !matches!(scenario, InterruptionScenario::BackgroundTargetRestart);
+                let expected_marker = matches!(
+                    scenario,
+                    InterruptionScenario::BackgroundTargetCrash | InterruptionScenario::BackgroundTargetCrashEc84
+                );
                 assert!(
                     marker_exists == expected_marker,
                     "background restart/crash lane observed unexpected unclean-shutdown marker state"


### PR DESCRIPTION
## Summary
- keep the EC8+4 background restart evidence lane on the graceful-stop path instead of accidentally using the crash stop path
- assert unclean-shutdown marker presence only for crash lanes, and absence for restart lanes
- preserve the release gate behavior: this single evidence case does not approve the full Scanner/Heal release matrix

## Validation
- cargo fmt --all --check
- git diff --check
- scripts/run_scanner_heal_evidence_case.sh --case background-target-restart-ec8-4 --plan-only
- cargo test --locked -p e2e_test --lib heal_erasure_disk_rebuild_test::tests::test_cluster_root_heal_recovers_ec84_shards_after_background_target_restart --no-run -j 4
- scripts/run_scanner_heal_evidence_case.sh --case background-target-restart-ec8-4
  - nextest run: 7cfcbe15-5c2e-4f59-9858-eb8e9ac0ead5
  - case: background-target-restart-ec8-4
  - result: PASS
  - release gate: remains blocked as expected

## Adversarial lenses
- Correctness: restart now exercises graceful shutdown for both default and EC8+4 variants; crash remains crash-only.
- Compatibility: no production code or public API changes; test-only harness refinement.
- Performance: no runtime impact; evidence case remains a single selected nextest case.
- Coverage: closes a false-positive gap in EC8+4 hard evidence by checking clean restart marker absence.