### PR TITLE
test(scanner): require MRF cleanup delete ENOSPC evidence

### DIFF
--- a/scripts/check_test_wiring.py
+++ b/scripts/check_test_wiring.py
@@ -170,6 +170,7 @@ SCANNER_HEAL_RELEASE_G08_REQUIRED_CASES = {
         "payload-write-enospc",
         "manifest-write-enospc",
         "journal-write-enospc",
+        "cleanup-delete-enospc",
     ),
     "replica_loss_matrix": (
         "single-replica-loss",
@@ -2641,7 +2642,13 @@ class SelfTests(unittest.TestCase):
             ("versions", "G09", "mixed_version_reader_evidence", lambda item: item.update({"versions": [1, 2]}), "mixed-version"),
             ("stale-versions", "G09", "mixed_version_writer_evidence", lambda item: item.update({"versions": ["a" * 40, "c" * 40]}), "tested source revision"),
             ("g08-capacity-cases", "G08", "mrf_capacity_evidence", lambda item: item.update({"capacity_cases": ["queue-count-limit"]}), "missing cases"),
-            ("g08-disk-full-cases", "G08", "disk_full_matrix", lambda item: item.pop("disk_full_cases"), "non-empty string list"),
+            (
+                "g08-disk-full-cases",
+                "G08",
+                "disk_full_matrix",
+                lambda item: item["disk_full_cases"].remove("cleanup-delete-enospc"),
+                "missing cases",
+            ),
             ("g08-replica-loss-cases", "G08", "replica_loss_matrix", lambda item: item.update({"replica_loss_cases": ["single-replica-loss"]}), "missing cases"),
             ("g07-responsibility-cases", "G07", "mrf_responsibility_oracle", lambda item: item.update({"mrf_responsibility_cases": ["legacy-journal-replay"]}), "missing cases"),
             ("g07-crash-cases", "G07", "commit_boundary_crash_matrix", lambda item: item.pop("commit_crash_cases"), "non-empty string list"),


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#2268
Related to rustfs/backlog#2240

## Summary of Changes
This tightens the Scanner/Heal release bundle validator for W13 G08 disk-full evidence.

- Require `cleanup-delete-enospc` in the G08 `disk_full_matrix` case list.
- Extend the release bundle self-test so removing that case fails with the existing missing-case guard.

This follows the MRF cleanup delete ENOSPC oracle added in rustfs/rustfs#7513 and keeps the final release evidence bundle from omitting that cleanup phase.

## Verification
Validated commit `5bb8293bdcb51d7a8c568bb510b772f5e789fe6d` against `origin/release`.

- `python3 scripts/check_test_wiring.py --self-test`
  - 42/42 passed.
- `python3 scripts/check_test_wiring.py`
  - passed.
- `PYTHONPYCACHEPREFIX=/private/tmp/rustfs-pycache python3 -m py_compile scripts/check_test_wiring.py`
  - passed.
- `git diff --check`
  - passed.

Not run: real filesystem ENOSPC/fill-to-full, distributed replica-loss matrix, mixed-version writer/reader deployment, rollback to an old binary, cleanup/GC soak, or the full release evidence bundle.

## Impact
Test-wiring only. Release approval now requires cleanup-delete ENOSPC evidence in addition to payload, manifest, and journal ENOSPC cases.

## Additional Notes
W13 remains open. This PR hardens required release evidence and does not replace the remaining real ENOSPC, distributed crash, replica-loss, mixed-version, rollback, cleanup/GC soak, or final release-evidence gates.
