### PR TITLE
test(odm): wait for pull counters before status assertions

### DIFF
--- a/crates/e2e_test/src/on_demand_migration/interaction_test.rs
+++ b/crates/e2e_test/src/on_demand_migration/interaction_test.rs
@@ -1137,7 +1137,12 @@ async fn test_odm_admin_config_is_redacted_and_status_counts_match_the_source() 
         let miss = env.raw_get(bucket, miss_key).await?;
         assert_eq!(miss.status, 404, "{}", String::from_utf8_lossy(&miss.body));
     }
-    assert!(env.wait_local_listed(bucket, hit_key, SETTLE).await?);
+    let (listed, _, _) = tokio::try_join!(
+        env.wait_local_listed(bucket, hit_key, SETTLE),
+        env.wait_for_status_counter(bucket, "/counters/pulled_objects_total/inline", 1, SETTLE),
+        env.wait_for_status_counter(bucket, "/counters/pulled_bytes_total", body.len() as u64, SETTLE),
+    )?;
+    assert!(listed);
 
     let status = env.status_json(bucket).await?;
     assert_eq!(status.pointer("/configured").and_then(Value::as_bool), Some(true), "{status}");


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#2401. Follow-up to the quality acceptance audit in rustfs/backlog#2297.

## Summary of Changes

The ODM admin status test can observe an object in the local listing before the background pull records its object and byte counters. The E2E smoke failure on #7512 captured exactly that state: the inline completion count was zero while one pull was still in flight.

Await local visibility and both completion counters using the existing polling helpers concurrently, then take the existing fresh status snapshot and assert the same exact values. The test keeps its existing settle window, redaction checks, request counts and source-journal assertions.

## Verification

- The original E2E smoke job on `0914466ac034e219e65343c0aa924398a7357369` failed at the inline object-count assertion (181 passed, 1 failed). Its test file and the relevant ODM implementation match the base used for this correction. The recorded failure is consistent with the traced completion ordering; it does not prove that a subsequent counter update occurred.
- Independent correctness and simplicity review checked separate object/byte updates, permanently missing or insufficient counts, duplicate counts, local visibility, error propagation and cancellation. A source comparison confirms the entire test file is unchanged outside the readiness block; exact assertions are preserved. Formatting and diff checks passed.
- On clean commit `eab754aa9968df6f53a86ada30747d9c5893f31f`, `cargo build --locked -p rustfs --bin rustfs` succeeded, then `CARGO_BIN_EXE_rustfs=<the explicitly built binary> cargo nextest run --locked --no-tests=fail -p e2e_test -E 'test(=on_demand_migration::interaction_test::test_odm_admin_config_is_redacted_and_status_counts_match_the_source)' -j 1` passed the real-server test in 8.53 seconds (one selected test; no retry). The binary SHA256 is `ed40162a62e06c324866401e258ae26ee189c53381b64eeca30f38d0013ae78d`; Rust 1.98.0/default features and loopback proxy isolation were used. `cargo +1.98.0 fmt --all --check` and `git diff --check` passed. This test-only change uses focused validation; no new full-workspace gate was run, and a deterministic local reproduction of the original timing window is not claimed.

## Impact

Test-only change. The existing polling helpers keep their cooperative deadline and error handling; this change does not introduce a hard HTTP timeout. Permanent missing counts still fail, and the final exact assertions continue to reject over-counting.

## Additional Notes

The patch adds no helper, fixed delay, retry policy, quarantine or production-code change.
