### PR TITLE
fix(nightly): push assets with plain git — the build fleet has no gh CLI

### DIFF
--- a/.github/workflows/nightly-gnu.yml
+++ b/.github/workflows/nightly-gnu.yml
@@ -372,15 +372,18 @@ jobs:
             [ -f "$f" ] || { echo "missing package: $f"; exit 1; }
           done
 
+          # Plain git + token URL: the build fleet has no gh CLI.
+          ASSETS_URL="https://x-access-token:${ASSETS_TOKEN}@github.com/rustfs/auto-testing.git"
           rm -rf assets-work && mkdir assets-work
-          if ! gh repo clone rustfs/auto-testing assets-work -- --depth 1 --branch assets --quiet 2>/dev/null; then
+          if git clone -q --depth 1 --branch assets "${ASSETS_URL}" assets-work 2>/dev/null; then
+            echo "assets branch cloned"
+          else
             echo "assets branch does not exist yet; creating an orphan"
-            ( cd assets-work && git init -q -b assets )
+            git -C assets-work init -q -b assets
           fi
           cd assets-work
-          git remote add origin "https://github.com/rustfs/auto-testing.git" 2>/dev/null || \
-            git remote set-url origin "https://github.com/rustfs/auto-testing.git"
-          gh auth setup-git >/dev/null
+          git remote add origin "${ASSETS_URL}" 2>/dev/null || \
+            git remote set-url origin "${ASSETS_URL}"
 
           mkdir -p nightly
           cp "../${DEB_FILE}" "nightly/${DEB_FILE}"


### PR DESCRIPTION
Caught by verification run [34324039335](https://github.com/rustfs/rustfs/actions/runs/34324039335) (nightly from `release`): the build, DEB, RPM, artifacts and the R2 upload all succeeded, but `Publish packages to auto-testing assets` failed with:

```
assets branch does not exist yet; creating an orphan
/home/runner/_work/_temp/...sh: line 21: gh: command not found
```

Two problems, one root cause: the `sm-standard-4` build fleet has no `gh` binary (functional-chain workflows that use gh run on the jumpbox, not here). The credential-helper setup died with 127, and the earlier `gh repo clone` failure had been masked by `2>/dev/null`, misleading the step into the orphan path.

Fix: clone the assets branch and set the remote with plain `git` and the token embedded in the URL (`https://x-access-token:${TOKEN}@github.com/...`). No gh dependency anywhere in the step; push semantics unchanged (single-commit orphan, force push).