### PR TITLE
docs: fix invalid docker-buildx.sh usage example in README and README_ZH

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,10 @@ For developers who want to build RustFS Docker images from source with multi-arc
 
 ```bash
 # Build multi-architecture images locally
-./docker-buildx.sh --build-arg RELEASE=latest
+./docker-buildx.sh
+
+# Build a single-platform image locally
+./docker-buildx.sh -p linux/amd64
 
 # Build and push to registry
 ./docker-buildx.sh --push

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -150,7 +150,10 @@ docker compose -f docker-compose-simple.yml up -d
 
 ```bash
 # 在本地构建多架构镜像
-./docker-buildx.sh --build-arg RELEASE=latest
+./docker-buildx.sh
+
+# 在本地构建单平台镜像
+./docker-buildx.sh -p linux/amd64
 
 # 构建并推送到仓库
 ./docker-buildx.sh --push


### PR DESCRIPTION

## Related Issues

N/A (docs cleanup)

## Summary of Changes

The README and README_ZH "Build from Source (Option 3)" sections showed
`./docker-buildx.sh --build-arg RELEASE=latest` as the first example. The
script's own CLI never accepted `--build-arg` (it is only an internal flag
passed through to `docker buildx build`), so the command exits immediately
with:

```
❌ Unknown option: --build-arg
```

This change replaces that broken example with invocations the script
actually supports:

- bare `./docker-buildx.sh` — default local build (kept the "multi-architecture
  images locally" comment as-is for now)
- `./docker-buildx.sh -p linux/amd64` — explicit single-platform local build

in both `README.md` and `README_ZH.md`.

## Verification

Docs-only change. Verified the fix against the script on this branch:

```
$ ./docker-buildx.sh --build-arg RELEASE=latest
❌ Unknown option: --build-arg        # old example fails immediately
```

The replacement invocations parse cleanly:

```
$ ./docker-buildx.sh --help
  -p, --platforms PLATFORMS  Target platforms (default: linux/amd64,linux/arm64)
  --push                     Push images to registry
  --release VERSION          Specify release version (default: auto-detect from git)
```

No full image build was run (docs-only; no CI behavior touched).

## Impact

Documentation only. No user-facing, API, compatibility, deployment, or
configuration impact.

## Additional Notes

Open question for maintainers, to be discussed on the PR:

The surrounding copy still reads "Build multi-architecture images locally"
for the bare `./docker-buildx.sh` invocation. In the default config the
script builds with `--platform linux/amd64,linux/arm64` and, when not
pushing, adds `--load` — and the docker exporter does not support loading
multi-platform images into the local Docker daemon unless the containerd
image store is enabled. So "multi-arch *locally*" is arguably not reachable
by the script as written.

Two candidate directions:

1. Rephrase the local example as single-platform (e.g. document
   `-p linux/amd64` as *the* local build) and state that multi-arch output
   requires `--push`.
2. Or keep `./docker-buildx.sh` as the "build all variants" local default
   (as its usage text says: "Build all variants locally") and add an
   explicit note that multi-architecture images are pushed, not loaded.

Happy to adjust this PR to whichever framing the maintainers prefer.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
