### PR TITLE
test(scanner): require G14 same-window field coverage

### DIFF
--- a/scripts/check_test_wiring.py
+++ b/scripts/check_test_wiring.py
@@ -1388,6 +1388,16 @@ def validate_release_bundle_artifact(bundle_path: Path, source_revision: str, ga
         require(evidence.get("successor_snapshot_published") is True,
                 f"{gate}.{field} requires successor snapshot publication evidence")
     if gate == "G14":
+        if field == "same_window_field_evidence":
+            required_fields = set(SCANNER_HEAL_RELEASE_BUNDLE_REQUIRED_EVIDENCE_FIELDS["G14"]) - {field}
+            same_window_fields = evidence.get("same_window_fields")
+            require(isinstance(same_window_fields, list) and
+                    len(set(same_window_fields)) == len(same_window_fields) and
+                    all(isinstance(item, str) and item in required_fields for item in same_window_fields),
+                    "G14.same_window_field_evidence requires named G14 field coverage")
+            missing_same_window_fields = sorted(required_fields - set(same_window_fields))
+            require(not missing_same_window_fields,
+                    "G14.same_window_field_evidence missing fields: " + ", ".join(missing_same_window_fields))
         if field == "ec8_4_evidence":
             topology = evidence.get("topology")
             require(isinstance(topology, dict), "G14.ec8_4_evidence missing topology")
@@ -1790,6 +1800,12 @@ class SelfTests(unittest.TestCase):
                     evidence["successor_snapshot_published"] = True
                 if gate == "G14" and field == "ec8_4_evidence":
                     evidence["topology"] = {"erasure": "EC8+4", "nodes": 3, "drives_per_node": 4}
+                if gate == "G14" and field == "same_window_field_evidence":
+                    evidence["same_window_fields"] = [
+                        item
+                        for item in SCANNER_HEAL_RELEASE_BUNDLE_REQUIRED_EVIDENCE_FIELDS["G14"]
+                        if item != "same_window_field_evidence"
+                    ]
                 if gate == "G14" and field == "multi_set_evidence":
                     evidence["sets"] = 2
                 if gate == "G14" and field == "multi_pool_evidence":
@@ -1890,6 +1906,7 @@ class SelfTests(unittest.TestCase):
             ("mrf-records", "G07", "mrf_responsibility_oracle", lambda item: item.pop("replayed_records"), "replayed_records"),
             ("mrf-anchor", "G07", "commit_boundary_crash_matrix", lambda item: item.update({"responsibility_anchor_retained": False}), "retained MRF responsibility anchors"),
             ("mrf-successor", "P4", "retained_responsibility_evidence", lambda item: item.pop("successor_snapshot_published"), "successor snapshot"),
+            ("same-window-fields", "G14", "same_window_field_evidence", lambda item: item.update({"same_window_fields": ["ec8_4_evidence", "multi_set_evidence"]}), "missing fields"),
         ):
             with self.subTest(fault=fault), tempfile.TemporaryDirectory() as tmp:
                 root, bundle = self.scanner_heal_release_bundle_fixture(Path(tmp))


### PR DESCRIPTION
## Related Issues

rustfs/backlog#2269

## Summary of Changes

- Require Scanner/Heal release bundle `G14.same_window_field_evidence` to explicitly name the G14 evidence fields covered by the same measurement window.
- The checker now fails closed when the same-window artifact omits `ec8_4_evidence`, `multi_set_evidence`, or `multi_pool_evidence`, even if the field timestamps and window ids otherwise look valid.
- Extend the release bundle parser fixture and self-test with a missing-field negative case.

## Verification

- `python3 scripts/check_test_wiring.py --self-test`: PASS, 39/39.
- `python3 scripts/check_test_wiring.py`: PASS.
- `git diff --check origin/release...HEAD`: PASS.

This is a checker-only W21 hardening slice. It does not execute the remaining real distributed, mixed-version, crash-restart, durable replay, EC8+4 long-window ABBA, or profile-evidence lanes.

## Impact

- G14 release evidence bundles cannot satisfy same-window coverage with a generic artifact that does not name the EC8+4, multi-set, and multi-pool fields it binds.
- No production runtime behavior changes.

## Additional Notes

Adversarial validation:

- Correctness: attacked a partial G14 same-window artifact that covered only EC8+4 and multi-set; the checker rejects it as incomplete.
- Simplicity: kept the change inside the existing release bundle validator and fixture path.
- Test coverage: reverting the G14 field-coverage check breaks the new self-test mutation.
- Compatibility: this intentionally tightens the pending release evidence contract before the G14 lane can be marked complete.
