### PR TITLE
test(scanner): report Linux evidence plan status

### DIFF
--- a/docs/testing/ci-gates.md
+++ b/docs/testing/ci-gates.md
@@ -375,6 +375,17 @@ scripts/python_bin.sh scripts/run_scanner_heal_linux_evidence_plan.py \
 The plan is only an execution manifest. Its `evidence_type` is `plan_only`, and
 it cannot satisfy any Gxx/Wxx/Rxx gate. Use `--run-preflight` only for the
 lightweight registry and runner self-tests before starting a long Linux run.
+After or during a Linux run, check which planned artifacts are still missing
+without approving the release bundle:
+
+```bash
+scripts/python_bin.sh scripts/run_scanner_heal_linux_evidence_plan.py \
+  --status-root /path/to/run-root --format json
+```
+
+The status command exits nonzero while evidence is missing or malformed and
+keeps `release_approved: false`; use its `pending_gates` and `next_step` fields
+for issue writeback and failure triage.
 
 Lane descriptors can be assembled into that bundle with:
 

--- a/scripts/run_scanner_heal_linux_evidence_plan.py
+++ b/scripts/run_scanner_heal_linux_evidence_plan.py
@@ -50,6 +50,10 @@ def command(*parts: str) -> list[str]:
     return list(parts)
 
 
+def expected_outputs(*parts: str) -> list[str]:
+    return list(parts)
+
+
 def git_output(*args: str) -> str:
     return subprocess.check_output(command("git", *args), cwd=ROOT, text=True).strip()
 
@@ -166,6 +170,14 @@ def concrete_case_steps(registry: dict[str, Any]) -> list[dict[str, Any]]:
                     f"$RUN_ROOT/cases/{case_id}",
                 )
             ],
+            "expected_outputs": expected_outputs(
+                f"$RUN_ROOT/cases/{case_id}/run.json",
+                f"$RUN_ROOT/cases/{case_id}/execution.json",
+                f"$RUN_ROOT/cases/{case_id}/listing.json",
+                f"$RUN_ROOT/cases/{case_id}/junit.xml",
+                f"$RUN_ROOT/cases/{case_id}/{cases[case_id]['oracle']}",
+                f"$RUN_ROOT/cases/{case_id}/release-status.json",
+            ),
         }
         for case_id in ordered_cases
     ]
@@ -189,6 +201,7 @@ def descriptor_steps() -> list[dict[str, Any]]:
                     "$RUN_ROOT/descriptors/authority",
                 )
             ],
+            "expected_outputs": expected_outputs("$RUN_ROOT/descriptors/authority/release-bundle-authority.json"),
         },
         {
             "id": "checkpoint-and-restart",
@@ -204,6 +217,7 @@ def descriptor_steps() -> list[dict[str, Any]]:
                     "$RUN_ROOT/descriptors/checkpoint",
                 )
             ],
+            "expected_outputs": expected_outputs("$RUN_ROOT/descriptors/checkpoint/release-bundle-checkpoint-crash.json"),
         },
         {
             "id": "status-and-outcome",
@@ -231,6 +245,12 @@ def descriptor_steps() -> list[dict[str, Any]]:
                     "$RUN_ROOT/descriptors/status-outcome",
                 ),
             ],
+            "expected_outputs": expected_outputs(
+                "$RUN_ROOT/raw/status-outcome/status-outcome.json",
+                "$RUN_ROOT/raw/status-outcome/status-compat.json",
+                "$RUN_ROOT/raw/status-outcome/disposition.json",
+                "$RUN_ROOT/descriptors/status-outcome/release-bundle-status-outcome.json",
+            ),
         },
         {
             "id": "ec8-4-multiset-descriptor",
@@ -248,6 +268,7 @@ def descriptor_steps() -> list[dict[str, Any]]:
                     "$RUN_ROOT/descriptors/g14",
                 )
             ],
+            "expected_outputs": expected_outputs("$RUN_ROOT/descriptors/g14/release-bundle-g14.json"),
         },
         {
             "id": "w16-recovery-intent",
@@ -260,6 +281,7 @@ def descriptor_steps() -> list[dict[str, Any]]:
                     "$RUN_ROOT/w16",
                 )
             ],
+            "expected_outputs": expected_outputs("$RUN_ROOT/w16/release-bundle-w16.json"),
         },
         {
             "id": "mrf-responsibility",
@@ -272,6 +294,7 @@ def descriptor_steps() -> list[dict[str, Any]]:
                     "$RUN_ROOT/w13",
                 )
             ],
+            "expected_outputs": expected_outputs("$RUN_ROOT/w13/release-bundle-w13.json"),
         },
         {
             "id": "mixed-version-rollback",
@@ -300,6 +323,11 @@ def descriptor_steps() -> list[dict[str, Any]]:
                     "$RUN_ROOT/descriptors/legacy-rollback",
                 ),
             ],
+            "expected_outputs": expected_outputs(
+                "$RUN_ROOT/g09/release-bundle-g09.json",
+                "$RUN_ROOT/descriptors/scoped-ack/release-bundle-scoped-ack.json",
+                "$RUN_ROOT/descriptors/legacy-rollback/release-bundle-legacy-rollback.json",
+            ),
         },
         {
             "id": "maintenance-producers",
@@ -315,6 +343,7 @@ def descriptor_steps() -> list[dict[str, Any]]:
                     "$RUN_ROOT/descriptors/maintenance",
                 )
             ],
+            "expected_outputs": expected_outputs("$RUN_ROOT/descriptors/maintenance/release-bundle-maintenance.json"),
         },
     ]
 
@@ -339,6 +368,7 @@ def performance_steps() -> list[dict[str, Any]]:
                     "$RUN_ROOT/abba/data",
                 )
             ],
+            "expected_outputs": expected_outputs("$RUN_ROOT/abba/out/report.json"),
         },
         {
             "id": "scheduler-pressure",
@@ -364,6 +394,7 @@ def performance_steps() -> list[dict[str, Any]]:
                     "$RUN_ROOT/descriptors/scheduler-pressure",
                 )
             ],
+            "expected_outputs": expected_outputs("$RUN_ROOT/descriptors/scheduler-pressure/release-bundle-scheduler-pressure.json"),
         },
     ]
 
@@ -399,6 +430,7 @@ def bundle_steps() -> list[dict[str, Any]]:
                     "$RUN_ROOT/release-bundle/release-evidence.json",
                 ),
             ],
+            "expected_outputs": expected_outputs("$RUN_ROOT/release-bundle/release-evidence.json"),
         }
     ]
 
@@ -469,6 +501,109 @@ def iter_preflight_commands(plan: dict[str, Any]) -> list[list[str]]:
     return commands
 
 
+def render_run_root_path(value: str, run_root: Path) -> Path:
+    rendered = value.replace("$RUN_ROOT", str(run_root))
+    return Path(rendered)
+
+
+def check_expected_output(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"path": str(path), "status": "missing"}
+    if not path.is_file():
+        return {"path": str(path), "status": "invalid", "error": "expected a file"}
+    size = path.stat().st_size
+    if size <= 0:
+        return {"path": str(path), "status": "empty", "bytes": size}
+    return {"path": str(path), "status": "present", "bytes": size}
+
+
+def covered_gates(step: dict[str, Any]) -> list[str]:
+    covers = step.get("covers")
+    if not isinstance(covers, dict):
+        return []
+    gate = covers.get("gate")
+    gates = covers.get("gates")
+    if isinstance(gate, str):
+        return [gate]
+    if isinstance(gates, list):
+        return [item for item in gates if isinstance(item, str)]
+    return []
+
+
+def build_status(plan: dict[str, Any], run_root: Path) -> dict[str, Any]:
+    run_root = run_root.resolve()
+    stage_statuses = []
+    totals = {"present": 0, "missing": 0, "empty": 0, "invalid": 0, "expected": 0}
+    pending_gates: set[str] = set()
+    next_step: dict[str, Any] | None = None
+    for stage in plan["stages"]:
+        step_statuses = []
+        for step in stage["steps"]:
+            outputs = [
+                check_expected_output(render_run_root_path(path, run_root))
+                for path in step.get("expected_outputs", [])
+            ]
+            counts = {"present": 0, "missing": 0, "empty": 0, "invalid": 0}
+            for output in outputs:
+                counts[output["status"]] += 1
+            for key in counts:
+                totals[key] += counts[key]
+            totals["expected"] += len(outputs)
+            if not outputs:
+                status = "not_tracked"
+            elif counts["invalid"] or counts["empty"]:
+                status = "invalid"
+            elif counts["missing"]:
+                status = "pending" if counts["present"] == 0 else "partial"
+            else:
+                status = "complete"
+            if status in {"pending", "partial", "invalid"}:
+                pending_gates.update(covered_gates(step))
+                if next_step is None:
+                    next_step = {
+                        "stage": stage["id"],
+                        "step": step["id"],
+                        "status": status,
+                        "commands": step["commands"],
+                    }
+            step_statuses.append({
+                "id": step["id"],
+                "status": status,
+                "covers": step.get("covers", {}),
+                "outputs": outputs,
+            })
+        tracked = [step for step in step_statuses if step["status"] != "not_tracked"]
+        if not tracked:
+            stage_state = "not_tracked"
+        elif all(step["status"] == "complete" for step in tracked):
+            stage_state = "complete"
+        elif any(step["status"] == "invalid" for step in tracked):
+            stage_state = "invalid"
+        elif any(step["status"] in {"complete", "partial"} for step in tracked):
+            stage_state = "partial"
+        else:
+            stage_state = "pending"
+        stage_statuses.append({"id": stage["id"], "status": stage_state, "steps": step_statuses})
+    if totals["invalid"] or totals["empty"]:
+        decision = "invalid"
+    elif totals["missing"]:
+        decision = "blocked"
+    else:
+        decision = "complete"
+    return {
+        "schema": 1,
+        "kind": "scanner-heal-linux-evidence-status",
+        "decision": decision,
+        "release_approved": False,
+        "source_revision": plan["source_revision"],
+        "run_root": str(run_root),
+        "artifact_totals": totals,
+        "pending_gates": sorted(pending_gates),
+        "next_step": next_step,
+        "stages": stage_statuses,
+    }
+
+
 def run_preflight(plan: dict[str, Any]) -> int:
     commands = iter_preflight_commands(plan)
     if not commands:
@@ -511,6 +646,20 @@ def self_test() -> None:
     path = write_plan(out_dir, plan)
     loaded = json.loads(path.read_text())
     assert loaded["source_revision"] == revision
+    status = build_status(plan, out_dir / "empty-run")
+    assert status["decision"] == "blocked"
+    assert status["release_approved"] is False
+    assert status["pending_gates"]
+    complete_root = out_dir / "complete-run"
+    for stage in plan["stages"]:
+        for step in stage["steps"]:
+            for output in step.get("expected_outputs", []):
+                path = render_run_root_path(output, complete_root)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("{}\n")
+    complete = build_status(plan, complete_root)
+    assert complete["decision"] == "complete"
+    assert complete["release_approved"] is False
     print("PASS: scanner/heal Linux evidence plan self-test")
 
 
@@ -522,6 +671,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--write-plan", action="store_true")
     parser.add_argument("--format", choices=("text", "json"), default="text")
     parser.add_argument("--run-preflight", action="store_true")
+    parser.add_argument("--status-root", type=Path)
     parser.add_argument("--self-test", action="store_true")
     return parser.parse_args(argv)
 
@@ -537,7 +687,13 @@ def main(argv: list[str] | None = None) -> int:
         phases = set(args.phase or ["all"])
         if "all" in phases and len(phases) > 1:
             raise ValueError("--phase all cannot be combined with another phase")
+        if args.status_root is not None and (args.write_plan or args.run_preflight):
+            raise ValueError("--status-root cannot be combined with --write-plan or --run-preflight")
         plan = build_plan(registry, source_revision(args.source_revision), phases)
+        if args.status_root is not None:
+            status = build_status(plan, args.status_root)
+            print(json.dumps(status, indent=2, sort_keys=True))
+            return 0 if status["decision"] == "complete" else 3
         if args.write_plan:
             path = write_plan(args.out_dir.resolve(), plan)
             print(path)

--- a/scripts/test_scanner_heal_linux_evidence_plan.sh
+++ b/scripts/test_scanner_heal_linux_evidence_plan.sh
@@ -49,6 +49,73 @@ test -s "$PLAN_PATH"
 rg -q '"evidence_type": "plan_only"' "$PLAN_PATH"
 rg -q '"stop_on_product_failure": true' "$PLAN_PATH"
 
+if "${RUSTFS_PYTHON_BIN:-python3}" "$RUNNER" \
+  --phase functional \
+  --source-revision aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  --status-root "$TMP_DIR/missing-run" >"$TMP_DIR/status-missing.json"; then
+  echo "missing evidence status should fail closed" >&2
+  exit 1
+fi
+rg -q '"decision": "blocked"' "$TMP_DIR/status-missing.json"
+rg -q '"release_approved": false' "$TMP_DIR/status-missing.json"
+rg -q '"next_step"' "$TMP_DIR/status-missing.json"
+
+if "${RUSTFS_PYTHON_BIN:-python3}" "$RUNNER" \
+  --phase functional \
+  --status-root "$TMP_DIR/missing-run" \
+  --run-preflight >/dev/null 2>"$TMP_DIR/status-mode.err"; then
+  echo "status mode should reject preflight execution" >&2
+  exit 1
+fi
+rg -q "status-root cannot be combined" "$TMP_DIR/status-mode.err"
+
+"${RUSTFS_PYTHON_BIN:-python3}" - "$RUNNER" "$TMP_DIR/complete-run" <<'PY'
+import json
+import pathlib
+import subprocess
+import sys
+
+runner = pathlib.Path(sys.argv[1])
+run_root = pathlib.Path(sys.argv[2])
+plan = json.loads(subprocess.check_output([
+    sys.executable,
+    str(runner),
+    "--phase",
+    "functional",
+    "--source-revision",
+    "a" * 40,
+    "--format",
+    "json",
+], text=True))
+for stage in plan["stages"]:
+    for step in stage["steps"]:
+        for output in step.get("expected_outputs", []):
+            path = pathlib.Path(output.replace("$RUN_ROOT", str(run_root)))
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("{}\n")
+status = json.loads(subprocess.check_output([
+    sys.executable,
+    str(runner),
+    "--phase",
+    "functional",
+    "--source-revision",
+    "a" * 40,
+    "--status-root",
+    str(run_root),
+], text=True))
+assert status["decision"] == "complete"
+assert status["release_approved"] is False
+assert status["artifact_totals"]["missing"] == 0
+PY
+
+if "${RUSTFS_PYTHON_BIN:-python3}" "$RUNNER" \
+  --phase performance \
+  --run-preflight >/dev/null 2>"$TMP_DIR/no-preflight.err"; then
+  echo "preflight execution without the preflight stage should fail" >&2
+  exit 1
+fi
+rg -q "requires the preflight stage" "$TMP_DIR/no-preflight.err"
+
 if "${RUSTFS_PYTHON_BIN:-python3}" "$RUNNER" --source-revision bad >/dev/null 2>"$TMP_DIR/bad.err"; then
   echo "invalid source revision should fail" >&2
   exit 1


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#2427
Refs rustfs/backlog#2428
Refs rustfs/backlog#2240

## Summary of Changes

- Add explicit `expected_outputs` to the Scanner/Heal Linux evidence plan so each functional, descriptor, performance, and bundle step advertises the artifacts it is expected to produce.
- Add `--status-root` to report whether a Linux run root is complete, blocked by missing artifacts, or invalid because artifacts are empty or malformed as files.
- Keep status mode fail-closed: it returns nonzero for missing or invalid evidence and always reports `release_approved: false`.
- Document the status command for issue writeback and Linux validation triage.

## Verification

- `PYTHONPYCACHEPREFIX=<tmp> python3 -m py_compile scripts/run_scanner_heal_linux_evidence_plan.py` passed.
- `scripts/test_scanner_heal_linux_evidence_plan.sh` passed, covering missing evidence, complete placeholder evidence, invalid command-mode mixing, invalid source revisions, and plan-only output.
- `scripts/python_bin.sh scripts/run_scanner_heal_linux_evidence_plan.py --self-test` passed through the repository Python entrypoint.
- `scripts/python_bin.sh scripts/run_scanner_heal_linux_evidence_plan.py --phase preflight --run-preflight` passed with 13 light preflight commands.
- `scripts/python_bin.sh scripts/run_scanner_heal_linux_evidence_plan.py --phase functional --source-revision <sha40> --status-root <run-root> --format json` returned exit code 3 as expected for a missing evidence root and reported `decision: blocked`, `release_approved: false`, and the next missing step.
- `scripts/check_doc_paths.sh` passed.
- `scripts/check_no_planning_docs.sh` passed.
- `git diff --check` passed.

## Impact

Developer tooling and testing documentation only. This does not change runtime scanner/heal behavior, but it makes the remaining Linux evidence workflow easier to audit and safer to write back to backlog issues.

## Additional Notes

Base branch is `release`. The status output is intentionally not release evidence; it is an operator-facing completeness probe for the measured Linux evidence flow.
