### PR TITLE
fix(e2e): group scanner heal evidence payload

### DIFF
--- a/crates/e2e_test/src/distributed/heal_test.rs
+++ b/crates/e2e_test/src/distributed/heal_test.rs
@@ -46,6 +46,18 @@ struct ScannerHealEvidenceContext {
     run: Value,
 }
 
+struct ScannerHealEvidencePayload<'a> {
+    dist: &'a DistCluster,
+    bucket: &'a str,
+    expected: &'a [ExpectedShard],
+    outage_key: &'a str,
+    outage_body: &'a [u8],
+    replaced_drive: &'a Path,
+    pid_before: u32,
+    pid_after: u32,
+    node_listings: Vec<Vec<String>>,
+}
+
 fn file_sha256(path: &Path) -> TestResult<String> {
     let mut file = std::fs::File::open(path)?;
     let mut digest = Sha256::new();
@@ -130,23 +142,12 @@ fn assert_ec84_geometry(census: &VersionShardCensus, key: &str) -> TestResult {
     Ok(())
 }
 
-async fn write_scanner_heal_evidence(
-    context: ScannerHealEvidenceContext,
-    dist: &DistCluster,
-    bucket: &str,
-    expected: &[ExpectedShard],
-    outage_key: &str,
-    outage_body: &[u8],
-    replaced_drive: &Path,
-    pid_before: u32,
-    pid_after: u32,
-    node_listings: Vec<Vec<String>>,
-) -> TestResult {
-    let verifier = dist.client(0)?;
+async fn write_scanner_heal_evidence(context: ScannerHealEvidenceContext, payload: ScannerHealEvidencePayload<'_>) -> TestResult {
+    let verifier = payload.dist.client(0)?;
     let mut objects = Vec::new();
-    for item in expected {
-        let actual = get_object_bytes(&verifier, bucket, &item.key).await?;
-        let physical = census_object_version_on_disk(replaced_drive, bucket, &item.key, None)?;
+    for item in payload.expected {
+        let actual = get_object_bytes(&verifier, payload.bucket, &item.key).await?;
+        let physical = census_object_version_on_disk(payload.replaced_drive, payload.bucket, &item.key, None)?;
         objects.push(serde_json::json!({
             "key": item.key,
             "version_id": null,
@@ -158,14 +159,14 @@ async fn write_scanner_heal_evidence(
             "physical": physical,
         }));
     }
-    let actual = get_object_bytes(&verifier, bucket, outage_key).await?;
-    let physical = census_object_version_on_disk(replaced_drive, bucket, outage_key, None)?;
+    let actual = get_object_bytes(&verifier, payload.bucket, payload.outage_key).await?;
+    let physical = census_object_version_on_disk(payload.replaced_drive, payload.bucket, payload.outage_key, None)?;
     objects.push(serde_json::json!({
-        "key": outage_key,
+        "key": payload.outage_key,
         "version_id": null,
-        "expected_bytes": outage_body.len(),
+        "expected_bytes": payload.outage_body.len(),
         "actual_bytes": actual.len(),
-        "expected_sha256": sha256_hex(outage_body),
+        "expected_sha256": sha256_hex(payload.outage_body),
         "actual_sha256": sha256_hex(&actual),
         "expected_physical": null,
         "physical": physical,
@@ -181,11 +182,11 @@ async fn write_scanner_heal_evidence(
         "binary_sha256": string_field(&context.run, "binary.sha256")?,
         "test_binary_sha256": string_field(&context.run, "test_binary.sha256")?,
         "topology": {"nodes": EC84_NODE_COUNT, "drives_per_node": EC84_DRIVES_PER_NODE},
-        "pid_before": pid_before,
-        "pid_after": pid_after,
+        "pid_before": payload.pid_before,
+        "pid_after": payload.pid_after,
         "unclean_shutdown_marker": false,
         "objects": objects,
-        "node_listings": node_listings,
+        "node_listings": payload.node_listings,
     });
     let data = serde_json::to_vec(&evidence)?;
     if data.len() > 1024 * 1024 {
@@ -347,15 +348,17 @@ async fn three_node_four_drive_ec8_4_root_heal_rebuilds_replaced_drive_after_res
     if let Some(context) = evidence_context {
         write_scanner_heal_evidence(
             context,
-            &dist,
-            &bucket,
-            &expected,
-            outage_key,
-            &outage_body,
-            &replaced_drive,
-            target_pid_before,
-            target_pid_after,
-            node_listings,
+            ScannerHealEvidencePayload {
+                dist: &dist,
+                bucket: &bucket,
+                expected: &expected,
+                outage_key,
+                outage_body: &outage_body,
+                replaced_drive: &replaced_drive,
+                pid_before: target_pid_before,
+                pid_after: target_pid_after,
+                node_listings,
+            },
         )
         .await?;
     }


### PR DESCRIPTION
## Related Issues
Part of rustfs/backlog#2269.

## Summary of Changes
The distributed EC8+4 Scanner/Heal evidence producer now groups its evidence-writer inputs into a typed payload struct.

This removes the `clippy::too_many_arguments` failure in `write_scanner_heal_evidence` without weakening lints or changing the evidence semantics. The writer still validates and records the same run receipt, S3 body hashes, physical shard census, process restart PIDs, and per-node listings.

## Verification
Tested commit: `7be726c8c722548933759ffd477e34e32ac731d5`, based on `release` commit `9aebcefa9c725912bf541048ff5be23fa37bdef7`.

- `cargo clippy --locked -p e2e_test --all-targets -j 4 -- -D warnings`: PASS. Covers the CI failure reported for `write_scanner_heal_evidence`.
- `cargo test --locked -p e2e_test --lib distributed::heal_test::three_node_four_drive_ec8_4_root_heal_rebuilds_replaced_drive_after_restart --no-run -j 4`: PASS.
- `cargo fmt --all --check`: PASS.
- `git diff --check`: PASS.

Not run: the real distributed EC8+4 e2e case. This PR is a lint/compile-safe refactor of the already registered evidence writer.

## Impact
No production runtime impact. This affects only the distributed e2e Scanner/Heal evidence producer and unblocks release PR checks that run `cargo clippy --all-targets -- -D warnings`.

## Additional Notes
Adversarial validation:

- Correctness: traced all original evidence inputs into the new payload and confirmed the writer still records the same receipt, object, shard, PID, and listing fields.
- Simplicity: grouped existing arguments into one local typed struct instead of adding a lint allowance.
- Test coverage: focused clippy reproduces the failed CI lint path; the target `--no-run` build proves the refactored async producer still compiles.
- Performance: no new I/O or allocations in production paths; the only structural change is an e2e-test payload object created once at evidence write time.

This PR intentionally keeps rustfs/backlog#2269 open because real mixed-version, durable replay, EC8+4 long-window ABBA, profile evidence, and multi-set/multi-pool evidence remain pending.
