### PR TITLE
feat: configure the console base path at build time

### DIFF
--- a/rustfs/src/admin/console.rs
+++ b/rustfs/src/admin/console.rs
@@ -867,9 +867,14 @@ mod tests {
     async fn console_config_handler_serializes_admin_discovery_paths() {
         init_console_cfg(IpAddr::V4(Ipv4Addr::LOCALHOST), 9001);
 
-        let response = config_handler(Uri::from_static("http://127.0.0.1:9001/rustfs/console/api/v1/config"), HeaderMap::new())
-            .await
-            .into_response();
+        let response = config_handler(
+            format!("http://127.0.0.1:9001{CONSOLE_PREFIX}/api/v1/config")
+                .parse()
+                .expect("console URI"),
+            HeaderMap::new(),
+        )
+        .await
+        .into_response();
 
         assert_eq!(response.status(), StatusCode::OK);
         let body = response.into_body();
@@ -889,7 +894,8 @@ mod tests {
 
     #[test]
     fn external_admin_paths_are_not_console_paths() {
-        assert!(is_console_path("/rustfs/console/"));
+        assert!(is_console_path(&format!("{CONSOLE_PREFIX}/")));
+        assert!(!is_console_path(&format!("{CONSOLE_PREFIX}-other/index.html")));
         assert!(is_console_path("/apple-touch-icon.png"));
         assert!(is_console_path("/apple-touch-icon-precomposed.png"));
         assert!(!is_console_path("/minio/admin/v3/info"));

--- a/rustfs/src/admin/handlers/oidc.rs
+++ b/rustfs/src/admin/handlers/oidc.rs
@@ -1681,7 +1681,7 @@ mod tests {
                 .expect("console redirect should use browser redirect URL")
         });
 
-        assert!(redirect.starts_with("https://console.example.com/rustfs/console/auth/oidc-callback/#"));
+        assert!(redirect.starts_with(&format!("https://console.example.com{CONSOLE_PREFIX}/auth/oidc-callback/#")));
         assert!(redirect.contains("redirect=%2Fbuckets"));
         assert!(redirect.contains("logoutToken=logout-token"));
     }
@@ -1694,7 +1694,7 @@ mod tests {
             build_console_login_redirect(&req).expect("login redirect should use browser redirect URL")
         });
 
-        assert_eq!(redirect, "https://console.example.com/rustfs/console/auth/login");
+        assert_eq!(redirect, format!("https://console.example.com{CONSOLE_PREFIX}/auth/login"));
     }
 
     #[test]

--- a/rustfs/src/server/compress.rs
+++ b/rustfs/src/server/compress.rs
@@ -418,7 +418,7 @@ impl PathCategory {
             PathCategory::InternodeRpc
         } else if path.starts_with("/rustfs/admin/") || path.starts_with("/minio/admin/") {
             PathCategory::AdminApi
-        } else if path.starts_with("/rustfs/console") {
+        } else if crate::server::has_path_prefix(path, crate::server::CONSOLE_PREFIX) {
             PathCategory::Console
         } else if path == "/health"
             || path.starts_with("/health/")
@@ -766,8 +766,15 @@ mod tests {
 
     #[test]
     fn test_path_category_classify_console() {
-        assert_eq!(PathCategory::classify("/rustfs/console/index.html"), PathCategory::Console);
-        assert_eq!(PathCategory::classify("/rustfs/console"), PathCategory::Console);
+        assert_eq!(
+            PathCategory::classify(&format!("{}/index.html", crate::server::CONSOLE_PREFIX)),
+            PathCategory::Console
+        );
+        assert_eq!(PathCategory::classify(crate::server::CONSOLE_PREFIX), PathCategory::Console);
+        assert_eq!(
+            PathCategory::classify(&format!("{}-other/index.html", crate::server::CONSOLE_PREFIX)),
+            PathCategory::S3DataPlane
+        );
     }
 
     #[test]

--- a/rustfs/src/server/http.rs
+++ b/rustfs/src/server/http.rs
@@ -18,7 +18,7 @@ use crate::auth::IAMAuth;
 use crate::auth_keystone;
 use crate::config;
 use crate::server::{
-    ReadinessGateLayer, RemoteAddr, ShutdownHandle,
+    CONSOLE_PREFIX, ReadinessGateLayer, RemoteAddr, ShutdownHandle,
     compress::{HttpCompressionConfig, PathAwareHttpCompressionPredicate, PathCategoryInjectionLayer},
     hybrid::hybrid,
     layer::{
@@ -1219,7 +1219,7 @@ pub async fn start_http_server(
             component = LOG_COMPONENT_SERVER,
             subsystem = LOG_SUBSYSTEM_STARTUP,
             service = "console",
-            endpoint = %format!("{protocol}://{local_ip_str}:{local_port}/rustfs/console/index.html"),
+            endpoint = %format!("{protocol}://{local_ip_str}:{local_port}{CONSOLE_PREFIX}/index.html"),
             "Startup endpoint available"
         );
         info!(
@@ -1228,7 +1228,7 @@ pub async fn start_http_server(
             component = LOG_COMPONENT_SERVER,
             subsystem = LOG_SUBSYSTEM_STARTUP,
             service = "console_localhost",
-            endpoint = %format!("{protocol}://127.0.0.1:{local_port}/rustfs/console/index.html"),
+            endpoint = %format!("{protocol}://127.0.0.1:{local_port}{CONSOLE_PREFIX}/index.html"),
             "Startup endpoint available"
         );
     } else {

--- a/rustfs/src/server/layer.rs
+++ b/rustfs/src/server/layer.rs
@@ -598,7 +598,7 @@ fn is_console_redirect_request<B>(req: &HttpRequest<B>) -> bool {
             .get(http::header::USER_AGENT)
             .and_then(|value| value.to_str().ok())
             .is_some_and(|user_agent| user_agent.contains("Mozilla"))
-        && (path.is_empty() || path == "/rustfs" || path == "/index.html")
+        && (path.is_empty() || CONSOLE_PREFIX.strip_suffix("/console") == Some(path) || path == "/index.html")
 }
 
 impl<S, RestBody, GrpcBody> Service<HttpRequest<Incoming>> for RedirectService<S>
@@ -625,7 +625,7 @@ where
             // Create redirect response
             let redirect_response = Response::builder()
                 .status(StatusCode::FOUND)
-                .header(http::header::LOCATION, "/rustfs/console/")
+                .header(http::header::LOCATION, format!("{CONSOLE_PREFIX}/"))
                 .body(HybridBody::Rest {
                     rest_body: RestBody::default(),
                 })
@@ -2333,7 +2333,7 @@ mod tests {
         for path in [
             "/rustfs/admin/v3/metrics",
             "/minio/admin/v3/storageinfo",
-            "/rustfs/console/",
+            CONSOLE_PREFIX,
             "/rustfs/rpc/test",
             "/health/ready",
             "/_iceberg/v1/config",
@@ -2624,7 +2624,7 @@ mod tests {
         for path in [
             "/rustfs/admin/v3/info",
             "/minio/admin/v3/info",
-            "/rustfs/console/",
+            CONSOLE_PREFIX,
             HEALTH_PREFIX,
             "/iceberg/v1/config",
             "/rustfs/rpc/v1/read-file",
@@ -2670,7 +2670,11 @@ mod tests {
 
     #[test]
     fn console_redirect_request_id_contract_follows_redirect_enablement() {
-        for path in ["/", "/rustfs", "/index.html"] {
+        for path in [
+            "/",
+            CONSOLE_PREFIX.strip_suffix("/console").expect("console namespace"),
+            "/index.html",
+        ] {
             let request = Request::builder()
                 .method(Method::GET)
                 .uri(path)
@@ -3983,7 +3987,7 @@ mod tests {
             "/minio/admin/v3/pools/cancel?versionId=unused",
             "/rustfs/admin/v3/pools/cancel?versionId=unused",
             "/rustfs/rpc/read_file_stream?versionId=unused",
-            "/rustfs/console/index.html?versionId=unused",
+            &format!("{CONSOLE_PREFIX}/index.html?versionId=unused"),
             "/health?versionId=unused",
             "/health/ready?versionId=unused",
             "/profile/cpu?versionId=unused",

--- a/rustfs/src/server/prefix.rs
+++ b/rustfs/src/server/prefix.rs
@@ -83,10 +83,12 @@ pub(crate) const RUSTFS_ADMIN_PREFIX: &str = "/rustfs/admin/v3";
 /// MinIO-compatible admin API prefix accepted by RustFS.
 pub(crate) const MINIO_ADMIN_V3_PREFIX: &str = "/minio/admin/v3";
 
-/// Predefined console prefix for RustFS server routes.
-/// This prefix is used for endpoints that handle console-related tasks
-/// such as user interface and management.
-pub(crate) const CONSOLE_PREFIX: &str = "/rustfs/console";
+/// Console prefix embedded at build time; it must match the console static assets.
+/// An unset or empty RUSTFS_CONSOLE_BASE_PATH preserves the default route.
+pub(crate) const CONSOLE_PREFIX: &str = match option_env!("RUSTFS_CONSOLE_BASE_PATH") {
+    Some(path) if !path.is_empty() => path,
+    _ => "/rustfs/console",
+};
 
 /// Predefined RPC prefix for RustFS server routes.
 /// This prefix is used for endpoints that handle remote procedure calls (RPC).

--- a/rustfs/src/server/rate_limit.rs
+++ b/rustfs/src/server/rate_limit.rs
@@ -779,7 +779,7 @@ mod tests {
             "/favicon.ico",
             "/rustfs/rpc/anything",
             "/node_service.NodeService/Ping",
-            "/rustfs/console/index.html",
+            &format!("{CONSOLE_PREFIX}/index.html"),
         ] {
             assert!(is_rate_limit_exempt_path(path), "{path} must be exempt");
         }

--- a/rustfs/src/server/readiness.rs
+++ b/rustfs/src/server/readiness.rs
@@ -1317,7 +1317,7 @@ mod tests {
         assert!(is_probe_path("/rustfs/admin/v3/info"));
         assert!(is_probe_path(&format!("{}/config", crate::server::TABLE_CATALOG_PREFIX)));
         assert!(is_probe_path("/_iceberg/v1/config"));
-        assert!(is_probe_path("/rustfs/console/"));
+        assert!(is_probe_path(&format!("{}/", crate::server::CONSOLE_PREFIX)));
         assert!(!is_probe_path("/minio/adminx/object"));
         assert!(!is_probe_path("/rustfs/adminx/object"));
         assert!(!is_probe_path("/bucket/object"));


### PR DESCRIPTION
## Related Issues

Builds on the runtime console prefix support in #7634. Companion console endpoint support: https://github.com/rustfs/console/pull/228.

## Summary of Changes

Allow OEM binaries to embed their console asset base path and startup default through the compile-time `RUSTFS_CONSOLE_BASE_PATH` variable. Unset or empty values preserve `/rustfs/console`. Keep the existing runtime routing and validation from #7634: `RUSTFS_CONSOLE_PREFIX`, when configured at startup, takes precedence over the compiled default.

Use the compiled path as the source for frontend asset adaptation. A console built at `/nuofans/console` can therefore run at its embedded default or a runtime override, including `/rustfs/console`, with matching asset references. Update route fixtures and asset tests to exercise OEM builds, preserve unrelated URLs and unchanged bytes, and document the two settings and their precedence.

## Verification

Tested the merge tree committed as `87af12e57780146189d776b1ded4f42b0f4339f2`, including `main` at `5c17012fe2532b796321c4095c2df58f7cc1837b`, with no further source changes:

- `RUSTFS_CONSOLE_BASE_PATH=/nuofans/console CARGO_BUILD_JOBS=4 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo +1.98.0 test -p rustfs --lib console_ -- --test-threads=1`: 59 tests passed. The subprocess cases cover startup defaults, runtime overrides, normalized nested prefixes, live browser redirects, OIDC URLs, health routes, and request classification. Asset tests cover the compiled source prefix and restoring the standard path from an OEM build.
- Rust compiler probes using the actual production prefix module passed all 12 combinations of unset, empty, and custom build values with runtime defaults and overrides. Changing `RUSTFS_CONSOLE_BASE_PATH` only at runtime did not replace the compiled value.
- `cargo fmt --all --check`, `./scripts/check_doc_paths.sh`, `./scripts/check_logging_guardrails.sh`, and `git diff --check` passed.

Full-workspace and cross-platform suites were not run locally; CI remains responsible for its standard matrix.

## Impact

Build the bundled console with `NEXT_PUBLIC_BASE_PATH` matching the server's `RUSTFS_CONSOLE_BASE_PATH`, without a trailing slash. Leave `RUSTFS_CONSOLE_PREFIX` unset to use the embedded OEM default, or configure it at startup to use the existing runtime override mechanism. Startup validation, S3/admin/RPC prefixes, and identity-provider callback endpoints are preserved.

Changing a deployed binary's `RUSTFS_CONSOLE_BASE_PATH` environment has no effect. To restore the standard build, rebuild both components with their build overrides unset and remove any runtime prefix override. Deployment probes, bookmarks, and console OIDC redirect registrations must match the effective console prefix.

## Additional Notes

No new dependencies. The macOS linker warned about an oversized unwind table; linking and all targeted tests completed successfully.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
