### PR TITLE
test(scanner): derive evidence runner profile from registry

### DIFF
--- a/scripts/check_test_wiring.py
+++ b/scripts/check_test_wiring.py
@@ -956,6 +956,9 @@ def scanner_heal_oracle_names(root: Path) -> tuple[str, ...]:
     names = set()
     for case_id, requirement in cases.items():
         require(isinstance(case_id, str) and case_id, "invalid scanner/heal case identity")
+        lane = requirement.get("lane")
+        require(isinstance(lane, str) and re.fullmatch(r"[a-z0-9-]+", lane) is not None,
+                f"invalid nextest profile lane for {case_id}")
         oracle = requirement.get("oracle")
         require(isinstance(oracle, str) and oracle.endswith(".json"), f"invalid oracle for {case_id}")
         path = Path(oracle)
@@ -1666,6 +1669,16 @@ class SelfTests(unittest.TestCase):
             })
         finish_scanner_heal_receipt(run_dir, 0, root)
         return root, run_dir
+
+    def test_scanner_heal_case_lane_is_required_for_runner_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root, _ = self.scanner_heal_fixture(Path(tmp))
+            registry_path = root / ".config/scanner-heal-required-tests.json"
+            registry = read_json(registry_path)
+            del registry["cases"]["ec84-target-drive-restart"]["lane"]
+            write_json(registry_path, registry)
+            with self.assertRaisesRegex(ValueError, "invalid nextest profile lane for ec84-target-drive-restart"):
+                scanner_heal_oracle_names(root)
 
     def scanner_heal_release_bundle_fixture(self, directory: Path) -> tuple[Path, Path]:
         """Parser fixtures only; the bundle is not runtime evidence."""

--- a/scripts/run_scanner_heal_evidence_case.sh
+++ b/scripts/run_scanner_heal_evidence_case.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PYTHON_BIN="${RUSTFS_PYTHON_BIN:-python3}"
-PROFILE="e2e-nightly"
+PROFILE=""
 CASE_ID="background-target-crash"
 RUN_DIR=""
 PLAN_ONLY=0
@@ -18,7 +18,7 @@ then validate the produced receipt, nextest listing, JUnit, and case oracle.
 
 Options:
   --case CASE          Registry case to run (default: background-target-crash)
-  --profile PROFILE   Nextest profile to use (default: e2e-nightly)
+  --profile PROFILE   Nextest profile to use (default: registry lane)
   --run-dir DIR       New evidence directory (default: target/scanner-heal-evidence/CASE-TIMESTAMP)
   --plan-only         Validate registry selection and print the exact filter without running cargo
   --self-test         Run lightweight CLI/registry checks without building Rust
@@ -29,6 +29,18 @@ a successful case run it verifies that the release gate still remains blocked.
 Set RUSTFS_E2E_TEST_PORT_MIN and RUSTFS_E2E_TEST_PORT_RANGE to move the e2e
 port allocator when the default 20000..30000 test range is unavailable.
 USAGE
+}
+
+case_ids() {
+    "$PYTHON_BIN" - "$ROOT/.config/scanner-heal-required-tests.json" <<'PY'
+import json
+import pathlib
+import sys
+
+registry = json.loads(pathlib.Path(sys.argv[1]).read_text())
+for case_id in sorted(registry["cases"]):
+    print(case_id)
+PY
 }
 
 case_field() {
@@ -109,20 +121,24 @@ PY
 }
 
 run_self_test() {
-    local filter
-    filter="$(test_filter_for background-target-crash)"
-    case "$filter" in
-        *background_target_crash*) ;;
-        *)
-            echo "self-test failed: crash case filter missing" >&2
-            return 1
-            ;;
-    esac
     if "$0" --case release --plan-only >/dev/null 2>&1; then
         echo "self-test failed: release pseudo-case must not be runnable" >&2
         return 1
     fi
-    "$0" --case background-target-crash --plan-only >/dev/null
+    local case_id
+    while IFS= read -r case_id; do
+        local expected_filter expected_profile plan
+        expected_filter="$(test_filter_for "$case_id")"
+        expected_profile="$(case_field "$case_id" lane)"
+        plan="$("$0" --case "$case_id" --plan-only)"
+        if [[ "$plan" != *"case=$case_id"* ]] ||
+            [[ "$plan" != *"profile=$expected_profile"* ]] ||
+            [[ "$plan" != *"filter=$expected_filter"* ]] ||
+            [[ "$plan" != *"run_dir=$ROOT/target/scanner-heal-evidence/$case_id-"* ]]; then
+            echo "self-test failed: registry case plan mismatch for $case_id" >&2
+            return 1
+        fi
+    done < <(case_ids)
 }
 
 while [[ $# -gt 0 ]]; do
@@ -166,6 +182,9 @@ fi
 
 case_field "$CASE_ID" name >/dev/null
 TEST_FILTER="$(test_filter_for "$CASE_ID")"
+if [[ -z "$PROFILE" ]]; then
+    PROFILE="$(case_field "$CASE_ID" lane)"
+fi
 case "$CASE_ID" in
   background-target-crash|background-target-restart)
     export RUSTFS_HEAL_CHAOS_OBJECT_COUNT="${RUSTFS_HEAL_CHAOS_OBJECT_COUNT:-64}"


### PR DESCRIPTION
## Related Issues
Related: rustfs/backlog#2269

## Summary of Changes
The Scanner/Heal release-evidence runner now derives its default nextest profile from each registry case's `lane` instead of hard-coding `e2e-nightly`.

The runner self-test now iterates every registered concrete evidence case and verifies that `--plan-only` reports the expected case id, registry-derived profile, exact nextest filter, and evidence run directory prefix. The release pseudo-case remains rejected because it is a checker-only aggregate gate.

The Scanner/Heal registry checker now also validates that every concrete case has a well-formed nextest profile lane, so future runner-profile evidence cannot depend on an unchecked registry field.

## Verification
- `bash -n scripts/run_scanner_heal_evidence_case.sh` passed.
- `scripts/run_scanner_heal_evidence_case.sh --self-test` passed and covered every registered concrete case.
- `python3 scripts/check_test_wiring.py --self-test` passed: 38/38 self-tests, including the missing case-lane rejection.
- `scripts/run_scanner_heal_evidence_case.sh --case ec84-target-drive-restart --plan-only` selected `profile=e2e-distributed` with the EC8+4 distributed restart filter.
- `scripts/run_scanner_heal_evidence_case.sh --case background-target-crash-ec8-4 --plan-only` selected `profile=e2e-nightly` with the EC8+4 crash filter.
- `scripts/run_scanner_heal_evidence_case.sh --case release --plan-only` failed closed with the expected checker-only pseudo-case rejection.
- `git diff --check` passed.

Tested commit: `ca26c0e875d0cee3bee92a9d605813f86032452c` on top of `release` at `595f9f662`.

Not run: the long-running real evidence cases. This change only hardens runner selection, registry schema validation, and self-test coverage; it does not claim completion of the remaining W21 distributed, mixed-version, crash-restart, durable replay, EC8+4 long-run ABBA, or profile-evidence gates.

## Impact
No production runtime impact. Evidence runs launched without an explicit `--profile` now follow the registry lane, so distributed registry cases no longer silently default to `e2e-nightly`. Existing callers that pass `--profile` keep the same override behavior.

## Additional Notes
Adversarial validation:

- Correctness: attacked wrong-lane defaulting, unchecked lane fields, omitted registered cases, and accidental release pseudo-case execution; no findings after the final diff.
- Test coverage: reverting the registry-derived profile, deleting a concrete case lane, or reducing self-test to one case breaks the focused script checks.
- Compatibility: explicit `--profile` remains supported, and existing `e2e-nightly` cases still resolve to that profile via the registry.
- Performance: self-test remains lightweight and plan-only; no cargo build or real e2e execution is added.
