### PR TITLE
fix(scanner): replay recovery intents while disabled

### DIFF
--- a/crates/scanner/src/scanner.rs
+++ b/crates/scanner/src/scanner.rs
@@ -964,9 +964,10 @@ async fn run_scanner_usage_recovery_intents_for_startup(
     Ok(attempted)
 }
 
-/// Start normal scanning when enabled, or one resume-only cleanup attempt.
+/// Start normal scanning when enabled, or one bounded recovery attempt.
 /// The disabled branch returns a finite task for the startup owner to join;
-/// it never enables ordinary namespace scanning or accepts a new reset intent.
+/// it never enables ordinary namespace scanning while it replays durable reset
+/// intents and cleanup markers.
 pub async fn init_scanner_with_recovery(
     ctx: CancellationToken,
     storeapi: Arc<ECStore>,
@@ -988,6 +989,17 @@ pub async fn init_scanner_with_recovery(
         return None;
     }
     Some(tokio::spawn(async move {
+        if let Err(error) = run_scanner_usage_recovery_intents_for_startup(ctx.clone(), storeapi.clone()).await {
+            warn!(
+                target: "rustfs::scanner",
+                event = EVENT_SCANNER_PERSIST_STATE,
+                component = LOG_COMPONENT_SCANNER,
+                subsystem = LOG_SUBSYSTEM_RUNTIME,
+                state = "recovery_intent_startup_discovery_failed",
+                error = %error,
+                "Scanner recovery intent startup discovery failed"
+            );
+        }
         if let Err(error) = resume_scanner_cycle_cleanup(ctx, storeapi).await {
             warn!(
                 target: "rustfs::scanner",

--- a/crates/scanner/src/scanner/tests/recovery_control.rs
+++ b/crates/scanner/src/scanner/tests/recovery_control.rs
@@ -551,7 +551,7 @@ async fn scanner_recovery_intent_startup_rejects_corrupt_pending_record() {
 
 #[tokio::test]
 #[serial]
-async fn scanner_recovery_intent_disabled_startup_preserves_non_terminal_intent() {
+async fn scanner_recovery_intent_disabled_startup_replays_non_terminal_intent() {
     let (_dir, store) = setup_scanner_cycle_store().await;
     let record = match accept_scanner_usage_recovery_intent(
         store.clone(),
@@ -567,12 +567,12 @@ async fn scanner_recovery_intent_disabled_startup_preserves_non_terminal_intent(
     let restarted = restart_scanner_cycle_store_from(&store).await;
     run_disabled_startup(CancellationToken::new(), restarted.clone()).await;
 
-    let preserved = get_scanner_usage_recovery_intent(restarted, &record.intent_id)
+    let completed = get_scanner_usage_recovery_intent(restarted, &record.intent_id)
         .await
-        .expect("startup-skipped intent should read")
-        .expect("startup-skipped intent should remain durable");
-    assert_eq!(preserved.state, "accepted");
-    assert_eq!(preserved.intent_id, record.intent_id);
+        .expect("startup-replayed intent should read")
+        .expect("startup-replayed intent should remain durable");
+    assert_eq!(completed.state, "completed");
+    assert_eq!(completed.intent_id, record.intent_id);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Replay durable scanner usage recovery intents during disabled scanner startup before cleanup marker resume.
- Keep ordinary namespace scanning disabled while preserving the bounded startup recovery path.
- Update the recovery-control regression test to assert that a non-terminal durable intent completes across restart even when scanner scheduling is disabled.

## Related

- Advances rustfs/backlog#2240.
- Advances rustfs/backlog#2279.

## Validation

- `cargo test --locked -p rustfs-scanner --lib scanner_recovery_intent -j 4`
- `cargo fmt --all --check`
- `git diff --check origin/release...HEAD`
- `./scripts/check_logging_guardrails.sh`
- `scripts/python_bin.sh scripts/check_test_wiring.py --self-test`
- `scripts/run_scanner_heal_evidence_case.sh --self-test`

## Remaining Evidence

- Real OS-crash/fsync restart evidence is still required for the full #2279 gate.
- Cross-process restart evidence, mixed-version fleet validation, and full release-bundle evidence remain outside this local fix.

---

Thank you for your contribution! We will review and get back to you as soon as possible.

Please make sure you have read our contributing guide:

https://github.com/rustfs/rustfs/blob/main/CONTRIBUTING.md
