### PR TITLE
test(scanner): reject synthetic heal evidence inputs

### DIFF
--- a/scripts/run_scanner_heal_checkpoint_crash_evidence.py
+++ b/scripts/run_scanner_heal_checkpoint_crash_evidence.py
@@ -32,6 +32,11 @@ def positive_int(value: Any, name: str, minimum: int = 1) -> int:
     return value
 
 
+def reject_non_measured_markers(payload: dict[str, Any], label: str) -> None:
+    for marker in ("fixture", "fixture_only", "dry_run", "synthetic"):
+        require(payload.get(marker) is not True, f"{label} is {marker}")
+
+
 def timestamp(value: Any, name: str) -> str:
     require(isinstance(value, str) and value.endswith("Z"), f"invalid {name}")
     datetime.fromisoformat(value.replace("Z", "+00:00"))
@@ -63,6 +68,7 @@ def load_reports(directory: Path) -> list[dict[str, Any]]:
         "raw_page_index_indexed_entries",
     }
     for index, report in enumerate(reports):
+        reject_non_measured_markers(report, f"round {index}")
         require(report.get("schema") == 1, f"round {index} has wrong schema")
         require(report.get("round") == index, f"round {index} order mismatch")
         for key in (
@@ -88,8 +94,7 @@ def load_reports(directory: Path) -> list[dict[str, Any]]:
 
 def require_measured_manifest(path: Path, source_revision: str) -> dict[str, Any]:
     manifest = read_json(path)
-    for marker in ("fixture", "fixture_only", "dry_run", "synthetic"):
-        require(manifest.get(marker) is not True, f"checkpoint/crash manifest is {marker}")
+    reject_non_measured_markers(manifest, "checkpoint/crash manifest")
     require(manifest.get("schema") == 1, "unsupported manifest schema")
     require(manifest.get("evidence_type") == "measured", "manifest must be measured")
     require(manifest.get("source_revision") == source_revision, "manifest source revision mismatch")
@@ -108,8 +113,7 @@ def derived_measured_manifest(directory: Path, source_revision: str, reports: li
     request_path = directory / "request.json"
     request = read_json(request_path)
     require(isinstance(request, dict), "diagnostic request must be a JSON object")
-    for marker in ("fixture", "fixture_only", "dry_run", "synthetic"):
-        require(request.get(marker) is not True, f"diagnostic request is {marker}")
+    reject_non_measured_markers(request, "diagnostic request")
     objects = positive_int(request.get("objects"), "request.objects")
     raw_entry_budget = positive_int(request.get("raw_entry_budget"), "request.raw_entry_budget")
     final_round = positive_int(request.get("round"), "request.round", 0)
@@ -422,6 +426,24 @@ def run_self_test() -> None:
             require("convergence" in str(err), "wrong self-test failure for non-converged diagnostic")
         else:
             raise ValueError("self-test accepted non-converged diagnostic")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        source_revision = git_head()
+        manifest, diagnostic = write_self_test_inputs(root, source_revision)
+        report = read_json(diagnostic / "round-0.json")
+        report["synthetic"] = True
+        write_json(diagnostic / "round-0.json", report)
+        try:
+            build_descriptor(parse_args([
+                "--manifest", str(manifest),
+                "--diagnostic-dir", str(diagnostic),
+                "--out-dir", str(root / "out"),
+            ]))
+        except ValueError as err:
+            require("round 0 is synthetic" in str(err), "wrong self-test failure for synthetic round report")
+        else:
+            raise ValueError("self-test accepted synthetic diagnostic round report")
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/scripts/run_scanner_heal_g14_multiset_evidence.py
+++ b/scripts/run_scanner_heal_g14_multiset_evidence.py
@@ -48,6 +48,11 @@ def positive_int(value: Any, name: str, minimum: int = 1) -> int:
     return value
 
 
+def reject_non_measured_markers(payload: dict[str, Any], label: str) -> None:
+    for marker in ("fixture", "fixture_only", "dry_run", "synthetic"):
+        require(payload.get(marker) is not True, f"{label} is {marker}")
+
+
 def parse_case_dir_arg(value: str) -> tuple[str | None, Path]:
     if "=" in value:
         case_id, raw_path = value.split("=", 1)
@@ -72,8 +77,7 @@ def proof_case_artifact_path(proof_path: Path, sample: dict[str, Any], index: in
 
 def load_proof(path: Path, source_revision: str) -> dict[str, Any]:
     proof = read_json(path)
-    for marker in ("fixture", "fixture_only", "dry_run", "synthetic"):
-        require(proof.get(marker) is not True, f"G14 proof is {marker}")
+    reject_non_measured_markers(proof, "G14 proof")
     require(proof.get("schema") == 1, "unsupported G14 proof schema")
     require(proof.get("evidence_type") == "measured", "G14 proof must be measured")
     require(proof.get("source_revision") == source_revision, "G14 proof source revision mismatch")
@@ -110,8 +114,7 @@ def load_proof(path: Path, source_revision: str) -> dict[str, Any]:
                 f"G14 case evidence {index} measurement window mismatch")
         artifact_payload = read_json(artifact)
         require(isinstance(artifact_payload, dict), f"G14 case evidence {index} artifact must be a JSON object")
-        for marker in ("fixture", "fixture_only", "dry_run", "synthetic"):
-            require(artifact_payload.get(marker) is not True, f"G14 case evidence {index} artifact is {marker}")
+        reject_non_measured_markers(artifact_payload, f"G14 case evidence {index} artifact")
         require(artifact_payload.get("case") == sample["case"], f"G14 case evidence {index} artifact case mismatch")
         if "source_revision" in artifact_payload:
             require(artifact_payload["source_revision"] == source_revision,
@@ -127,6 +130,10 @@ def load_case_directory(raw_value: str, source_revision: str) -> dict[str, Any]:
     require(directory.is_dir(), f"G14 case directory is missing: {directory}")
     run = read_json(directory / "run.json")
     execution = read_json(directory / "execution.json")
+    require(isinstance(run, dict), "G14 case run must be a JSON object")
+    require(isinstance(execution, dict), "G14 case execution must be a JSON object")
+    reject_non_measured_markers(run, "G14 case run")
+    reject_non_measured_markers(execution, "G14 case execution")
     require(run.get("schema") == 1, "G14 case run schema mismatch")
     require(isinstance(run.get("run_id"), str) and re.fullmatch(r"[0-9a-f]{32}", run["run_id"]),
             "invalid G14 case run id")
@@ -156,6 +163,7 @@ def load_case_directory(raw_value: str, source_revision: str) -> dict[str, Any]:
     if expected_case is not None:
         require(oracle.get("case") == expected_case, "G14 case directory case id mismatch")
     require(oracle.get("source_revision") == source_revision, "G14 oracle source revision mismatch")
+    reject_non_measured_markers(oracle, "G14 oracle")
     require(oracle.get("evidence") in {"process-restart", "process-crash-restart"}, "G14 oracle has wrong evidence type")
     topology = oracle.get("topology")
     require(isinstance(topology, dict), "G14 oracle missing topology")
@@ -503,6 +511,27 @@ def run_self_test() -> None:
             require("multi-set/multi-pool" in str(err), "wrong self-test failure for missing multi-pool case")
         else:
             raise ValueError("self-test accepted case evidence without multi-pool proof")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        source_revision = git_head()
+        multi_pool = write_self_test_case_dir(root, source_revision, "background-target-crash-ec8-4-multi-pool", 3, 3)
+        oracle_path = multi_pool / "background-target-crash-ec8-4-multi-pool.json"
+        oracle = read_json(oracle_path)
+        oracle["fixture_only"] = True
+        write_json(oracle_path, oracle)
+        execution = read_json(multi_pool / "execution.json")
+        execution["artifacts"][oracle_path.name] = digest(oracle_path)
+        write_json(multi_pool / "execution.json", execution)
+        try:
+            build_descriptor(parse_args([
+                "--case-dir", f"background-target-crash-ec8-4-multi-pool={multi_pool}",
+                "--out-dir", str(root / "out"),
+            ]))
+        except ValueError as err:
+            require("G14 oracle is fixture_only" in str(err), "wrong self-test failure for fixture oracle")
+        else:
+            raise ValueError("self-test accepted fixture-only G14 case oracle")
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#2427
Refs rustfs/backlog#2240
Refs rustfs/backlog#2269
Refs rustfs/backlog#2278

## Summary of Changes

The Scanner/Heal release evidence producers already reject fixture or synthetic top-level proofs. This PR closes two narrower acceptance gaps before the Linux evidence flow:

- G02/R-E checkpoint restart descriptors now reject diagnostic round reports marked as `fixture`, `fixture_only`, `dry_run`, or `synthetic`.
- G14 case-directory descriptors now reject marked `run.json`, `execution.json`, and case oracle payloads before packaging EC8+4 multi-set/multi-pool evidence.

Both changes keep valid measured evidence accepted while preventing marked non-production artifacts from being repackaged as release-bundle inputs.

## Verification

Tested commit: `f8d8ba05affa38fb42d8ad0e23080157760957a0`, based on `release@358bf6832d5287d4096050fd36f146687640599d`, with no uncommitted changes after commit.

- `scripts/test_scanner_heal_g14_multiset_evidence.sh`: passed.
- `scripts/test_scanner_heal_checkpoint_crash_evidence.sh`: passed.
- `scripts/python_bin.sh scripts/check_test_wiring.py --self-test`: 51 tests passed.
- `python3 -m py_compile scripts/run_scanner_heal_g14_multiset_evidence.py scripts/run_scanner_heal_checkpoint_crash_evidence.py`: passed.
- `git diff --check`: passed.

Not run: full Scanner/Heal release bundle, Linux distributed evidence, mixed-version matrix, EC8+4 long-stable ABBA, and profile/soak gates. Those remain tracked by rustfs/backlog#2428.

## Impact

No runtime behavior or public API changes. The release evidence tooling now fails closed when an operator accidentally points it at marked fixture, dry-run, or synthetic diagnostic inputs.

## Additional Notes

This is a focused coding slice for the Scanner/Heal V2 release-base implementation queue. It does not claim final release approval for rustfs/backlog#2240.
