### PR TITLE
fix(scanner): avoid movement debt for stale remote lease

### DIFF
--- a/crates/scanner/src/scanner.rs
+++ b/crates/scanner/src/scanner.rs
@@ -1995,10 +1995,22 @@ where
                             if let Some((notification_system, grants)) = remote_lease_probe.as_ref()
                                 && notification_system.validate_scanner_publication_leases(grants).await.is_err()
                             {
-                                // A remote restart or movement flip invalidates
-                                // the token proof; usage_store interprets this
-                                // as a publication barrier and performs no PUT.
-                                return Some(ScannerCycleDeferReason::DataMovement);
+                                let remote_lease_targets = grants
+                                    .iter()
+                                    .map(|grant| {
+                                        (
+                                            grant.host.clone(),
+                                            grant.lease.session_id.clone(),
+                                            grant.lease.movement_generation,
+                                        )
+                                    })
+                                    .collect::<Vec<_>>();
+                                let remote_leases_valid = grants.iter().all(|grant| grant.lease.is_valid());
+                                return Some(scanner_remote_publication_lease_failure_defer_reason(
+                                    &remote_lease_targets,
+                                    remote_leases_valid,
+                                    probe_scanner_activity(storeapi.as_ref(), true).await,
+                                ));
                             }
                             scanner_local_publication_defer_reason(storeapi.as_ref()).await
                         }
@@ -3411,6 +3423,61 @@ fn scanner_post_lease_activity_defer_reason(
         }
         Ok(_) | Err(_) => Some(ScannerCycleDeferReason::ActivityBaselineUnavailable),
     }
+}
+
+fn scanner_remote_publication_lease_failure_defer_reason(
+    remote_lease_targets: &[(String, String, u64)],
+    remote_leases_valid: bool,
+    activity_after_failure: Result<ScannerActivitySnapshot, String>,
+) -> ScannerCycleDeferReason {
+    if !remote_leases_valid {
+        return ScannerCycleDeferReason::DataMovement;
+    }
+    let Ok(snapshot) = activity_after_failure else {
+        return ScannerCycleDeferReason::ActivityBaselineUnavailable;
+    };
+    if !scanner_activity_allows_usage_publication(&snapshot) {
+        return ScannerCycleDeferReason::DataMovement;
+    }
+    if scanner_publication_lease_targets_match_activity(remote_lease_targets, &snapshot) {
+        ScannerCycleDeferReason::ActivityBaselineUnavailable
+    } else {
+        ScannerCycleDeferReason::DataMovement
+    }
+}
+
+fn scanner_publication_lease_targets_match_activity(
+    remote_lease_targets: &[(String, String, u64)],
+    activity: &ScannerActivitySnapshot,
+) -> bool {
+    let mut expected = BTreeMap::new();
+    for (host, instance_id, movement_generation) in remote_lease_targets {
+        if host.is_empty()
+            || expected
+                .insert(host.as_str(), (instance_id.as_str(), *movement_generation))
+                .is_some()
+        {
+            return false;
+        }
+    }
+
+    let mut observed_remote_targets = 0usize;
+    for (host, node_activity) in activity {
+        if host == LOCAL_SCANNER_ACTIVITY_NODE {
+            continue;
+        }
+        observed_remote_targets = observed_remote_targets.saturating_add(1);
+        let Some((expected_instance_id, expected_movement_generation)) = expected.get(host.as_str()) else {
+            return false;
+        };
+        if node_activity.instance_id != *expected_instance_id
+            || node_activity.movement_generation != *expected_movement_generation
+        {
+            return false;
+        }
+    }
+
+    observed_remote_targets == remote_lease_targets.len()
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/scanner/src/scanner/tests.rs
+++ b/crates/scanner/src/scanner/tests.rs
@@ -9227,6 +9227,64 @@ fn post_lease_activity_proof_rejects_a_put_tail_that_finished_before_lease_acqui
 }
 
 #[test]
+fn remote_lease_validation_failure_without_movement_debt_is_activity_baseline_unavailable() {
+    let before = BTreeMap::from([("node-2".to_string(), scanner_node_activity("epoch-a", 7, 3))]);
+    let lease_targets = scanner_activity_publication_lease_targets(&before);
+    let mut after = before.clone();
+    after
+        .get_mut("node-2")
+        .expect("writer should be present")
+        .namespace_generation += 1;
+
+    assert_eq!(
+        before["node-2"].movement_generation, after["node-2"].movement_generation,
+        "ordinary namespace writes must not be reported as movement"
+    );
+    assert!(scanner_activity_allows_usage_publication(&after));
+    assert_eq!(
+        scanner_remote_publication_lease_failure_defer_reason(&lease_targets, true, Ok(after)),
+        ScannerCycleDeferReason::ActivityBaselineUnavailable
+    );
+}
+
+#[test]
+fn remote_lease_validation_failure_preserves_movement_defer_for_remote_fence_loss() {
+    let before = BTreeMap::from([("node-2".to_string(), scanner_node_activity("epoch-a", 7, 3))]);
+    let lease_targets = scanner_activity_publication_lease_targets(&before);
+
+    let mut movement_changed = before.clone();
+    movement_changed
+        .get_mut("node-2")
+        .expect("writer should be present")
+        .movement_generation += 1;
+    assert_eq!(
+        scanner_remote_publication_lease_failure_defer_reason(&lease_targets, true, Ok(movement_changed)),
+        ScannerCycleDeferReason::DataMovement
+    );
+
+    let mut restarted = before.clone();
+    restarted.get_mut("node-2").expect("writer should be present").instance_id = "epoch-b".to_string();
+    assert_eq!(
+        scanner_remote_publication_lease_failure_defer_reason(&lease_targets, true, Ok(restarted)),
+        ScannerCycleDeferReason::DataMovement
+    );
+
+    let mut blocked = before.clone();
+    blocked
+        .get_mut("node-2")
+        .expect("writer should be present")
+        .publication_blocked = true;
+    assert_eq!(
+        scanner_remote_publication_lease_failure_defer_reason(&lease_targets, true, Ok(blocked)),
+        ScannerCycleDeferReason::DataMovement
+    );
+    assert_eq!(
+        scanner_remote_publication_lease_failure_defer_reason(&lease_targets, false, Ok(before)),
+        ScannerCycleDeferReason::DataMovement
+    );
+}
+
+#[test]
 fn post_lease_activity_proof_requires_a_complete_matching_baseline() {
     let before = BTreeMap::from([("node-2".to_string(), scanner_node_activity("epoch-a", 7, 3))]);
     let digest = scanner_activity_snapshot_digest(&before);


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#2383.
Related to rustfs/backlog#2240.

## Summary of Changes

When the final remote scanner publication lease validation fails, the scanner no longer classifies every validation error as `DataMovement`.

The route probe now samples a fresh scanner activity snapshot after the failed validation. If the remote peers are still publishable and their host, scanner session, and movement generation still match the granted leases, the cycle keeps the publication rejected as `ActivityBaselineUnavailable` instead of creating durable movement pause backlog debt. Expired leases, peer restarts, remote movement-generation changes, and active publication blocks still defer as `DataMovement`.

This preserves the publication fence: no usage snapshot is written and dirty usage is not acknowledged when the final lease proof fails.

## Verification

- RED before fix: `cargo test --locked -p rustfs-scanner --lib remote_lease_validation_failure_without_movement_debt_is_activity_baseline_unavailable -j 4` failed with `left: DataMovement`, `right: ActivityBaselineUnavailable`.
- GREEN after fix: `cargo test --locked -p rustfs-scanner --lib remote_lease_validation_failure -j 4` passed, 2 passed.
- GREEN after rebase to `origin/release`: `cargo test --locked -p rustfs-scanner --lib remote_lease_validation_failure -j 4` passed, 2 passed, 889 filtered out.
- GREEN after rebase to `origin/release`: `cargo test --locked -p rustfs-scanner --lib post_lease_activity_proof -j 4` passed, 2 passed, 889 filtered out.
- `cargo fmt --all --check` passed.
- `git diff --check` passed.

Not run: the full multi-process e2e selectors for coordinator restart and background target crash/restart. I started `cargo build --locked -p rustfs --bin rustfs -j 4` to create the same-head binary, but the local macOS debug binary build produced no progress for several minutes during the late link phase and was interrupted before `target/debug/rustfs` existed. Therefore this PR does not claim full Heal/scanner e2e recovery for those scenarios.

## Impact

Namespace-only writes that invalidate a final remote scanner publication lease no longer create movement catch-up debt or enter the 300-second movement backlog pacing path. Real data movement, peer restart, publication blocking, and expired lease cases remain fail-closed as movement deferrals.

No public API, config, disk format, wire format, or S3 behavior changes.

## Additional Notes

Adversarial review, pass 1:

- Correctness: no finding. The new downgrade requires a valid lease window, publishable fresh activity, and exact host/session/movement-generation agreement with the granted lease targets.
- Concurrency/durability: no finding. The failed validation path still rejects publication and performs no usage PUT or dirty-usage ACK; no new locks or durable writes were added.
- Test coverage: partial. Focused tests fail if the namespace-only downgrade is reverted and if movement/restart/block cases are weakened. Full e2e recovery remains unverified locally.
- Performance: no finding. The extra activity probe runs only after final remote lease validation has already failed, not on successful publication or object request hot paths.

Adversarial review, pass 2:

- Correctness: no finding. Duplicate, missing, or extra remote lease targets cannot pass the matching helper because host membership and remote target count must match exactly.
- Concurrency/durability: no finding. Expired lease grants stay `DataMovement`; a lease expiring around the failure path cannot be converted into a baseline-only deferral.
- Test coverage: residual risk is limited to live four-node timing. The deterministic unit test covers the previously unprotected final validation classifier, while the issue's coordinator/target e2e selectors still need CI or a host that can finish the same-head binary build.
- Performance: no finding. The helper allocates only small per-peer maps/vectors on the error path.
