### PR TITLE
test(e2e): record deferred G14 outage writes

### DIFF
--- a/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
+++ b/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
@@ -2124,7 +2124,21 @@ mod tests {
                 evidence_context.run.binary.sha256,
                 "server build changed during restart"
             );
-            let evidence = serde_json::json!({
+            let outage_write_diagnostic = (!outage_target_manifest_required).then(|| {
+                serde_json::json!({
+                    "attempted": true,
+                    "required": false,
+                    "accepted": true,
+                    "attempts": if outage_write_deferred_until_rejoin {
+                        max_outage_write_attempts
+                    } else {
+                        service_unavailable_outage_writes + 1
+                    },
+                    "service_unavailable": service_unavailable_outage_writes,
+                    "deferred_until_rejoin": outage_write_deferred_until_rejoin,
+                })
+            });
+            let mut evidence = serde_json::json!({
                 "schema": 1, "case": evidence_context.case.id, "evidence": evidence_context.case.evidence,
                 "run_id": evidence_context.run.run_id, "source_revision": evidence_context.run.source_revision,
                 "test_build": compiled_test_identity(),
@@ -2147,6 +2161,9 @@ mod tests {
                 "unclean_shutdown_marker": unclean_shutdown_marker_observed.unwrap_or(false),
                 "objects": evidence_objects, "node_listings": node_listings,
             });
+            if let Some(outage_write) = outage_write_diagnostic {
+                evidence["outage_write"] = outage_write;
+            }
             let data = serde_json::to_vec(&evidence)?;
             if data.len() > 1024 * 1024 {
                 return Err("scanner/heal oracle exceeds the 1 MiB artifact budget".into());


### PR DESCRIPTION
## Summary
- include optional outage-write diagnostics in G14 e2e evidence oracles
- bind deferred multi-pool outage writes to down-window ServiceUnavailable counts and post-rejoin S3 acceptance

## Validation
- cargo fmt --all --check
- python3 scripts/check_test_wiring.py --self-test
- cargo test -p e2e_test test_cluster_root_heal_recovers_ec84_shards_across_multi_pool_after_background_target_crash --no-run
- git diff --check origin/release...HEAD

## Linux Evidence
- Current release-head multi-pool runtime passed before this patch, then evidence validation rejected the oracle because deferred outage-write diagnostics were missing.
- This PR adds the missing measured evidence fields; Linux measured proof will be rerun on the PR head.