### PR TITLE
test(e2e): keep G14 multi-set restart graceful

### DIFF
--- a/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
+++ b/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
@@ -1823,6 +1823,7 @@ mod tests {
                 scenario,
                 InterruptionScenario::BackgroundTargetRestart
                     | InterruptionScenario::BackgroundTargetRestartEc84
+                    | InterruptionScenario::BackgroundTargetRestartEc84MultiSet
                     | InterruptionScenario::BackgroundCoordinatorRestart
             ) {
                 cluster.stop_node_gracefully(interruption_node).await?;


### PR DESCRIPTION
## Summary
- keep the EC8+4 multi-set restart scenario on the graceful interruption path
- preserve crash scenarios as the only lanes that expect an unclean-shutdown marker

## Validation
- cargo fmt --all --check
- git diff --check origin/release...HEAD
- cargo test -p e2e_test test_cluster_root_heal_recovers_ec84_shards_across_multi_set_after_background_target_restart --no-run
- Linux measured proof: scripts/run_scanner_heal_evidence_case.sh --case background-target-restart-ec8-4-multi-set passed on commit 8f358323b67a86b0e1f4a4d52459d34d829a1b2b

## Linux Evidence Summary
- case: background-target-restart-ec8-4-multi-set
- topology: 3 nodes, 8 drives per node, EC8+4, 2 sets, 1 pool
- outage write deferred until rejoin: false
- unclean-shutdown marker observed: false
- evidence objects recorded: 33

This follow-up closes the harness semantic gap found after #7630 merged.