### PR TITLE
test(scanner): run scoped fallback cases on dedicated stack

### DIFF
--- a/crates/scanner/src/scanner_io/tests/scoped_entry_fallback.rs
+++ b/crates/scanner/src/scanner_io/tests/scoped_entry_fallback.rs
@@ -226,9 +226,40 @@ fn record_segment_dirty_usage(bucket: &str) {
     }
 }
 
-#[tokio::test]
+// The scoped fallback fixture keeps two EC pools and several scan futures live
+// at once. Run the async cases on a dedicated stack so Linux libtest defaults
+// exercise the assertions instead of aborting before the oracle finishes.
+fn run_scoped_entry_fallback_test<F, Fut>(thread_name: &'static str, test_fn: F)
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()> + 'static,
+{
+    let handle = std::thread::Builder::new()
+        .name(thread_name.to_string())
+        .stack_size(32 * 1024 * 1024)
+        .spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("scoped entry fallback runtime should build");
+            runtime.block_on(test_fn());
+        })
+        .expect("scoped entry fallback test thread should spawn");
+    if let Err(payload) = handle.join() {
+        std::panic::resume_unwind(payload);
+    }
+}
+
+#[test]
 #[serial]
-async fn scoped_entry_fallback_distinguishes_planned_scope_from_real_cold_walks() {
+fn scoped_entry_fallback_distinguishes_planned_scope_from_real_cold_walks() {
+    run_scoped_entry_fallback_test(
+        "scanner-scoped-entry-planned-scope",
+        scoped_entry_fallback_distinguishes_planned_scope_from_real_cold_walks_case,
+    );
+}
+
+async fn scoped_entry_fallback_distinguishes_planned_scope_from_real_cold_walks_case() {
     let (_dir, store) = setup_two_pool_scanner_store().await;
     clear_dirty_usage_buckets_for_tests();
     let hot = format!("hot-{}", Uuid::new_v4().simple());
@@ -251,9 +282,16 @@ async fn scoped_entry_fallback_distinguishes_planned_scope_from_real_cold_walks(
     clear_dirty_usage_buckets_for_tests();
 }
 
-#[tokio::test]
+#[test]
 #[serial]
-async fn scoped_entry_fallback_rejects_invalid_persisted_baseline_at_the_walker() {
+fn scoped_entry_fallback_rejects_invalid_persisted_baseline_at_the_walker() {
+    run_scoped_entry_fallback_test(
+        "scanner-scoped-entry-invalid-baseline",
+        scoped_entry_fallback_rejects_invalid_persisted_baseline_at_the_walker_case,
+    );
+}
+
+async fn scoped_entry_fallback_rejects_invalid_persisted_baseline_at_the_walker_case() {
     let (_dir, store) = setup_two_pool_scanner_store().await;
     clear_dirty_usage_buckets_for_tests();
     let hot = format!("hot-{}", Uuid::new_v4().simple());
@@ -310,9 +348,16 @@ async fn scoped_entry_fallback_rejects_invalid_persisted_baseline_at_the_walker(
     clear_dirty_usage_buckets_for_tests();
 }
 
-#[tokio::test]
+#[test]
 #[serial]
-async fn scoped_entry_fallback_covers_overflow_and_new_bucket_inventory() {
+fn scoped_entry_fallback_covers_overflow_and_new_bucket_inventory() {
+    run_scoped_entry_fallback_test(
+        "scanner-scoped-entry-overflow-inventory",
+        scoped_entry_fallback_covers_overflow_and_new_bucket_inventory_case,
+    );
+}
+
+async fn scoped_entry_fallback_covers_overflow_and_new_bucket_inventory_case() {
     let (_dir, store) = setup_two_pool_scanner_store().await;
     clear_dirty_usage_buckets_for_tests();
     let hot = format!("hot-{}", Uuid::new_v4().simple());


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#2240
Refs rustfs/backlog#2269

## Summary of Changes

The scanner scoped-entry fallback tests can overflow Linux libtest's default stack after the segment reuse activation gate enabled deeper two-pool EC-store fixtures. This keeps the production code unchanged and wraps those three async fixture cases in the repository's existing dedicated-stack test pattern.

The tests now execute their assertions under default `cargo test` on Linux instead of requiring callers to set `RUST_MIN_STACK`.

## Verification

- Before this fix, `release@a4b265bf` failed on Azure Linux x86_64 with `cargo test --locked -p rustfs-scanner --lib scoped_entry_fallback -j 2 -- --nocapture`: `scoped_entry_fallback_covers_overflow_and_new_bucket_inventory` aborted with stack overflow.
- `cargo fmt --all --check` passed.
- `cargo test --locked -p rustfs-scanner --lib scoped_entry_fallback -j 2 -- --nocapture` passed locally: 3 passed, 0 failed.
- Azure Linux x86_64 PR-head `65540580a` passed the same default-stack command: 3 passed, 0 failed.
- `git diff --check` passed.

Remaining risk: this is a test-only stability fix. It does not expand the scanner production behavior matrix beyond the scoped fallback cases that exposed the Linux stack issue.

## Impact

Test-only. No runtime, API, configuration, or compatibility impact.

## Additional Notes

The fix mirrors the dedicated-stack pattern already used by larger EC-store and scanner integration fixtures.
