### PR TITLE
test(storage): cover MRF cleanup delete ENOSPC anchor

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -22601,6 +22601,56 @@ mod test {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn conditional_mrf_manifest_storage_full_delete_keeps_recovery_anchors() {
+        use tempfile::tempdir;
+
+        const MRF_COMMIT_MANIFEST_SLOT_0: &str = ".heal-mrf-commit.0.bin";
+        const MRF_SCOPED_JOURNAL_PATH: &str = "buckets/.heal/mrf/journal-scoped.bin";
+
+        let _mode = durability_mode_override::set(DurabilityMode::Relaxed);
+        let dir = tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+        let committed_manifest = Bytes::from_static(b"mrf-committed-manifest-v1");
+        let legacy_journal = Bytes::from_static(b"legacy-mrf-journal-records");
+
+        assert_eq!(
+            disk.compare_and_update_file(RUSTFS_META_BUCKET, MRF_COMMIT_MANIFEST_SLOT_0, None, Some(committed_manifest.clone()),)
+                .await
+                .expect("committed MRF manifest should publish"),
+            ConditionalFileUpdate::Updated
+        );
+        disk.write_all(RUSTFS_META_BUCKET, MRF_SCOPED_JOURNAL_PATH, legacy_journal.clone())
+            .await
+            .expect("legacy MRF journal should be retained");
+
+        let manifest_path = disk
+            .get_object_path(RUSTFS_META_BUCKET, MRF_COMMIT_MANIFEST_SLOT_0)
+            .expect("MRF manifest path should resolve");
+        let parent = manifest_path.parent().expect("MRF manifest path should have a parent");
+        os::fsync_dir_recorder::set_failure(parent, ErrorKind::StorageFull);
+
+        let err = disk
+            .compare_and_update_file(RUSTFS_META_BUCKET, MRF_COMMIT_MANIFEST_SLOT_0, Some(committed_manifest.clone()), None)
+            .await
+            .expect_err("storage-full fsync failure must fail the MRF manifest cleanup delete");
+        assert!(matches!(err, DiskError::Io(ref err) if err.kind() == ErrorKind::StorageFull));
+        assert_eq!(
+            disk.read_all(RUSTFS_META_BUCKET, MRF_COMMIT_MANIFEST_SLOT_0)
+                .await
+                .expect("committed MRF manifest should be restored after failed cleanup delete"),
+            committed_manifest
+        );
+        assert_eq!(
+            disk.read_all(RUSTFS_META_BUCKET, MRF_SCOPED_JOURNAL_PATH)
+                .await
+                .expect("legacy MRF journal should remain readable after failed cleanup delete"),
+            legacy_journal
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn conditional_file_update_dir_fsync_failure_removes_new_file_without_anchor() {
         use tempfile::tempdir;
 


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#2268
Related to rustfs/backlog#2240

## Summary of Changes
This adds a focused regression test for the durable MRF cleanup delete boundary.

- Inject a `StorageFull` directory fsync failure while deleting an MRF committed manifest through the local disk CAS path.
- Verify the cleanup delete fails visibly and the committed manifest is restored.
- Verify the retained scoped legacy journal remains readable after the failed cleanup delete.

No production behavior, public API, configuration, or on-disk format changes are included.

## Verification
Validated commit `76dd2d51832d6da3a7c84ef421b44e60142a513f` on `origin/release` at `ae9fe62fb13c1233fa7a3a9a619df718df99ead0`.

- `cargo fmt --all --check`
- `git diff --check`
- `git diff --check origin/release...HEAD`
- `cargo test --locked -p rustfs-ecstore conditional_mrf_manifest_storage_full_delete_keeps_recovery_anchors -j 4`
  - 1 passed; 0 failed; 5335 filtered out.
  - The linker emitted the existing large `__eh_frame` warning.

Not run: real filesystem ENOSPC/fill-to-full, distributed cleanup/GC soak, replica-loss matrix, mixed-version writer/reader deployment, rollback to an old binary, or the full release evidence bundle.

## Impact
Test-only hardening for MRF cleanup durability. The new oracle catches cleanup delete paths that might otherwise treat an unflushed manifest removal as successful and lose a recoverable MRF anchor.

## Additional Notes
W13 remains open. This PR covers one narrow cleanup-delete failure oracle and does not replace the remaining real ENOSPC, distributed crash, replica-loss, mixed-version, rollback, cleanup/GC soak, or final release-evidence gates.
