### PR TITLE
fix(e2e): ignore untracked files in build identity

### DIFF
--- a/crates/e2e_test/build.rs
+++ b/crates/e2e_test/build.rs
@@ -51,7 +51,7 @@ fn main() {
         }
     }
     let revision = git(&root, &["rev-parse", "HEAD"]).unwrap_or_else(|| "unknown".to_owned());
-    let dirty = git(&root, &["status", "--porcelain", "--untracked-files=normal"]).is_none_or(|status| !status.is_empty());
+    let dirty = git(&root, &["status", "--porcelain", "--untracked-files=no"]).is_none_or(|status| !status.is_empty());
     let lock = git(&root, &["hash-object", "Cargo.lock"]).unwrap_or_else(|| "unknown".to_owned());
     let mut features = std::env::vars()
         .filter_map(|(key, _)| {


### PR DESCRIPTION
## Summary
- align e2e_test build provenance with Scanner/Heal evidence receipts by using tracked-only dirty detection
- prevent unrelated untracked worktrees/evidence directories from making real evidence cases fail before the test body runs

## Failure Observed
- `scripts/run_scanner_heal_evidence_case.sh --case ec84-target-drive-restart` on `release@3fa2b334bea3e8a8643323d16624c4ea8549b34d` failed before the e2e body with `compiled test identity differs for dirty`
- the run receipt records tracked-source cleanliness, while `crates/e2e_test/build.rs` marked the compiled test binary dirty because of untracked workspace directories

## Validation
- PASS: `cargo fmt --all --check`
- PASS: `git diff --check`
- PASS: `cargo test --locked -p e2e_test --lib distributed::heal_test::three_node_four_drive_ec8_4_root_heal_rebuilds_replaced_drive_after_restart --no-run -j 4`

## Tracking
Part of rustfs/backlog#2269. This removes an evidence-runner provenance blocker; it does not by itself complete the real EC8+4 evidence run.