### PR TITLE
test(scanner): bind MRF release artifacts to evidence kinds

### DIFF
--- a/scripts/check_test_wiring.py
+++ b/scripts/check_test_wiring.py
@@ -129,6 +129,17 @@ SCANNER_HEAL_RELEASE_MRF_DURABLE_REPLAY_FIELDS = {
     ("P4", "retained_responsibility_evidence"),
     ("P4", "mrf_cleanup_gc_soak_evidence"),
 }
+SCANNER_HEAL_RELEASE_MRF_ARTIFACT_KINDS = {
+    ("G07", "mrf_responsibility_oracle"): "mrf-durable-responsibility-oracle",
+    ("G07", "commit_boundary_crash_matrix"): "mrf-commit-boundary-crash-matrix",
+    ("G08", "mrf_capacity_evidence"): "mrf-capacity-boundary",
+    ("G08", "disk_full_matrix"): "mrf-disk-full-enospc-matrix",
+    ("G08", "replica_loss_matrix"): "mrf-replica-loss-matrix",
+    ("P4", "mrf_scale_measurement"): "mrf-scale-measurement",
+    ("P4", "mrf_replay_cost_measurement"): "mrf-replay-cost-measurement",
+    ("P4", "retained_responsibility_evidence"): "mrf-retained-responsibility-soak",
+    ("P4", "mrf_cleanup_gc_soak_evidence"): "mrf-cleanup-gc-soak",
+}
 SCANNER_HEAL_SEGMENT_ACTIVATION_FAIL_CLOSED_CHECKS = (
     "missing_producer_identity",
     "restart_gap",
@@ -1580,6 +1591,10 @@ def validate_release_bundle_json_artifact_payload(path: Path, source_revision: s
     require(payload.get("field") == field, f"{prefix} JSON artifact field mismatch")
     if artifact_kind is not None:
         require(payload.get("artifact_kind") == artifact_kind, f"{prefix} JSON artifact kind mismatch")
+    mrf_artifact_kind = SCANNER_HEAL_RELEASE_MRF_ARTIFACT_KINDS.get((gate, field))
+    if mrf_artifact_kind is not None:
+        require(payload.get("artifact_kind") == mrf_artifact_kind,
+                f"{prefix} JSON artifact kind must be {mrf_artifact_kind}")
     mirror_fields = release_bundle_json_artifact_mirrored_fields(gate, field)
     for mirror_field in mirror_fields:
         require(mirror_field in payload, f"{prefix} JSON artifact missing {mirror_field}")
@@ -2805,6 +2820,9 @@ class SelfTests(unittest.TestCase):
                     "gate": gate,
                     "field": field,
                 }
+                mrf_artifact_kind = SCANNER_HEAL_RELEASE_MRF_ARTIFACT_KINDS.get((gate, field))
+                if mrf_artifact_kind is not None:
+                    artifact_payload["artifact_kind"] = mrf_artifact_kind
                 for mirror_field in release_bundle_json_artifact_mirrored_fields(gate, field):
                     artifact_payload[mirror_field] = evidence[mirror_field]
                 write_json(artifact, artifact_payload)
@@ -3174,6 +3192,12 @@ class SelfTests(unittest.TestCase):
                 lambda payload: payload.update({"fixture": True}),
                 ("G08", "disk_full_matrix"),
                 "JSON artifact is fixture",
+            ),
+            (
+                "mrf-artifact-kind",
+                lambda payload: payload.update({"artifact_kind": "generic-json"}),
+                ("G08", "disk_full_matrix"),
+                "JSON artifact kind must be mrf-disk-full-enospc-matrix",
             ),
             (
                 "g08-case-mirror",


### PR DESCRIPTION
## Related Issues
rustfs/backlog#2268
rustfs/backlog#2240

## Summary of Changes
Require Scanner/Heal G07/G08/P4 JSON artifacts to declare the exact MRF evidence kind expected for each release-bundle field.

This prevents a generic measured JSON artifact from satisfying durable replay, commit-boundary crash, capacity, ENOSPC, replica-loss, MRF scale, replay-cost, retained-responsibility, or cleanup-GC soak gates. The self-test fixture now emits those artifact kinds, and the JSON artifact provenance test covers the fail-closed path for a mismatched MRF artifact kind.

## Verification
Tested commit: `0e5a639bfb88e7633915320dec8bb16e8f006b6f`

- `python3 scripts/check_test_wiring.py --self-test`: PASS, 48 tests
- `PYTHONPYCACHEPREFIX=/tmp/rustfs-w13-mrf-kind-pycache python3 -m py_compile scripts/check_test_wiring.py`: PASS
- `git diff --check origin/release...HEAD`: PASS

Not run: Cargo tests, because this is a Python release-bundle checker change with no Rust runtime or crate source changes.

## Impact
No runtime or S3 API behavior change.

The release bundle checker is stricter for MRF hard-evidence lanes. Existing valid MRF JSON artifacts must include the field-specific `artifact_kind` value listed by this patch.

## Additional Notes
This does not close W13 by itself. It makes the final evidence gate more specific before the remaining measured distributed crash, ENOSPC/capacity, replica-loss, mixed-version/rollback, cleanup-GC soak, and bundle verification work is completed.