### PR TITLE
test(scanner): require exact ABBA release evidence sets

### DIFF
--- a/scripts/scanner_abba.py
+++ b/scripts/scanner_abba.py
@@ -173,6 +173,17 @@ def release_evidence_true(value, name):
     require(value is True, f"missing release_evidence.{name}")
 
 
+def release_evidence_exact_set(value, name, expected):
+    require(
+        isinstance(value, list)
+        and all(isinstance(item, str) and item.strip() for item in value),
+        f"invalid release_evidence.{name}",
+    )
+    observed = set(value)
+    require(len(observed) == len(value), f"duplicate release_evidence.{name}")
+    require(observed == set(expected), f"invalid release_evidence.{name}")
+
+
 def validate_release_evidence_manifest(manifest):
     if manifest["evidence"] != "measured":
         return
@@ -210,13 +221,7 @@ def validate_release_evidence_manifest(manifest):
 
     crash = evidence.get("crash_restart")
     require(isinstance(crash, dict), "missing release_evidence.crash_restart")
-    fault_modes = crash.get("fault_modes")
-    require(
-        isinstance(fault_modes, list)
-        and all(mode in fault_modes for mode in RELEASE_FAULT_MODES)
-        and all(isinstance(mode, str) and mode.strip() for mode in fault_modes),
-        "missing release_evidence.crash_restart.fault_modes",
-    )
+    release_evidence_exact_set(crash.get("fault_modes"), "crash_restart.fault_modes", RELEASE_FAULT_MODES)
     release_evidence_true(crash.get("unclean_shutdown_marker"), "crash_restart.unclean_shutdown_marker")
 
     mixed = evidence.get("mixed_version")
@@ -236,13 +241,7 @@ def validate_release_evidence_manifest(manifest):
 
     profile = evidence.get("profile")
     require(isinstance(profile, dict), "missing release_evidence.profile")
-    artifacts = profile.get("required_artifacts")
-    require(
-        isinstance(artifacts, list)
-        and all(item in artifacts for item in RELEASE_PROFILE_ARTIFACTS)
-        and all(isinstance(item, str) and item.strip() for item in artifacts),
-        "missing release_evidence.profile.required_artifacts",
-    )
+    release_evidence_exact_set(profile.get("required_artifacts"), "profile.required_artifacts", RELEASE_PROFILE_ARTIFACTS)
     for key in ("collector_config_sha256", "profiler_config_sha256"):
         require(sha(profile.get(key)), f"invalid release_evidence.profile.{key}")
 

--- a/scripts/test_scanner_abba.py
+++ b/scripts/test_scanner_abba.py
@@ -548,6 +548,12 @@ class ScannerAbbaTest(unittest.TestCase):
             "missing crash": lambda manifest: manifest["release_evidence"]["crash_restart"].update(
                 fault_modes=["process-restart"],
             ),
+            "unknown crash": lambda manifest: manifest["release_evidence"]["crash_restart"].update(
+                fault_modes=["process-restart", "process-crash-restart", "power-cycle"],
+            ),
+            "duplicate crash": lambda manifest: manifest["release_evidence"]["crash_restart"].update(
+                fault_modes=["process-restart", "process-restart", "process-crash-restart"],
+            ),
             "clean crash marker": lambda manifest: manifest["release_evidence"]["crash_restart"].update(
                 unclean_shutdown_marker=False,
             ),
@@ -557,6 +563,12 @@ class ScannerAbbaTest(unittest.TestCase):
             ),
             "missing profile": lambda manifest: manifest["release_evidence"]["profile"].update(
                 required_artifacts=["allocation-profile", "flamegraph", "rss-samples"],
+            ),
+            "unknown profile": lambda manifest: manifest["release_evidence"]["profile"].update(
+                required_artifacts=["allocation-profile", "flamegraph", "rss-samples", "save-frequency", "heap-dump"],
+            ),
+            "duplicate profile": lambda manifest: manifest["release_evidence"]["profile"].update(
+                required_artifacts=["allocation-profile", "flamegraph", "rss-samples", "save-frequency", "flamegraph"],
             ),
             "bad profile hash": lambda manifest: manifest["release_evidence"]["profile"].update(
                 profiler_config_sha256="not-a-sha",


### PR DESCRIPTION
## Related Issues
Related: rustfs/backlog#2269

## Summary of Changes
The Scanner/Heal ABBA manifest release-evidence contract now requires exact sets for crash/restart fault modes and profile artifacts.

Measured ABBA manifests can no longer include duplicate entries or unknown extra labels such as an unverified `power-cycle` fault mode or an untracked `heap-dump` profile artifact while still passing the release-evidence contract.

## Verification
- `python3 scripts/test_scanner_abba.py` passed: 27/27 tests, including unknown/duplicate fault mode and profile artifact rejection.
- `python3 scripts/test_summarize_scanner_heal_perf.py` passed: 11/11 tests.
- `git diff --check` passed.

Tested commit: `17aab411ee310c8540aac1972f2d3eec2ca377a8` on top of `release` at `4d68c32b`.

Not run: real EC8+4 long-run ABBA, distributed crash/restart, mixed-version, durable replay, or profile capture. This PR only tightens the manifest contract and does not claim W21 completion.

## Impact
No production runtime impact. Measured Scanner/Heal ABBA evidence manifests must now use exactly the release-required crash/restart and profile artifact sets; unrecognized or duplicate labels fail closed.

## Additional Notes
Adversarial validation:

- Correctness: attacked unknown extra labels, duplicate labels, and missing required labels; no findings after the final diff.
- Simplicity: used one local exact-set helper and kept validation inside the existing release-evidence manifest boundary.
- Test coverage: reverting exact-set validation breaks the new focused `test_scanner_abba.py` negative cases.
- Performance: no benchmark path or real ABBA execution changes; validation remains O(number of configured labels).
