### PR TITLE
test(ecstore): remove redundant transition clone

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/legacy_transition_state_reconcile.rs
+++ b/crates/ecstore/src/bucket/lifecycle/legacy_transition_state_reconcile.rs
@@ -1078,7 +1078,7 @@ mod tests {
             tier_generation: 1,
         };
         let digest = response_digest(&source, &sets, &target).expect("valid source digest");
-        let mut changed = source.clone();
+        let mut changed = source;
         changed.remote_object.push_str("-changed");
         assert_ne!(digest, response_digest(&changed, &sets, &target).expect("changed source digest"));
     }


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#2240. Helps unblock release-base Scanner/Heal queue CI where the existing release branch hit `clippy::redundant_clone` in the legacy transition state reconcile tests.

## Summary of Changes

Remove an unnecessary clone in the `digest_binds_source_sets_and_target` regression. The test computes the digest from the original source and then mutates a changed copy; the original value is no longer used afterward, so moving it into `changed` preserves the same assertion while satisfying warnings-denied Clippy lanes.

No production path, API, disk format, compatibility contract, or reconciliation behavior changes.

## Verification

Tested commit: `b67e3c411763b04c1e9a4dfe1bb1ccecfece5c49`, based on `release` at `8be1e9b2c15707393196cfcffa40fff78e0c484d`.

- `cargo clippy -p rustfs-ecstore --lib --tests -- -D warnings`: passed.
- `cargo test -p rustfs-ecstore --lib digest_binds_source_sets_and_target --locked -j 6`: passed, 1/1.
- `cargo test -p rustfs-ecstore --lib legacy_transition_state_reconcile --locked -j 6`: passed, 16/16.
- `cargo fmt --all --check`: passed.
- `git diff --check origin/release...HEAD`: passed.

Not run: Linux live validation, full workspace test matrix, performance benchmarks, or Scanner/Heal distributed evidence gates. This is a test-only lint cleanup for the current release branch.

## Impact

Release CI lanes that deny Clippy warnings should no longer fail on this existing test clone. Runtime behavior and operator workflows are unchanged.

## Additional Notes

The failure was observed in release-base CI jobs as `clippy::redundant_clone` for `legacy_transition_state_reconcile.rs`. The same queue still needs its normal downstream CI and review before merge.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
