### PR TITLE
fix(scanner): stabilize retired backlog survivor commits

### DIFF
--- a/crates/scanner/src/scanner/backlog.rs
+++ b/crates/scanner/src/scanner/backlog.rs
@@ -1100,7 +1100,23 @@ fn select_scanner_pause_backlog_replicas(replicas: Vec<ScannerPauseBacklogReplic
         });
     };
 
-    let stable_matches_ledger = matches!(&stable_consensus, Ok(Some(stable)) if stable == &selected);
+    let stable_matches_ledger = match &authoritative_commit {
+        Some(committed) => {
+            committed.ledger == selected
+                && committed.replicas.iter().all(|id| {
+                    replicas.iter().any(|replica| {
+                        replica.id == *id
+                            && matches!(
+                                &replica.state,
+                                ScannerPauseBacklogReplicaState::Valid(record)
+                                    if record.stable.as_ref() == Some(&selected)
+                                        && record.committed.as_ref() == Some(committed)
+                            )
+                    })
+                })
+        }
+        None => matches!(&stable_consensus, Ok(Some(stable)) if stable == &selected),
+    };
     let healthy_replicas = replicas
         .iter()
         .filter(|replica| {
@@ -1901,12 +1917,35 @@ mod tests {
             .await
             .expect("fresh native disk selection");
         assert_eq!(&loaded.ledger, expected, "membership repair preserves every ledger field");
-        assert!(loaded.durable && loaded.stable_matches_ledger);
+        assert!(
+            loaded.durable && loaded.stable_matches_ledger,
+            "unexpected loaded state: persistence_state={}, durable={}, stable_matches_ledger={}, healthy_replicas={}, stale_or_unavailable_replicas={}",
+            loaded.persistence_state,
+            loaded.durable,
+            loaded.stable_matches_ledger,
+            loaded.healthy_replicas,
+            loaded.stale_or_unavailable_replicas
+        );
         assert_eq!(loaded.healthy_replicas, 4);
         let committed = loaded.authoritative_commit.expect("complete current cohort proof");
-        assert_eq!(committed.replicas, scanner_pause_backlog_replica_ids(&loaded.replicas));
-        for set in store.scanner_pause_backlog_writable_set_disks().await {
-            let (bytes, _) = native_replica_bytes(&set).await;
+        let mut healthy_ids = loaded
+            .replicas
+            .iter()
+            .filter_map(|replica| {
+                matches!(
+                    &replica.state,
+                    ScannerPauseBacklogReplicaState::Valid(record)
+                        if record.stable.as_ref() == Some(expected)
+                            && record.committed.as_ref() == Some(&committed)
+                )
+                .then_some(replica.id)
+            })
+            .collect::<Vec<_>>();
+        healthy_ids.sort_unstable();
+        assert_eq!(committed.replicas, healthy_ids);
+        for id in &committed.replicas {
+            let set = &store.pools[id.pool_index].disk_set[id.set_index];
+            let (bytes, _) = native_replica_bytes(set).await;
             let ScannerPauseBacklogReplicaState::Valid(record) = decode_scanner_pause_backlog_ledger(&bytes) else {
                 panic!("native survivor record");
             };


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#2240 and rustfs/backlog#2268.

## Summary of Changes

Scanner pause-backlog native retirement can leave retired source replicas missing while every surviving committed member already stores the same stable and committed record. The selector previously treated those missing retired replicas as part of the stable consensus, leaving the loaded state as unstable even though the authoritative survivor commit was complete.

This changes `stable_matches_ledger` to use the authoritative commit membership when a commit exists, while still reporting topology repair through `membership_repair_pending`. The native retirement test helper now verifies the survivor commit members instead of expecting deleted source replicas to remain readable.

## Verification

Tested commit: 1ab8eedcd0 on top of rustfs/rustfs@cf41b1d3cf873a74a783c41b98a9f916291da57a.

Failing before this fix on Linux x86_64, at rustfs/rustfs@ca876930b30bb79eac392021d29691c79d8bb146:
- `cargo test --locked -p rustfs-scanner --lib native_retirement -j 2` selected 10 tests; 8 passed and 2 failed:
  - `native_retirement_bootstraps_an_unacknowledged_first_claim_and_retries_partial_commit`
  - `native_retirement_partial_native_phases_resume_from_persisted_authority`

Passing after this fix on Linux x86_64:
- `cargo test --locked -p rustfs-scanner --lib native_retirement -j 2`: 10 passed
- `cargo test --locked -p rustfs-scanner --lib backlog::tests -j 2`: 37 passed
- `cargo test --locked -p rustfs-heal --lib root_recovery -j 2`: 29 passed
- `cargo test --locked -p rustfs-ecstore --lib scanner_backlog -j 2`: 5 passed
- `cargo test --locked -p rustfs-scanner --lib segment_reuse_activation -j 2`: 8 passed
- `cargo test --locked -p rustfs-scanner --lib scanner_durable_segment_invalidation_evidence -j 2`: 1 passed
- `cargo test --locked -p rustfs-scanner --lib completed_data_usage_info_carries_segment_invalidation_proof_to_set_state -j 2`: 1 passed
- `cargo test --locked -p rustfs-scanner --lib scoped_entry_fallback -j 2 -- --nocapture`: 3 passed
- `cargo test --locked -p rustfs-data-usage --lib set_state_segment_invalidation_proof_is_additive -j 2`: 1 passed
- `cargo fmt --all --check`: passed
- `git diff --check`: passed
- `python3 scripts/check_test_wiring.py`: passed
- `scripts/check_no_planning_docs.sh`: passed

Not rerun after this fix: full G09/W13 release evidence bundle. Earlier source-bound runs passed on ancestor release revisions, but current-head closure still needs a fresh release bundle after this PR lands.

## Impact

No API or format change. This preserves scanner pause-backlog survivor authority during native pool retirement recovery and avoids treating already-retired missing source replicas as an unstable survivor commit.

## Additional Notes

N/A
