### PR TITLE
docs(obs): correct metric export interval and explain alert timing

### DIFF
--- a/crates/obs/README.md
+++ b/crates/obs/README.md
@@ -122,7 +122,11 @@ All configuration is read from environment variables at startup.
 | `RUSTFS_OBS_PROFILING_EXPORT_ENABLED` | `false`   | Toggle profiling export                                    |
 | `RUSTFS_OBS_USE_STDOUT`               | `false`   | Mirror all signals to stdout alongside OTLP                |
 | `RUSTFS_OBS_SAMPLE_RATIO`             | `0.1`     | Trace sampling ratio `0.0`–`1.0`                           |
-| `RUSTFS_OBS_METER_INTERVAL`           | `15`      | Metrics export interval (seconds)                          |
+| `RUSTFS_OBS_METER_INTERVAL`           | `30`      | Metrics export interval (seconds)                          |
+
+The export interval is separate from application metric collection. Without interval overrides, node/disk metrics refresh every 60 seconds (`RUSTFS_METRICS_NODE_INTERVAL_SEC`), cluster metrics every 60 seconds (`RUSTFS_METRICS_CLUSTER_INTERVAL_SEC`), and per-bucket metrics every 300 seconds (`RUSTFS_METRICS_BUCKET_INTERVAL_SEC`). See the [collection defaults](src/metrics/config.rs) and [interval configuration](src/metrics/scheduler.rs) for collector-specific and global overrides.
+
+With OTLP → Collector → Prometheus, the time from a failure to an alert also includes underlying health detection, collection and export work, transport and Collector batching, Prometheus `scrape_interval` and `evaluation_interval`, and any alert rule `for` duration. A shorter scrape interval cannot refresh a value that RustFS has not yet collected and exported. These periodic intervals do not guarantee a fixed detection or alert latency; see the [Prometheus alert rule documentation](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) for the role of `for`.
 
 ### Service identity
 


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#2419.

## Summary of Changes

The observability README lists a 15-second metric export interval, while the implementation defaults to 30 seconds. Correct the documented default and distinguish it from the 60-second node/disk and cluster collection intervals and the 300-second per-bucket collection interval.

Explain how health detection, collection, OTLP export, Collector batching, Prometheus scraping and evaluation, and an alert rule's `for` duration contribute to alert latency. These intervals do not guarantee a fixed detection or alert time.

## Verification

Validated the documentation diff committed as `1eba6c017309cdff569d9b32ce067f5c633ddf63`:

- `git diff --check` — passed.
- `bash scripts/check_doc_paths.sh` — passed.
- Cross-checked the export and collection defaults against the release implementation.

Rust compilation and tests were skipped under the documentation-only verification tier.

## Impact

Documentation only; runtime behavior and configured intervals are unchanged. The change helps operators interpret monitoring freshness and alert timing.

## Additional Notes

The health-refresh optimization discussed in rustfs/backlog#2419 remains deferred. This PR documents current behavior and does not close that issue.
