### PR TITLE
test(scanner): list full P4 release evidence fields

### DIFF
--- a/.config/scanner-heal-required-tests.json
+++ b/.config/scanner-heal-required-tests.json
@@ -318,6 +318,9 @@
       "description": "Measured MRF scale and replay cost with retained responsibility",
       "requires": ["MRF scale measurement", "MRF replay-cost measurement", "retained responsibility evidence", "cleanup/GC soak evidence"],
       "evidence_fields": [
+        "mrf_scale_measurement",
+        "mrf_replay_cost_measurement",
+        "retained_responsibility_evidence",
         "mrf_cleanup_gc_soak_evidence"
       ]
     },

--- a/scripts/check_test_wiring.py
+++ b/scripts/check_test_wiring.py
@@ -77,6 +77,9 @@ SCANNER_HEAL_RELEASE_REQUIRED_EVIDENCE_FIELDS = {
         "distributed_segment_invalidation_evidence",
     ),
     "P4": (
+        "mrf_scale_measurement",
+        "mrf_replay_cost_measurement",
+        "retained_responsibility_evidence",
         "mrf_cleanup_gc_soak_evidence",
     ),
     "P2": (
@@ -102,12 +105,7 @@ SCANNER_HEAL_RELEASE_BUNDLE_REQUIRED_EVIDENCE_FIELDS = {
     "P1": ("cold_walk_share_measurement", "foreground_latency_throughput_measurement", "profile_evidence"),
     "P2": SCANNER_HEAL_RELEASE_REQUIRED_EVIDENCE_FIELDS["P2"],
     "P3": ("two_hour_pressure_measurement", "heal_capacity_measurement", "recovery_window_measurement"),
-    "P4": (
-        "mrf_scale_measurement",
-        "mrf_replay_cost_measurement",
-        "retained_responsibility_evidence",
-        "mrf_cleanup_gc_soak_evidence",
-    ),
+    "P4": SCANNER_HEAL_RELEASE_REQUIRED_EVIDENCE_FIELDS["P4"],
     "R-E": ("fixed_budget_restart_evidence", "enumeration_evidence", "classification_evidence"),
     "R-D": ("manager_disposition_evidence", "event_disposition_evidence", "ledger_disposition_evidence", "grace_handling"),
     "R-L": ("legacy_source_conflict_evidence", "migration_gap_evidence", "crash_safe_source_retirement_evidence"),
@@ -3430,7 +3428,10 @@ class SelfTests(unittest.TestCase):
             self.assertIn("segment_activation_preflight", requirements["G11"]["evidence_fields"])
             self.assertIn("distributed_segment_invalidation_evidence", requirements["G14"]["evidence_fields"])
             self.assertIn("cold_segment_reuse_measurement", requirements["P2"]["evidence_fields"])
-            self.assertIn("mrf_cleanup_gc_soak_evidence", requirements["P4"]["evidence_fields"])
+            self.assertEqual(
+                tuple(requirements["P4"]["evidence_fields"]),
+                SCANNER_HEAL_RELEASE_REQUIRED_EVIDENCE_FIELDS["P4"],
+            )
 
     def test_scanner_heal_required_evidence_fields_cannot_be_removed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Related Issues
rustfs/backlog#2268
rustfs/backlog#2240

## Summary of Changes
Align the Scanner/Heal P4 release requirement fields with the P4 release bundle gate.

The registry already described P4 as requiring MRF scale, replay cost, retained responsibility, and cleanup/GC soak evidence, and the release bundle gate already required all four artifacts. The public release requirement field list only exposed `mrf_cleanup_gc_soak_evidence`, which made the closure checklist less strict than the gate that reviewers actually run.

This change lists all four P4 evidence fields in `.config/scanner-heal-required-tests.json` and makes the Python checker use the same constant for the P4 release requirement and bundle requirement.

## Verification
Tested commit: `001c1a8fd356dfdcc46b83a1a456f59f57f3f517`

- `python3 scripts/check_test_wiring.py --self-test`: PASS, 48 tests
- `PYTHONPYCACHEPREFIX=/tmp/rustfs-w13-p4-pycache python3 -m py_compile scripts/check_test_wiring.py`: PASS
- `git diff --check origin/release...HEAD`: PASS

Not run: Cargo tests, because this is a JSON/Python release gate metadata change with no Rust runtime or crate source changes.

## Impact
No runtime or S3 API behavior change.

Scanner/Heal release readiness reporting now keeps P4 visible as a four-artifact measured evidence gate: scale, replay cost, retained responsibility, and cleanup/GC soak.

## Additional Notes
This does not close W13 by itself. It tightens the final release checklist before the remaining measured evidence is collected and assembled.
