### PR TITLE
test(scanner): require MRF retention GC evidence

### DIFF
--- a/scripts/check_test_wiring.py
+++ b/scripts/check_test_wiring.py
@@ -214,6 +214,12 @@ SCANNER_HEAL_RELEASE_MIXED_VERSION_CASES = {
         "unknown-field-retained",
     ),
 }
+SCANNER_HEAL_RELEASE_P4_RETAINED_RESPONSIBILITY_CASES = (
+    "retain-pending-replay-anchor",
+    "verified-proof-discharges-anchor",
+    "idle-cleanup-reclaims-runtime-checkpoint",
+    "idle-cleanup-reclaims-replay-source",
+)
 SCANNER_HEAL_RELEASE_SCHEDULER_BOUNDS = (
     "admission-retry-idempotency",
     "deadline-budget",
@@ -1614,6 +1620,26 @@ def validate_release_bundle_domain_evidence(gate: str, field: str, evidence: dic
             for metric in ("recovery_p95_ms", "recovery_p99_ms"):
                 release_bundle_number(evidence.get(metric), f"{gate}.{field}.{metric}", 1)
 
+    if gate == "P4" and field == "retained_responsibility_evidence":
+        release_bundle_exact_strings(
+            evidence.get("retained_responsibility_cases"),
+            SCANNER_HEAL_RELEASE_P4_RETAINED_RESPONSIBILITY_CASES,
+            f"{gate}.{field}.retained_responsibility_cases",
+        )
+        retention_window = evidence_integer(
+            evidence.get("retention_window_seconds"),
+            f"{gate}.{field}.retention_window_seconds",
+            7200,
+            86400,
+        )
+        duration = evidence_integer(evidence.get("duration_seconds"), f"{gate}.{field}.duration_seconds", 1, 86400)
+        require(duration >= retention_window, f"{gate}.{field} duration must cover retention window")
+        release_bundle_bool_true(evidence.get("idle_cleanup_observed"), f"{gate}.{field}.idle_cleanup_observed")
+        release_bundle_bool_true(
+            evidence.get("verified_proof_discharge_observed"),
+            f"{gate}.{field}.verified_proof_discharge_observed",
+        )
+
 
 def validate_release_bundle_artifact(bundle_path: Path, source_revision: str, gate: str, field: str,
                                      evidence: dict[str, object]) -> str:
@@ -2214,6 +2240,15 @@ class SelfTests(unittest.TestCase):
                     evidence["cold_walked_segments"] = 0
                     evidence["full_walk_oracle_equivalent"] = True
                     evidence["published_root_equivalent"] = True
+                if gate == "P4" and field == "retained_responsibility_evidence":
+                    evidence["duration_seconds"] = 7200
+                    evidence["finished_at"] = (started + timedelta(seconds=7200)).isoformat().replace("+00:00", "Z")
+                    evidence["retained_responsibility_cases"] = list(
+                        SCANNER_HEAL_RELEASE_P4_RETAINED_RESPONSIBILITY_CASES
+                    )
+                    evidence["retention_window_seconds"] = 7200
+                    evidence["idle_cleanup_observed"] = True
+                    evidence["verified_proof_discharge_observed"] = True
                 if field == "profile_evidence":
                     evidence["resolved_samples"] = 1
                     evidence["allocation_bytes"] = 1024
@@ -2398,6 +2433,34 @@ class SelfTests(unittest.TestCase):
                 "cold_segment_reuse_measurement",
                 lambda item: item.update({"full_walk_oracle_equivalent": False}),
                 "full-walk oracle equivalence",
+            ),
+            (
+                "p4-retained-responsibility-cases",
+                "P4",
+                "retained_responsibility_evidence",
+                lambda item: item["retained_responsibility_cases"].remove("idle-cleanup-reclaims-replay-source"),
+                "retained_responsibility_cases missing cases",
+            ),
+            (
+                "p4-retention-window",
+                "P4",
+                "retained_responsibility_evidence",
+                lambda item: item.update({"retention_window_seconds": 7199}),
+                "retention_window_seconds",
+            ),
+            (
+                "p4-idle-cleanup",
+                "P4",
+                "retained_responsibility_evidence",
+                lambda item: item.update({"idle_cleanup_observed": False}),
+                "idle_cleanup_observed",
+            ),
+            (
+                "p4-proof-discharge",
+                "P4",
+                "retained_responsibility_evidence",
+                lambda item: item.pop("verified_proof_discharge_observed"),
+                "verified_proof_discharge_observed",
             ),
         ):
             with self.subTest(fault=fault), tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Related Issues

rustfs/backlog#2268
rustfs/backlog#2240

## Summary of Changes

This tightens the scanner/heal release bundle checker for the W13/P4 retained-responsibility boundary.

- Requires `P4.retained_responsibility_evidence` to enumerate the replay-anchor retention and idle cleanup/GC cases.
- Requires a measured retention window of at least two hours, with the field duration covering that window.
- Requires explicit observations for idle cleanup and verified-proof discharge.
- Extends the parser fixture and negative self-test matrix so missing cases, short windows, absent idle cleanup, or absent proof discharge block release approval.

No production runtime behavior changes.

## Verification

- PASS: `python3 scripts/check_test_wiring.py --self-test` ran 41 tests and accepted the complete measured fixture while rejecting the new P4 negative cases.
- PASS: `python3 scripts/check_test_wiring.py`
- PASS: `PYTHONPYCACHEPREFIX=/private/tmp/rustfs-pycache python3 -m py_compile scripts/check_test_wiring.py`
- PASS: `git diff --check`
- PASS: `git diff --check origin/release...HEAD`

Tested commit: `ebb567873`.

Not run: real two-hour retention soak, real distributed cleanup/GC run, real mixed-version deployment, ENOSPC/disk-full matrix, replica-loss matrix, and final release evidence bundle generation. This PR only hardens release approval requirements for those future artifacts.

## Impact

Release evidence bundles for P4 retained MRF responsibility must now provide explicit retention/cleanup cases and a two-hour retention window before approval. Runtime behavior, APIs, disk formats, and S3-visible behavior are unchanged.

## Additional Notes

Adversarial validation:

- Correctness: no blocking findings; the complete fixture remains approved, and the new P4 case/window/cleanup/proof-discharge omissions are rejected.
- Simplicity: no blocking findings; the change reuses the existing domain-evidence validator and self-test fixture shape.
- Test coverage: no blocking findings; reverting the validator additions or fixture fields breaks the new self-test subcases.
