### PR TITLE
test(ecstore): bind MRF manifest CAS dirsync recovery

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -22465,6 +22465,86 @@ mod test {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn conditional_mrf_manifest_dir_fsync_failure_keeps_recovery_anchors() {
+        use tempfile::tempdir;
+
+        const MRF_COMMIT_MANIFEST_SLOT_0: &str = ".heal-mrf-commit.0.bin";
+        const MRF_COMMIT_MANIFEST_SLOT_1: &str = ".heal-mrf-commit.1.bin";
+        const MRF_SCOPED_JOURNAL_PATH: &str = "buckets/.heal/mrf/journal-scoped.bin";
+
+        let _mode = durability_mode_override::set(DurabilityMode::Relaxed);
+        let dir = tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+        let previous_manifest = Bytes::from_static(b"mrf-committed-manifest-v1");
+        let successor_manifest = Bytes::from_static(b"mrf-committed-manifest-v2");
+        let legacy_journal = Bytes::from_static(b"legacy-mrf-journal-records");
+
+        assert_eq!(
+            disk.compare_and_update_file(RUSTFS_META_BUCKET, MRF_COMMIT_MANIFEST_SLOT_0, None, Some(previous_manifest.clone()),)
+                .await
+                .expect("previous MRF manifest should commit"),
+            ConditionalFileUpdate::Updated
+        );
+        disk.write_all(RUSTFS_META_BUCKET, MRF_SCOPED_JOURNAL_PATH, legacy_journal.clone())
+            .await
+            .expect("legacy MRF journal should be retained");
+
+        let manifest_path = disk
+            .get_object_path(RUSTFS_META_BUCKET, MRF_COMMIT_MANIFEST_SLOT_0)
+            .expect("MRF manifest path should resolve");
+        let parent = manifest_path.parent().expect("MRF manifest path should have a parent");
+        assert!(
+            os::fsync_dir_recorder::was_fsynced(parent),
+            "system metadata MRF manifest publication must fsync the metadata directory even under relaxed durability"
+        );
+        os::fsync_dir_recorder::set_failure(parent, ErrorKind::Other);
+
+        let err = disk
+            .compare_and_update_file(
+                RUSTFS_META_BUCKET,
+                MRF_COMMIT_MANIFEST_SLOT_0,
+                Some(previous_manifest.clone()),
+                Some(successor_manifest),
+            )
+            .await
+            .expect_err("directory fsync failure must fail the MRF manifest successor commit");
+        assert!(matches!(err, DiskError::Io(ref err) if err.kind() == ErrorKind::Other));
+        assert_eq!(
+            disk.read_all(RUSTFS_META_BUCKET, MRF_COMMIT_MANIFEST_SLOT_0)
+                .await
+                .expect("previous committed MRF manifest should remain readable after rollback"),
+            previous_manifest
+        );
+
+        os::fsync_dir_recorder::set_failure(parent, ErrorKind::Other);
+        let err = disk
+            .compare_and_update_file(
+                RUSTFS_META_BUCKET,
+                MRF_COMMIT_MANIFEST_SLOT_1,
+                None,
+                Some(Bytes::from_static(b"first-successor-manifest")),
+            )
+            .await
+            .expect_err("directory fsync failure must fail first MRF manifest commit");
+        assert!(matches!(err, DiskError::Io(ref err) if err.kind() == ErrorKind::Other));
+        assert!(
+            matches!(
+                disk.read_all(RUSTFS_META_BUCKET, MRF_COMMIT_MANIFEST_SLOT_1).await,
+                Err(DiskError::FileNotFound)
+            ),
+            "uncommitted first MRF manifest must be removed when no committed anchor exists"
+        );
+        assert_eq!(
+            disk.read_all(RUSTFS_META_BUCKET, MRF_SCOPED_JOURNAL_PATH)
+                .await
+                .expect("legacy MRF journal should remain readable after failed manifest publication"),
+            legacy_journal
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn conditional_file_update_dir_fsync_failure_removes_new_file_without_anchor() {
         use tempfile::tempdir;
 


### PR DESCRIPTION
## Related Issues
- rustfs/backlog#2263
- rustfs/backlog#2240

## Summary of Changes
- Add a LocalDisk CAS durability fixture for the exact committed MRF manifest paths under the RustFS metadata bucket.
- Cover a metadata directory fsync failure after a successor manifest rename: the CAS call fails, rollback restores the previous committed manifest bytes, and the old recovery anchor remains readable.
- Cover a first-manifest publication failure with no committed anchor: the uncommitted successor manifest is removed and the retained scoped legacy MRF journal remains readable.
- Run the fixture under relaxed global durability to prove system metadata keeps strict commit metadata syncing for this path.

## Verification
- Tested commit: 5ab51752628f244101c77edbc7479ff772026133 with no uncommitted task diff.
- `cargo test --locked -p rustfs-ecstore --lib conditional_mrf_manifest_dir_fsync_failure_keeps_recovery_anchors -j 4`: passed, 1/1.
- `cargo test --locked -p rustfs-heal --lib manifest_cas_publication_transitions_from_legacy_without_losing_anchor -j 4`: passed, 1/1.
- `cargo test --locked -p rustfs-heal --lib committed_snapshot_writer_publishes_100k_records_with_bounded_readback -j 4`: passed, 1/1.
- `cargo fmt --all --check`: passed.
- `git diff --check`: passed.

Not run: full distributed, mixed-version, crash-restart, EC8+4 long-stability, and profiling lanes. This PR only closes the W12 local CAS/dirsync/legacy-anchor evidence gap.

## Impact
- Test-only change. No runtime, API, config, on-disk format, or deployment behavior changes.
- Strengthens regression coverage for committed MRF checkpoint publication on the local disk owner path.

## Additional Notes
- Correctness: attacked missing-anchor, existing-anchor, fsync failure, and stale successor cases; the fixture asserts exact bytes and error variants instead of success-only behavior.
- Test coverage: reverting the CAS rollback or system-metadata strict fsync behavior makes the new focused test fail.
- Concurrency/durability: no new locks or production writes were added; the test covers the write-temp, rename, parent-fsync, rollback path for the MRF manifest location.
- Compatibility: legacy scoped MRF journal bytes remain untouched and readable when committed manifest publication fails.
- Performance: no production hot-path code changed; the test verifies strict metadata fsync applies only through the existing system metadata durability gate.
