### PR TITLE
fix(kms): prevent transient health failures from latching status

### DIFF
--- a/crates/kms/src/service_manager.rs
+++ b/crates/kms/src/service_manager.rs
@@ -577,13 +577,16 @@ impl KmsServiceManager {
         Some(service_version.probe_worker.as_ref()?.status())
     }
 
-    /// Health check for the KMS service
+    /// Check backend health without changing the service lifecycle state.
+    ///
+    /// A transient backend failure leaves the published service available for
+    /// subsequent checks and operations. Readiness uses the background probe
+    /// to evaluate backend availability independently of lifecycle state.
     pub async fn health_check(&self) -> Result<bool> {
         let checked_state = self.state.load_full();
         match checked_state.current_service.as_ref() {
             Some(service_version) => {
                 let manager = service_version.manager.clone();
-                let checked_version = service_version.version;
                 // Perform health check on the backend
                 match manager.health_check().await {
                     Ok(healthy) => {
@@ -594,8 +597,6 @@ impl KmsServiceManager {
                     }
                     Err(e) => {
                         error!("KMS health check error: {}", e);
-                        let _guard = self.lifecycle_mutex.lock().await;
-                        self.mark_health_error_if_current(checked_version, &e);
                         Err(e)
                     }
                 }
@@ -738,17 +739,6 @@ impl KmsServiceManager {
             cancel,
             task: std::sync::Mutex::new(Some(task)),
         }))
-    }
-
-    fn mark_health_error_if_current(&self, checked_version: u64, error: &KmsError) {
-        let current = self.state.load_full();
-        if current.current_service.as_ref().map(|version| version.version) == Some(checked_version) {
-            self.state.store(Arc::new(RuntimeState {
-                config: current.config.clone(),
-                status: KmsServiceStatus::Error(format!("Health check failed: {error}")),
-                current_service: current.current_service.clone(),
-            }));
-        }
     }
 }
 
@@ -1002,19 +992,6 @@ mod tests {
         assert_eq!(manager.get_service_version().await, Some(first_version));
         assert_eq!(manager.start_or_restart(true).await.expect("forced restart"), KmsStartOutcome::Restarted);
         assert!(manager.get_service_version().await.expect("restarted version") > first_version);
-    }
-
-    #[tokio::test]
-    async fn stale_health_failure_cannot_poison_new_service_status() {
-        let manager = KmsServiceManager::new();
-        manager.configure(static_config("key-a", 0x11)).await.expect("configure");
-        manager.start().await.expect("start");
-        let old_version = manager.get_service_version().await.expect("old version");
-        manager.restart().await.expect("restart");
-
-        manager.mark_health_error_if_current(old_version, &KmsError::backend_error("stale failure"));
-
-        assert_eq!(manager.get_status().await, KmsServiceStatus::Running);
     }
 
     #[tokio::test]

--- a/crates/kms/tests/behavior_resilience.rs
+++ b/crates/kms/tests/behavior_resilience.rs
@@ -76,6 +76,44 @@ fn unreachable_vault_config() -> KmsConfig {
 }
 
 #[tokio::test]
+async fn transient_health_failure_does_not_latch_the_service_status() {
+    let kms = TestKms::local().await;
+    let manager = kms.manager();
+    let service = manager.get_encryption_service().await.expect("running service");
+    let version = manager.get_service_version().await.expect("running version");
+    assert!(manager.health_check().await.expect("initial backend health"));
+
+    // Move only this test's keys out of reach, then restore the same backend.
+    let key_dir = kms.key_dir().expect("local key directory");
+    let outage = tempfile::TempDir::new().expect("temporary outage directory");
+    let hidden_keys = outage.path().join("keys");
+    tokio::fs::rename(&key_dir, &hidden_keys)
+        .await
+        .expect("make backend unavailable");
+    let failure = manager.health_check().await;
+    let outage_status = manager.get_status().await;
+    tokio::fs::rename(&hidden_keys, &key_dir).await.expect("restore backend");
+
+    assert!(failure.is_err(), "the outage must surface as a health-check error");
+    assert!(manager.health_check().await.expect("backend recovers without restart"));
+    assert!(Arc::ptr_eq(
+        &service,
+        &manager.get_encryption_service().await.expect("service survives the outage")
+    ));
+    assert_eq!(manager.get_service_version().await, Some(version));
+    assert_eq!(
+        manager.get_status().await,
+        KmsServiceStatus::Running,
+        "a recovered backend must not leave service-status and readiness latched in Error"
+    );
+    assert_eq!(
+        outage_status,
+        KmsServiceStatus::Running,
+        "backend health does not change the running service's lifecycle state"
+    );
+}
+
+#[tokio::test]
 async fn starting_against_an_unreachable_backend_fails_without_publishing_a_service() {
     let manager = KmsServiceManager::new();
     let config = unreachable_vault_config();


### PR DESCRIPTION
## Related Issues

Fixes #7554.

## Summary of Changes

A transient backend health-check error previously set the KMS service status to `Error` permanently, even after the backend recovered. The admin status endpoint then skipped subsequent checks, and readiness continued to reject the node despite successful background probes.

Keep immediate health-check results separate from the running service lifecycle state. Backend errors still propagate to callers, while subsequent admin checks can report recovery without restarting KMS. Remove the obsolete status mutation helper and its helper-specific test, and add a public-API regression test that makes a Local backend temporarily unavailable and restores it without replacing the service instance or version.

## Verification

Tested the source committed as `35675296d80cf4719f2f2fa6a70e1024d24e25ad`; the working tree is clean.

- Before the fix, `cargo test -p rustfs-kms --test behavior_resilience transient_health_failure_does_not_latch_the_service_status -- --exact --nocapture` failed at the recovery assertion: the backend health check succeeded, but the service status remained `Error("Health check failed: Backend error: Key directory does not exist")`. The regression passes after the fix and also asserts that lifecycle status remains `Running` during the outage.
- `cargo test -p rustfs-kms --test behavior_resilience --test behavior_lifecycle --test behavior_concurrency` passed all 23 tests. `cargo test -p rustfs-kms --lib service_manager::tests` passed 16 tests; the existing live AWS test remained ignored. Test commands bypassed proxies for localhost.
- `cargo fmt --all --check` and `git diff --check` passed. No live Vault outage or HTTP admin end-to-end test was run; the regression exercises the shared service-manager path through the Local backend. No rotation or versioning behavior changes.

## Impact

For an already running service, an immediate backend error is reported through the health-check result (`healthy: false` in the admin response), while lifecycle status remains `Running`. Startup/configuration errors retain their existing behavior. Readiness continues to use the existing background-probe policy, and a transient admin check can no longer permanently override recovery. There are no response schema, configuration, or persisted-format changes.

Rollback: revert this commit; doing so restores the status-latching behavior.

## Additional Notes

Thanks to @stevapple for reporting this issue and providing a detailed diagnosis, production observations, and reproduction steps.

Two sequential final-diff review passes completed: correctness — errors still propagate and recovery remains observable; simplicity — remove the status side effect without introducing recovery state; test coverage — confirmed failing-before/passing-after behavior and existing lifecycle checks; concurrency — health checks no longer mutate shared lifecycle state or overwrite a newer service; compatibility — response shapes are unchanged, with the intended status semantics described above. No additional findings.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
