### PR TITLE
fix(ci): bind performance runs to selected inputs

### DIFF
--- a/.github/workflows/rustfs-performance-test.yml
+++ b/.github/workflows/rustfs-performance-test.yml
@@ -82,6 +82,12 @@ jobs:
   performance-test:
     runs-on: pf-testing
     timeout-minutes: 900
+    env:
+      RUSTFS_BENCH_SCRIPT: ${{ github.workspace }}/auto-testing/rustfs_performance_testing.sh
+      RUSTFS_WARP_METHODS: ${{ inputs.test_method }}
+      RUSTFS_WARP_SIZES: ${{ inputs.object_size }}
+      RUSTFS_WARP_DURATION: ${{ inputs.warp_duration || '5m' }}
+      RUSTFS_WARP_CONCURRENCY: ${{ inputs.warp_concurrency || '64' }}
     # Run on manual dispatch, or when the nightly build completed successfully.
     # Skipped when nightly failed.
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' }}
@@ -158,19 +164,15 @@ jobs:
       - name: Run benchmark (GET/PUT/MIXED)
         id: benchmark
         run: |
-          # Empty on automatic (workflow_run) runs -> full 30 rounds.
-          # Manual dispatch can restrict method(s)/size(s).
-          export WARP_METHODS="${{ inputs.test_method }}"
-          export WARP_SIZES="${{ inputs.object_size }}"
           ./auto-testing/rustfs_performance_test.sh \
             --step 5 -y \
-            --warp-duration "${{ inputs.warp_duration || '5m' }}" \
-            --warp-concurrency "${{ inputs.warp_concurrency || '64' }}" \
             --log-file "${LOG_FILE}"
 
       - name: Analyze results
         if: ${{ steps.benchmark.conclusion == 'success' }}
         run: |
+          export WARP_METHODS="${RUSTFS_WARP_METHODS}" WARP_SIZES="${RUSTFS_WARP_SIZES}"
+          export WARP_DURATION="${RUSTFS_WARP_DURATION}" WARP_CONCURRENCY="${RUSTFS_WARP_CONCURRENCY}"
           ./auto-testing/rustfs_performance_test.sh --step 6 -y --log-file "${LOG_FILE:-/dev/null}"
 
       - name: Collect RustFS version info

--- a/scripts/test_security_workflow.py
+++ b/scripts/test_security_workflow.py
@@ -837,6 +837,55 @@ emit_step_result() {
             self.assertIn(value, contents)
         self.assertNotIn("OLD RUN EVIDENCE", contents)
 
+    def test_performance_commands_bind_runner_selection_and_preserve_failures(self) -> None:
+        self.prepare("performance")
+        source = self.source.splitlines()
+        job = yaml_block(source, "performance-test", 2)
+        runner = WorkflowSteps()
+        runner.directory = self.directory / "workspace with spaces"
+        scripts = runner.directory / "auto-testing"
+        scripts.mkdir(parents=True)
+        wrapper = scripts / "rustfs_performance_test.sh"
+        wrapper.write_text(f"#!{sys.executable}\nimport json, os, sys\n" +
+                           "print(json.dumps({'args': sys.argv[1:], 'env': {key: os.environ.get(key) for key in " +
+                           "('RUSTFS_BENCH_SCRIPT', 'RUSTFS_WARP_METHODS', 'RUSTFS_WARP_SIZES', " +
+                           "'RUSTFS_WARP_DURATION', 'RUSTFS_WARP_CONCURRENCY', 'WARP_METHODS', " +
+                           "'WARP_SIZES', 'WARP_DURATION', 'WARP_CONCURRENCY')}}))\n" +
+                           "sys.exit(int(os.environ['FAKE_BENCH_EXIT']))\n")
+        wrapper.chmod(0o755)
+        runner.steps = named_steps(job)
+        for methods, sizes, duration, concurrency in (
+            ("get", "1KiB", "1s", "7"), ("all", "all", "5m", "64"), ("", "", "5m", "64")
+        ):
+            runner.context = {"github.workspace": str(runner.directory), "inputs.test_method": methods,
+                              "inputs.object_size": sizes, "inputs.warp_duration || '5m'": duration,
+                              "inputs.warp_concurrency || '64'": concurrency}
+            runner.env = {**self.env, "RUSTFS_BENCH_SCRIPT": "/unverified/home-script.sh",
+                          "RUSTFS_WARP_METHODS": "put", "RUSTFS_WARP_SIZES": "64MiB",
+                          "RUSTFS_WARP_DURATION": "99h", "RUSTFS_WARP_CONCURRENCY": "2",
+                          "WARP_DURATION": "88h", "WARP_CONCURRENCY": "3", "WARP_METHODS": "mixed", "WARP_SIZES": "32MiB",
+                          "LOG_FILE": str(self.directory / "suite.log")}
+            runner.env.update(runner.step_env(job, indent=4))
+            for step, number in (("Run benchmark (GET/PUT/MIXED)", "5"), ("Analyze results", "6")):
+                for code in (0, 42):
+                    with self.subTest(methods=methods, sizes=sizes, step=step, exit=code):
+                        runner.env["FAKE_BENCH_EXIT"] = str(code)
+                        result = runner.run_step(step)
+                        self.assertEqual(result.returncode, code, result.stderr)
+                        invocation = json.loads(result.stdout)
+                        expected = ["--step", number, "-y", "--log-file", runner.env["LOG_FILE"]]
+                        self.assertEqual(invocation["args"], expected)
+                        self.assertEqual(invocation["env"]["RUSTFS_BENCH_SCRIPT"], str(scripts / "rustfs_performance_testing.sh"))
+                        self.assertEqual(invocation["env"]["RUSTFS_WARP_METHODS"], methods)
+                        self.assertEqual(invocation["env"]["RUSTFS_WARP_SIZES"], sizes)
+                        self.assertEqual(invocation["env"]["RUSTFS_WARP_DURATION"], duration)
+                        self.assertEqual(invocation["env"]["RUSTFS_WARP_CONCURRENCY"], concurrency)
+                        if number == "6":
+                            self.assertEqual(invocation["env"]["WARP_METHODS"], methods)
+                            self.assertEqual(invocation["env"]["WARP_SIZES"], sizes)
+                            self.assertEqual(invocation["env"]["WARP_DURATION"], duration)
+                            self.assertEqual(invocation["env"]["WARP_CONCURRENCY"], concurrency)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Related Issues

Part of rustfs/backlog#2297. Uses the benchmark failure handling already merged in rustfs/auto-testing#39.

## Summary of Changes

The performance workflow exports method and size selections under names that its wrapper replaces from inherited runner settings. On a runner with `RUSTFS_WARP_METHODS=put`, a manual GET request can therefore execute PUT; an automatic full run can succeed after only one round. The wrapper also prefers an executable benchmark script under the runner's home directory, and a rebuilt report can lose the selected methods, sizes, duration, and concurrency.

Bind the benchmark script to the `auto-testing` checkout and supply workflow inputs through the wrapper's existing `RUSTFS_WARP_*` variables. Pass the same selection and budget values into result analysis. Reuse the existing workflow fixture for one regression covering manual, all, and automatic selections, a workspace path containing spaces, inherited setting conflicts, and exit statuses 0 and 42.

## Verification

Validated commit `0914466ac034e219e65343c0aa924398a7357369` against main `73957d0faf74ccb3c1354915230078467df4e6ec`; patch SHA-256 is `b17937818dfc2d8553a1924617e2c6fca4e86cd763d8b61424ef6ba118c6071f`.

- `./scripts/python_bin.sh -B scripts/test_security_workflow.py`: 21 tests passed. The new regression fails against the unchanged main workflow. Ten deliberate runner, namespace, selection, and budget regressions are caught by both this public test and execution through the current private scripts.
- Executed the actual workflow benchmark and analysis commands against `auto-testing@8b1b968a614a841f445a3e7e926b291c70f040ac`, using its existing fake-Warp fixture and blocked remote-command boundaries. Before the change, the home script ran, a manual GET request executed inherited PUT, and automatic inputs could pass with one round. After the change, GET/1KiB/1s/7 and MIXED/4KiB/250ms/19 each execute the requested round; blank automatic inputs execute all 30 rounds at 5m/64 despite inherited settings. Forced report reconstruction retains the same selection and budget metadata. Failed benchmark rounds remain nonzero.
- `./scripts/python_bin.sh -B scripts/check_test_wiring.py`, `actionlint .github/workflows/rustfs-performance-test.yml`, `cargo +1.98.0 fmt --all --check`, and `git diff --check`: passed.

This is a bounded workflow invocation change. No Rust build or full workspace gate was run because Rust compilation targets and CI lane selection are unchanged. No live SSH, VM operation, package installation, or real performance benchmark was executed.

## Impact

Performance execution and reconstructed reports honor the same workflow inputs. The runner's home-directory script and inherited selection values no longer replace them. Existing cleanup, shared VM concurrency, package selection, and failure propagation remain in place.

## Additional Notes

Execution is bound to the checked-out script path. Immutable private revision binding remains a separate dependency. The private clone still follows its default branch, and package identity and complete nightly-chain evidence remain separate follow-ups. This change alone does not establish that nightly coverage can replace required PR checks.
