### PR TITLE
fix(heal): harden MRF replay boundaries

### DIFF
--- a/crates/heal/src/heal/mrf_queue.rs
+++ b/crates/heal/src/heal/mrf_queue.rs
@@ -294,7 +294,11 @@ fn decode_one(data: &[u8]) -> Option<(MrfIntent, usize)> {
     };
     let attempts = data[3];
     let enqueued_at_ms = u64::from_le_bytes(data[4..12].try_into().ok()?);
-    let has_version = data[12] != 0;
+    let has_version = match data[12] {
+        0 => false,
+        1 => true,
+        _ => return None,
+    };
     let mut cursor = MRF_RECORD_FIXED_HEAD;
     let version_id = if has_version {
         if data.len() < cursor + 16 {
@@ -718,7 +722,7 @@ fn replay_must_retain_journal(
 #[derive(Clone, Copy)]
 enum ReplayCleanup {
     Legacy,
-    Committed { sequence: u64 },
+    Committed { owner: Uuid, sequence: u64 },
 }
 
 struct ReplaySource {
@@ -731,6 +735,7 @@ async fn read_replay_source(max_bytes: usize) -> Result<Option<ReplaySource>, sn
         return Ok(Some(ReplaySource {
             data: committed.payload().to_vec(),
             cleanup: ReplayCleanup::Committed {
+                owner: committed.owner(),
                 sequence: committed.sequence(),
             },
         }));
@@ -754,18 +759,20 @@ async fn read_replay_source(max_bytes: usize) -> Result<Option<ReplaySource>, sn
 async fn delete_replay_source(cleanup: ReplayCleanup, max_bytes: usize) -> bool {
     let committed_deleted = match cleanup {
         ReplayCleanup::Legacy => true,
-        ReplayCleanup::Committed { sequence } => match snapshot::delete_committed_snapshots_through(sequence, max_bytes).await {
-            Ok(deleted) => deleted,
-            Err(err) => {
-                tracing::warn!(
-                    target: "rustfs::heal::mrf",
-                    error = %err,
-                    sequence,
-                    "MRF committed replay checkpoint cleanup failed"
-                );
-                false
+        ReplayCleanup::Committed { owner, sequence } => {
+            match snapshot::delete_committed_snapshots_through(owner, sequence, max_bytes).await {
+                Ok(deleted) => deleted,
+                Err(err) => {
+                    tracing::warn!(
+                        target: "rustfs::heal::mrf",
+                        error = %err,
+                        sequence,
+                        "MRF committed replay checkpoint cleanup failed"
+                    );
+                    false
+                }
             }
-        },
+        }
     };
     committed_deleted && delete_journals().await
 }
@@ -1342,6 +1349,25 @@ mod tests {
         let (decoded, truncated) = decode_journal(&corrupt);
         assert!(decoded.is_empty());
         assert_eq!(truncated, corrupt.len());
+    }
+
+    #[test]
+    fn journal_rejects_unknown_version_presence_flag_even_with_valid_crc() {
+        let mut versioned = intent("rollback-bucket", "object", 0);
+        versioned.version_id = Some([9; 16]);
+        let mut buf = Vec::new();
+        assert!(encode_intent(&versioned, &mut buf));
+
+        buf[12] = 2;
+        let crc_offset = buf.len() - 4;
+        let mut hasher = crc_fast::Digest::new(crc_fast::CrcAlgorithm::Crc32IsoHdlc);
+        hasher.update(&buf[..crc_offset]);
+        let checksum = u32::try_from(hasher.finalize()).expect("CRC32 fits");
+        buf[crc_offset..].copy_from_slice(&checksum.to_le_bytes());
+
+        let (decoded, truncated) = decode_journal(&buf);
+        assert!(decoded.is_empty(), "unknown boolean encodings are not rollback-compatible payloads");
+        assert_eq!(truncated, buf.len());
     }
 
     #[test]

--- a/crates/heal/src/heal/mrf_queue/snapshot.rs
+++ b/crates/heal/src/heal/mrf_queue/snapshot.rs
@@ -555,20 +555,25 @@ pub async fn inspect_local_committed_snapshot(max_bytes: usize) -> Result<Option
     read_committed(&super::journal_disks().await, max_bytes).await
 }
 
-/// Remove committed manifests whose sequence is no newer than
+/// Remove committed manifests from `owner` whose sequence is no newer than
 /// `committed_through`.
 ///
 /// Payload files are intentionally left as orphans after their manifest is
 /// removed. Readers cannot discover a payload without its matching manifest,
 /// and deleting manifests first prevents an older retained slot from becoming
 /// visible again after the newest replay has been fully discharged.
-pub async fn delete_committed_snapshots_through(committed_through: u64, max_bytes: usize) -> Result<bool, SnapshotError> {
+pub async fn delete_committed_snapshots_through(
+    owner: Uuid,
+    committed_through: u64,
+    max_bytes: usize,
+) -> Result<bool, SnapshotError> {
     let disks = super::journal_disks().await;
-    delete_committed_snapshots_through_on(&disks, committed_through, max_bytes).await
+    delete_committed_snapshots_through_on(&disks, owner, committed_through, max_bytes).await
 }
 
 async fn delete_committed_snapshots_through_on(
     disks: &[EcstoreDiskStore],
+    owner: Uuid,
     committed_through: u64,
     max_bytes: usize,
 ) -> Result<bool, SnapshotError> {
@@ -598,7 +603,7 @@ async fn delete_committed_snapshots_through_on(
                     continue;
                 }
             };
-            if manifest.sequence > committed_through {
+            if manifest.owner != owner || manifest.sequence > committed_through {
                 continue;
             }
             match EcstoreDiskAPI::compare_and_update_file(
@@ -1360,7 +1365,7 @@ mod tests {
         commit(&disk, 1, owner, 4, &newer).await;
 
         assert!(
-            delete_committed_snapshots_through_on(std::slice::from_ref(&disk), 3, 4096)
+            delete_committed_snapshots_through_on(std::slice::from_ref(&disk), owner, 3, 4096)
                 .await
                 .expect("delete old manifest"),
             "old committed manifest should be removed"
@@ -1385,6 +1390,47 @@ mod tests {
             .expect("newer commit remains visible");
         assert_eq!(recovered.sequence(), 4);
         assert_eq!(recovered.payload(), newer);
+    }
+
+    #[tokio::test]
+    async fn committed_cleanup_preserves_other_owner_manifests_within_sequence_window() {
+        let root = TempDir::new().expect("test directory");
+        let disk = disk(&root, "disk").await;
+        let replay_owner = Uuid::new_v4();
+        let other_owner = Uuid::new_v4();
+        let replay_payload = payload("replay-owner");
+        let other_payload = payload("other-owner");
+        commit(&disk, 0, replay_owner, 9, &replay_payload).await;
+        commit(&disk, 1, other_owner, 4, &other_payload).await;
+
+        assert!(
+            delete_committed_snapshots_through_on(std::slice::from_ref(&disk), replay_owner, 9, 4096)
+                .await
+                .expect("delete replay-owner manifest"),
+            "the matched owner manifest should be removed"
+        );
+
+        assert!(
+            matches!(
+                EcstoreDiskAPI::read_all(disk.as_ref(), RUSTFS_META_BUCKET, MANIFEST_PATHS[0]).await,
+                Err(EcstoreDiskError::FileNotFound | EcstoreDiskError::VolumeNotFound)
+            ),
+            "the replay owner's manifest is reclaimed"
+        );
+        assert_eq!(
+            EcstoreDiskAPI::read_all(disk.as_ref(), RUSTFS_META_BUCKET, MANIFEST_PATHS[1])
+                .await
+                .expect("other owner manifest retained")
+                .as_ref(),
+            manifest(other_owner, 4, &other_payload)
+        );
+        assert_eq!(
+            EcstoreDiskAPI::read_all(disk.as_ref(), RUSTFS_META_BUCKET, PAYLOAD_PATHS[1])
+                .await
+                .expect("other owner payload retained")
+                .as_ref(),
+            other_payload
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related Issues

rustfs/backlog#2268
rustfs/backlog#2240

## Summary of Changes

- Reject MRF journal records whose version-presence flag is neither `0` nor `1`, even when the record CRC is otherwise valid. This keeps rollback/future payload bytes from being accepted as a known journal record.
- Carry the committed checkpoint writer owner through replay cleanup and delete committed manifests only when both owner and sequence match the replay source. This prevents one owner cleanup window from reclaiming another retained committed anchor with a lower sequence.

## Verification

- PASS: `cargo test --locked -p rustfs-heal --lib committed_cleanup_preserves_other_owner_manifests_within_sequence_window -j 4` (1/1).
- PASS: `cargo test --locked -p rustfs-heal mrf_queue -j 4` (61/61; includes strict journal flag parsing, owner-scoped cleanup, snapshot writer/reader, migration, and 100k bounded-read coverage).
- PASS: `cargo test --locked -p rustfs-heal --test mrf_pipeline_test -j 4` (15/15; includes child-process replay, service-kill, successor flush, and authoritative fsync/stale legacy boundaries).
- PASS: `cargo fmt --all --check`.
- PASS: `git diff --check`.
- PASS: `cargo check --locked -p rustfs-heal --lib`.
- PASS: `cargo clippy --locked -p rustfs-heal --all-targets -- -D warnings`.

Not run: real mixed-version clusters, distributed crash matrix, disk-full capacity injection, long-running cleanup/GC soak, and release evidence bundle. Those remain pending for W13/W21 and are not claimed by this PR.

## Impact

Runtime behavior changes only for MRF replay persistence boundaries. Valid v1/v2 journal records keep decoding as before; malformed/future boolean encodings fail closed. Committed checkpoint cleanup is more conservative across writer owners and may retain additional anchors until their own owner-scoped cleanup path runs.

Adversarial validation:
- Correctness: attacked unknown journal flag payloads with a recomputed valid CRC and verified they truncate instead of decoding.
- Concurrency/durability: attacked committed cleanup after a newer replay source while another owner has an older retained slot; the other owner manifest and payload remain intact.
- Compatibility: valid v1/v2 journal records and legacy mirror behavior are unchanged; unknown record encodings fail closed instead of being interpreted as current format.
- Test coverage: reverting the strict flag check fails `journal_rejects_unknown_version_presence_flag_even_with_valid_crc`; reverting owner-gated cleanup fails `committed_cleanup_preserves_other_owner_manifests_within_sequence_window`.
- Performance/resources: no new disk fan-out, fsync, queue scan, or hot-path allocation; cleanup adds only an owner equality check on manifests already read by the existing cleanup pass.

## Additional Notes

This PR advances W13 cleanup/rollback boundaries after durable MRF replay core reached `release`. It does not close rustfs/backlog#2268.
