### PR TITLE
fix(scanner): keep G09 source binary path clean

### DIFF
--- a/scripts/run_scanner_heal_g09_upgrade_evidence.sh
+++ b/scripts/run_scanner_heal_g09_upgrade_evidence.sh
@@ -168,7 +168,7 @@ ensure_default_asset_platform() {
 
 verify_sha256() {
     local archive="$1"
-    if command -v sha256sum >/dev/null 2>&1; then
+    if command -v sha256sum >/dev/null 2>&1 && [[ "$(sha256sum --help 2>&1)" == *"--check"* ]]; then
         printf '%s  %s\n' "$SOURCE_SHA256" "$archive" | sha256sum --check --strict
     elif command -v shasum >/dev/null 2>&1; then
         printf '%s  %s\n' "$SOURCE_SHA256" "$archive" | shasum -a 256 --check
@@ -232,7 +232,7 @@ resolve_source_binary() {
     local archive="$SOURCE_DIR/$SOURCE_ASSET"
     curl --fail --location --retry 3 --output "$archive" \
         "https://github.com/$SOURCE_REPOSITORY/releases/download/$SOURCE_VERSION/$SOURCE_ASSET"
-    verify_sha256 "$archive"
+    verify_sha256 "$archive" >&2
     unzip -q "$archive" -d "$SOURCE_DIR"
     chmod +x "$binary"
     test -x "$binary"
@@ -422,6 +422,18 @@ run_self_test() {
     fi
 
     mkdir -p "$tmp/run/mixed-version-upgrade" "$tmp/run/bucket-config-rollback"
+    mkdir -p "$tmp/source"
+    local archive checksum checksum_output
+    archive="$tmp/source/$SOURCE_ASSET"
+    printf 'not a real archive\n' >"$archive"
+    if command -v shasum >/dev/null 2>&1; then
+        checksum="$(shasum -a 256 "$archive" | awk '{print $1}')"
+    else
+        checksum="$(sha256sum "$archive" | awk '{print $1}')"
+    fi
+    checksum_output="$(SOURCE_SHA256="$checksum" verify_sha256 "$archive")"
+    [[ "$checksum_output" == *"OK"* ]]
+
     local current previous
     current="$(git rev-parse HEAD)"
     previous="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#2269 and rustfs/backlog#2240.

## Summary of Changes

Fix the Scanner/Heal G09 upgrade evidence runner so checksum verification output cannot pollute the resolved previous-release binary path.

`resolve_source_binary` is used inside command substitution, so it must write only the executable path to stdout. The checksum `OK` line now goes to stderr/log output. The same script also tolerates non-GNU `sha256sum` during lightweight self-tests by falling back to `shasum` when GNU `--check` support is unavailable.

The branch was created from `release`; `origin/main` was already up to date with this release head.

## Verification

- PASS: `bash -n scripts/run_scanner_heal_g09_upgrade_evidence.sh`
- PASS: `scripts/run_scanner_heal_g09_upgrade_evidence.sh --self-test`
- PASS: `CARGO_TARGET_DIR=relative-target scripts/run_scanner_heal_g09_upgrade_evidence.sh --plan-only --run-dir target/g09-plan --source-binary /tmp/rustfs-prev`
- PASS: `git diff --check`

Azure validation will run the full G09 mixed-version and rollback evidence lanes against this PR head.

## Impact

No runtime behavior change. This fixes release-validation tooling so the G09 runner passes a clean previous-release binary path into the upgrade E2E tests.

## Additional Notes

N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
