### PR TITLE
test(ci): reserve runner capacity for bounded rollback probe

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -197,6 +197,12 @@ test-group = 'e2e-cluster-nightly'
 filter = 'package(e2e_test) & (test(/^kms::kms_vault_test::/) | test(/^kms::kms_rekey_sweep_test::/) | test(/^kms::configured_roundtrip_test::test_configured_vault_kms_admin_and_versioned_cleanup$/))'
 test-group = 'e2e-vault'
 
+# This four-disk, 65-member rollback probe already drives up to 32 concurrent
+# durable deletions. Reserve this nextest run's capacity for its progress oracle.
+[[profile.default.overrides]]
+filter = 'package(rustfs-ecstore) & test(=store::init::tests::dispatch_manifest_rollback_bounded_concurrency_reaches_tail_behind_slow_member)'
+threads-required = "num-test-threads"
+
 # ---------------------------------------------------------------------------
 # ci profile — the strict CI gate (ci.yml `cargo nextest run --profile ci`)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#2297 and rustfs/backlog#2410. The timeout investigation remains open.

## Summary of Changes

The bounded rollback regression creates 65 journal members on four disks and drives up to 32 durable deletions while holding the first member. Give this one test `threads-required = "num-test-threads"` so it is scheduled without overlapping other test executions in the same nextest run while measuring tail progress. The default override also applies to the CI profile.

## Verification

Final configuration: `8c5577e1506d5eb606fb237a5d99e31b49e0999d`, based on `789f1832a408507a96d5811225040fb42ddaa9c3`.

- `cargo +1.98.0 fmt --all --check` and `git diff --check` passed. Parsing the final TOML and removing its single new override exactly reproduces the base configuration; Rust sources, test selection, deadlines, assertions and retries are unchanged.
- The final effective TOML equals the previously exercised candidate. Captured nextest events from three controlled, zero-retry runs showed target overlap under the original configuration and target exclusivity under both candidate `default` and `ci` profiles; all three selected tests passed in each run. These scheduling experiments used the retained Darwin ecstore harness `66d178a75a22776f`, built from `9ecb500c` plus diagnostic-only patch SHA256 `6e61db0e87707063a0b2e75ae2b788c62b1f1984c0c7b78c1024d14b948c34a8` with `default,gcs,test-util`, rather than claiming a fresh build of this PR. The diagnostic patch is excluded from this PR.
- Final configuration parsing, exact single-test selection and independent correctness, simplicity and coverage checks are recorded for this diff. This bounded runner-scheduling change does not change compilation or the test matrix; broad Cargo compilation and `make pre-pr` were not repeated.

## Impact

One test reserves the runner's configured test capacity. Its internal concurrency, 65-member fixture, both 30-second assertions, cleanup checks and zero-remote-delete assertion remain intact. Other tests retain their existing scheduling rules.

## Additional Notes

This establishes a test resource contract, not a demonstrated root-cause fix for #2410. It does not isolate unrelated host processes or the fixture's own background recovery, and it does not waive the earlier failed local E2E validation gate. The original failure evidence remains in the linked issue.
