### PR TITLE
test(heal): cover MRF rollback mirror filtering

### DIFF
--- a/crates/heal/src/heal/mrf_queue.rs
+++ b/crates/heal/src/heal/mrf_queue.rs
@@ -1474,6 +1474,62 @@ mod tests {
     }
 
     #[test]
+    fn rollback_legacy_payload_omits_scoped_only_responsibilities() {
+        let mut scoped = intent("rollback-bucket", "scoped-only-object", 0);
+        scoped.kind = MrfKind::PartialWrite;
+        scoped.scope = Some(rustfs_common::mrf_channel::MrfScope {
+            pool_index: 3,
+            set_index: 7,
+        });
+        let compat = intent("rollback-bucket", "v1-compatible-object", 0);
+
+        let mut runtime = MrfRuntime {
+            queue: MrfQueue::new(4, usize::MAX),
+            config: MrfConsumerConfig::default(),
+            checkpoint_owner: Uuid::new_v4(),
+            next_checkpoint_sequence: 1,
+            new_since_flush: 0,
+            dirty: true,
+            journal_on_disk: false,
+            retain_replay_journal: false,
+            durable_replay_anchors: Vec::new(),
+            replay_cleanup: None,
+            runtime_checkpoint: None,
+            backoff_until: None,
+        };
+        assert_eq!(runtime.queue.try_push_typed(scoped.clone()), MrfQueuePushResult::Enqueued);
+        assert_eq!(runtime.queue.try_push_typed(compat.clone()), MrfQueuePushResult::Enqueued);
+
+        let (authoritative, legacy) = runtime.snapshot();
+        let (authoritative_decoded, authoritative_truncated) = decode_journal(&authoritative);
+        assert_eq!(authoritative_truncated, 0);
+        assert_eq!(authoritative_decoded.len(), 2);
+        assert!(
+            authoritative_decoded
+                .iter()
+                .any(|intent| intent.object.as_ref() == "scoped-only-object" && intent.scope == scoped.scope),
+            "new readers must retain the scoped partial-write responsibility"
+        );
+
+        let (legacy_decoded, legacy_truncated) = decode_journal(&legacy);
+        assert_eq!(legacy_truncated, 0);
+        assert_eq!(legacy_decoded.len(), 1, "rollback payload must contain one v1-compatible record");
+        let legacy_record = legacy_decoded.first().expect("one rollback-compatible record");
+        assert_eq!(legacy_record.bucket, compat.bucket);
+        assert_eq!(legacy_record.object, compat.object);
+        assert_eq!(legacy_record.version_id, compat.version_id);
+        assert_eq!(legacy_record.kind, compat.kind);
+        assert_eq!(legacy_record.scope, None);
+        assert_eq!(legacy_record.attempts, compat.attempts);
+        assert!(
+            !legacy
+                .windows(b"scoped-only-object".len())
+                .any(|window| window == b"scoped-only-object"),
+            "legacy rollback bytes must not disguise a scoped-only responsibility as an unscoped record"
+        );
+    }
+
+    #[test]
     fn mrf_dedupe_failure_releases_key_for_retry() {
         let mut queue = MrfQueue::new(1, usize::MAX);
         assert_eq!(queue.try_push_typed(intent("bucket", "object", 0)), MrfQueuePushResult::Enqueued);


### PR DESCRIPTION
## Related Issues
Related rustfs/backlog#2268.
Related rustfs/backlog#2240.

## Summary of Changes
- Adds a focused MRF rollback compatibility oracle for the runtime snapshot path.
- Verifies that the authoritative v2 checkpoint keeps scoped partial-write responsibilities for new readers while the legacy rollback mirror only carries v1-compatible unscoped responsibilities.
- Confirms the legacy rollback bytes do not silently disguise a scoped-only responsibility as an unscoped legacy record.

## Verification
- Commit tested: `0155a5f51780f89d31979cf3837d651b4b070e25`; task diff contains one committed test-only change in `crates/heal/src/heal/mrf_queue.rs`.
- `cargo fmt --all --check` passed.
- `cargo test --locked -p rustfs-heal --lib rollback_legacy_payload_omits_scoped_only_responsibilities -j 4` passed with 1 test passed.
- `cargo test --locked -p rustfs-heal --lib mrf_queue -j 4` passed with 66 tests passed.
- `cargo check --locked -p rustfs-heal --lib -j 4` passed.
- `cargo clippy --locked -p rustfs-heal --all-targets -j 4 -- -D warnings` passed.
- `git diff --check origin/release...HEAD` passed.
- Not run: real mixed-version writer/reader deployment, rollback to an older binary, distributed crash matrix, ENOSPC/disk-full matrix, and long-running cleanup/GC soak. Those remain W13 follow-up coverage, not evidence from this PR.

## Impact
Test-only. No runtime, API, configuration, or deployment behavior changes are expected.

## Additional Notes
- Adversarial validation: correctness, simplicity, compatibility, and test-coverage lenses found no implementation finding in this test-only diff.
- This closes one rollback-payload unit-test gap by making the legacy mirror filtering contract executable, while keeping the broader W13 durability matrix open.
