### PR TITLE
fix(heal): retry fully recoverable batch failures

### DIFF
--- a/crates/heal/src/heal/manager.rs
+++ b/crates/heal/src/heal/manager.rs
@@ -536,14 +536,14 @@ fn completed_status_is_retrying(status: &HealTaskStatus) -> bool {
     matches!(status, HealTaskStatus::Retrying { .. })
 }
 
-fn retry_budget_for_result(task: &HealTask, result: &Result<()>) -> Option<(Duration, String)> {
+fn retry_budget_for_result(task: &HealTask, result: &Result<()>, retryable_batch_failure: bool) -> Option<(Duration, String)> {
     let Err(err) = result else {
         return None;
     };
     if task.retry_attempts >= MAX_RECOVERABLE_HEAL_RETRIES {
         return None;
     }
-    if task.has_batch_failure() {
+    if task.has_batch_failure() && !retryable_batch_failure {
         return None;
     }
 
@@ -559,12 +559,13 @@ fn retry_budget_for_result(task: &HealTask, result: &Result<()>) -> Option<(Dura
 
 #[cfg(test)]
 fn retry_request_for_result(task: &HealTask, result: &Result<()>) -> Option<(HealRequest, Duration, String)> {
-    let (delay, error) = retry_budget_for_result(task, result)?;
+    let (delay, error) = retry_budget_for_result(task, result, false)?;
     Some((task.retry_request(), delay, error))
 }
 
 async fn retry_request_for_result_with_budget(task: &HealTask, result: &Result<()>) -> Option<(HealRequest, Duration, String)> {
-    let (delay, error) = retry_budget_for_result(task, result)?;
+    let retryable_batch_failure = task.batch_failure_is_retryable().await;
+    let (delay, error) = retry_budget_for_result(task, result, retryable_batch_failure)?;
     let request = match task.retry_request_with_remaining_timeout().await {
         Ok(request) => request,
         Err(err) => {

--- a/crates/heal/src/heal/manager/tests.rs
+++ b/crates/heal/src/heal/manager/tests.rs
@@ -2613,7 +2613,7 @@ fn test_retry_request_for_recoverable_error_stops_at_limit() {
 }
 
 #[tokio::test]
-async fn test_retry_request_does_not_rescan_batch_after_object_retries_exhausted() {
+async fn test_retry_request_rescans_batch_when_all_exhausted_objects_are_retryable() {
     let storage: Arc<dyn HealStorageAPI> = Arc::new(MockStorage);
     let task = HealTask::from_request(HealRequest::bucket("bucket".to_string()), storage);
     let result = Err(task
@@ -2627,7 +2627,32 @@ async fn test_retry_request_does_not_rescan_batch_after_object_retries_exhausted
         })
         .await);
 
-    assert!(retry_request_for_result(&task, &result).is_none());
+    let (retry_request, retry_delay, error) = retry_request_for_result_with_budget(&task, &result)
+        .await
+        .expect("all-retryable batch failure should rescan within the manager retry budget");
+
+    assert_eq!(retry_request.id, task.id);
+    assert_eq!(retry_request.retry_attempts, 1);
+    assert!(retry_delay > Duration::ZERO);
+    assert!(error.contains("Lock acquisition timeout"));
+}
+
+#[tokio::test]
+async fn test_retry_request_does_not_rescan_batch_with_permanent_failures() {
+    let storage: Arc<dyn HealStorageAPI> = Arc::new(MockStorage);
+    let task = HealTask::from_request(HealRequest::bucket("bucket".to_string()), storage);
+    let result = Err(task
+        .record_batch_failure(BatchHealFailure {
+            scope: "bucket:bucket".to_string(),
+            failed: 2,
+            retryable: 1,
+            permanent: 1,
+            first_object: "object-a".to_string(),
+            first_error: "Lock acquisition timeout".to_string(),
+        })
+        .await);
+
+    assert!(retry_request_for_result_with_budget(&task, &result).await.is_none());
 }
 
 #[test]

--- a/crates/heal/src/heal/task.rs
+++ b/crates/heal/src/heal/task.rs
@@ -651,6 +651,14 @@ impl HealTask {
         self.batch_failure_recorded.load(Ordering::Acquire)
     }
 
+    pub(crate) async fn batch_failure_is_retryable(&self) -> bool {
+        self.batch_failure
+            .read()
+            .await
+            .as_ref()
+            .is_some_and(|failure| failure.failed > 0 && failure.failed == failure.retryable && failure.permanent == 0)
+    }
+
     pub(crate) async fn record_batch_failure(&self, failure: BatchHealFailure) -> Error {
         self.batch_failure_recorded.store(true, Ordering::Release);
         let message = failure.to_string();


### PR DESCRIPTION
## Related Issues
rustfs/backlog#2411
rustfs/backlog#2240

## Summary of Changes
PR #7599 made the failed object visible in legacy/admin heal status. This PR fixes the remaining execution gap for recursive bucket and cluster heals: when a completed traversal records a batch failure whose failed objects are all retryable, the heal manager now lets that task use the existing bounded retry budget instead of immediately publishing a terminal `CompletedWithErrors` snapshot.

Permanent or mixed batch failures remain terminal. The canonical heal outcome still records the failed attempt as `CompletedWithErrors`; the change only decides whether a follow-up manager retry should be scheduled for an all-retryable batch failure such as transient lock contention.

## Verification
- PASS: `cargo test -p rustfs-heal retry_request --lib` (11 tests)
- PASS: `cargo test -p rustfs-heal admin_cluster_lock_timeout_exhaustion_keeps_progress_and_retry_outcome --lib` (1 test)
- PASS: `cargo fmt --all --check`
- PASS: `git diff --check`
- PASS: `cargo clippy -p rustfs-heal --lib --tests -- -D warnings`

Tested commit: `48a93c4a20780d3d5f30a90ecfd62708af8fa602`.

Not run: the original Linux 3-node SNMD heal workflow from backlog#2411, crash/restart replay during a retrying batch, mixed-version rollback, and long-running EC8+4/performance evidence. Local tests cover the retry decision and preserve the strict terminal outcome for the failed attempt; distributed confirmation still needs the nightly/functional lane.

## Impact
Recursive bucket and cluster heals may perform a bounded manager-level retry after a traversal ends with only retryable object failures. This can recover transient lock/quorum failures that outlive the inline object retry window. Permanent object failures and mixed retryable/permanent batches still stop with a failed/stopped outcome.

No API, wire-format, configuration, or compatibility changes.

## Additional Notes
Adversarial validation:
- Correctness: all-retryable batch failures can retry; permanent/mixed batches still cannot; the failed attempt's `CompletedWithErrors` outcome remains strict.
- Simplicity: the change reuses the existing manager retry budget and timeout path; no new scheduler or outcome abstraction.
- Test coverage: reverting the retry gate breaks `test_retry_request_rescans_batch_when_all_exhausted_objects_are_retryable`; widening it to permanent/mixed failures breaks `test_retry_request_does_not_rescan_batch_with_permanent_failures`.
