### PR TITLE
test(heal): cover MRF idle checkpoint cleanup

### DIFF
--- a/crates/heal/src/heal/mrf_queue.rs
+++ b/crates/heal/src/heal/mrf_queue.rs
@@ -1138,6 +1138,7 @@ fn tick_action(dirty: bool, depth: usize, journal_on_disk: bool, retain_replay_j
 mod tests {
     use super::*;
     use rustfs_common::mrf_channel::{MrfIntent, MrfKind, MrfVerifiedRepairDisposition, MrfVerifiedRepairEvent};
+    use serial_test::serial;
     use std::sync::Arc as StdArc;
 
     fn intent(bucket: &str, object: &str, attempts: u8) -> MrfIntent {
@@ -1151,6 +1152,12 @@ mod tests {
             enqueued_at_ms: 1_700_000_000_000,
             attempts,
         }
+    }
+
+    fn encoded_payload(intent: &MrfIntent) -> Vec<u8> {
+        let mut payload = Vec::new();
+        assert!(encode_intent(intent, &mut payload), "fixture intent must encode");
+        payload
     }
 
     #[test]
@@ -1284,6 +1291,66 @@ mod tests {
             Some(ReplayCleanup::Legacy),
             "journals written by the runtime still use the legacy cleanup path"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial]
+    async fn runtime_idle_cleanup_deletes_runtime_and_replay_recovery_anchors() {
+        let _env = rustfs_test_utils::TestECStoreEnv::builder()
+            .prefix("rustfs_mrf_runtime_idle_cleanup")
+            .build()
+            .await;
+        let disks = journal_disks().await;
+        assert!(!disks.is_empty(), "test environment must register local disks");
+
+        let replay_owner = Uuid::new_v4();
+        let runtime_owner = Uuid::new_v4();
+        let config = MrfConsumerConfig::default();
+        let journal_max_bytes = config.journal_max_bytes;
+        let replay_payload = encoded_payload(&intent("cleanup-bucket", "replay-object", 0));
+        let runtime_payload = encoded_payload(&intent("cleanup-bucket", "runtime-object", 0));
+        snapshot::publish_committed_snapshot(&disks, replay_owner, 7, &replay_payload, journal_max_bytes)
+            .await
+            .expect("publish retained replay checkpoint");
+        snapshot::publish_committed_snapshot(&disks, runtime_owner, 8, &runtime_payload, journal_max_bytes)
+            .await
+            .expect("publish runtime checkpoint");
+        assert!(write_journal(MRF_SCOPED_JOURNAL_PATH, &runtime_payload).await);
+        assert!(write_journal(MRF_JOURNAL_PATH, &runtime_payload).await);
+
+        let mut runtime = MrfRuntime {
+            queue: MrfQueue::new(2, usize::MAX),
+            config,
+            checkpoint_owner: Uuid::new_v4(),
+            next_checkpoint_sequence: 9,
+            new_since_flush: 0,
+            dirty: false,
+            journal_on_disk: true,
+            retain_replay_journal: false,
+            durable_replay_anchors: Vec::new(),
+            replay_cleanup: Some(ReplayCleanup::Committed {
+                owner: replay_owner,
+                sequence: 7,
+            }),
+            runtime_checkpoint: Some((runtime_owner, 8)),
+            backoff_until: None,
+        };
+
+        assert!(
+            runtime.delete_idle_recovery_anchors().await,
+            "idle cleanup should remove both runtime and replay recovery anchors"
+        );
+        assert_eq!(runtime.replay_cleanup, None);
+        assert_eq!(runtime.runtime_checkpoint, None);
+        assert!(
+            snapshot::inspect_local_committed_snapshot(journal_max_bytes)
+                .await
+                .expect("inspect committed checkpoints after cleanup")
+                .is_none(),
+            "both committed checkpoint generations must be gone after idle cleanup"
+        );
+        assert_eq!(read_journal(MRF_SCOPED_JOURNAL_PATH).await, None);
+        assert_eq!(read_journal(MRF_JOURNAL_PATH).await, None);
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#2268.
Related to rustfs/backlog#2240.

## Summary of Changes
Adds a focused `rustfs-heal` regression test for the MRF runtime idle cleanup path.

The test publishes both a retained replay committed checkpoint and a runtime committed checkpoint on registered local disks, writes both scoped and legacy journal files, then calls `MrfRuntime::delete_idle_recovery_anchors()` and verifies that:

- the runtime checkpoint state is cleared;
- the retained replay cleanup state is cleared;
- no committed checkpoint generation remains inspectable;
- both scoped and legacy journal files are removed.

No production behavior changes are included.

## Verification
Tested commit: `20153fcd9a7cdcab8195b4fec701f69364ea0fb9`.

- `cargo fmt --all --check` passed.
- `cargo test --locked -p rustfs-heal --lib runtime_idle_cleanup_deletes_runtime_and_replay_recovery_anchors -j 4` passed; the new test fails if idle cleanup stops deleting either committed checkpoint generation or either journal path.
- `cargo test --locked -p rustfs-heal --lib mrf_queue -j 4` passed; all 65 focused MRF queue, snapshot, migration, and cleanup unit tests remained green.
- `cargo test --locked -p rustfs-heal --test mrf_pipeline_test -j 4 -- --test-threads=1` passed; all 15 MRF pipeline crash/replay tests remained green.
- `cargo check --locked -p rustfs-heal --lib -j 4` passed.
- `cargo clippy --locked -p rustfs-heal --all-targets -j 4 -- -D warnings` passed.
- `git diff --check` and `git diff --check origin/release..HEAD` passed.

Checks not run: real mixed-version writer/reader deployment, real rollback payload replay, real ENOSPC/disk-full matrix, full distributed crash matrix, long cleanup/GC soak, and release evidence bundle remain outside this test-only slice.

## Impact
Test-only change. No user-facing, API, wire-format, on-disk-format, deployment, or configuration impact is expected.

## Additional Notes
Adversarial validation:

- Correctness: attacked false-positive cleanup by requiring both runtime and retained replay committed checkpoints to disappear from real registered local disks, not only from in-memory state.
- Simplicity: kept the change to one reusable fixture encoder and one focused test; no production helper or abstraction was added.
- Test coverage: the new assertion set distinguishes runtime checkpoint deletion, retained replay cleanup deletion, scoped journal deletion, and legacy journal deletion.
- Concurrency/durability: the test uses `#[serial]` with the existing test environment pattern because MRF journal state is process-global, and it exercises the existing delete path after durable checkpoint publication.
- Compatibility: the test keeps both scoped and legacy journal cleanup in the same oracle, preserving the mixed legacy mirror cleanup expectation while real mixed-version deployment evidence remains pending.
