### PR TITLE
chore(release): prepare 1.0.0-rc.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,9 +259,6 @@ jobs:
           } > artifacts/test-and-lint/doctest-diagnostics.txt
           exit "${status}"
 
-      - name: Check offline enrollment E2E root boundary
-        run: ./scripts/check_offline_enrollment_e2e.sh
-
       - name: Upload test reports and diagnostics
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
@@ -295,6 +292,36 @@ jobs:
       # quarantined so they gain nothing from the ci profile's retry overrides.
       - name: Run rebalance/decommission migration proofs
         run: ./scripts/check_migration_gate_count.sh
+
+  # The root boundary requires fresh CLI and integration-test builds. Give it
+  # its own time budget instead of sharing the workspace lint/test budget.
+  offline-enrollment-root-boundary:
+    name: Offline Enrollment Root Boundary
+    if: needs.classify-changes.outputs.mode == 'full' && (github.event_name != 'pull_request' || github.event.action != 'closed')
+    needs: [ quick-checks, classify-changes ]
+    runs-on: sm-standard-4
+    timeout-minutes: 90
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust environment
+        uses: ./.github/actions/setup
+        with:
+          rust-version: stable
+          cache-shared-key: ci-dev
+          cache-save-if: 'false'
+          install-build-packaging-tools: 'false'
+
+      - name: Protect Connect test home
+        run: chmod go-w "$(realpath "$HOME")"
+
+      - name: Check offline enrollment E2E root boundary
+        run: ./scripts/check_offline_enrollment_e2e.sh
 
   # Dedicated serial lane for the ILM / lifecycle integration tests. These tests
   # drive the object layer through process-global singletons (the GLOBAL_ENV
@@ -1189,6 +1216,7 @@ jobs:
       - typos
       - quick-checks
       - test-and-lint
+      - offline-enrollment-root-boundary
       - test-ilm-integration-serial
       - test-and-lint-rio-v2
       - connect-short-credential-boundary
@@ -1222,6 +1250,7 @@ jobs:
       - typos
       - quick-checks
       - test-and-lint
+      - offline-enrollment-root-boundary
       - test-ilm-integration-serial
       - test-and-lint-rio-v2
       - test-and-lint-protocols

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3986,7 +3986,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e_test"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -9476,7 +9476,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9624,7 +9624,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-audit"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "const-str",
  "futures",
@@ -9646,7 +9646,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-checksums"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9662,7 +9662,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-common"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "hotpath",
  "metrics",
@@ -9675,7 +9675,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-concurrency"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "hotpath",
  "insta",
@@ -9688,7 +9688,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-config"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "const-str",
  "hotpath",
@@ -9698,7 +9698,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-credentials"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "base64-simd",
  "hmac 0.13.0",
@@ -9712,7 +9712,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-crypto"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9733,7 +9733,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-data-usage"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "hotpath",
  "rmp-serde",
@@ -9743,7 +9743,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-ecstore"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -9879,7 +9879,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-extension-schema"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "hotpath",
  "serde",
@@ -9889,7 +9889,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-filemeta"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "byteorder",
@@ -9917,7 +9917,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -9954,7 +9954,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal-contracts"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -9964,7 +9964,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-iam"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -10013,7 +10013,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-core"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "bytes",
  "hotpath",
@@ -10025,7 +10025,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-metrics"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "criterion",
  "hotpath",
@@ -10089,7 +10089,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-keystone"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "bytes",
  "futures",
@@ -10116,7 +10116,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-kms"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -10166,14 +10166,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-license"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "rustfs-lifecycle"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "async-trait",
  "hotpath",
@@ -10195,7 +10195,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lock"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "async-trait",
  "compact_str",
@@ -10218,7 +10218,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-log-analyzer"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "chrono",
  "flate2",
@@ -10237,7 +10237,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-madmin"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "hotpath",
  "http 1.5.0",
@@ -10275,7 +10275,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-notify"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -10310,7 +10310,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-capacity"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "criterion",
  "futures",
@@ -10329,7 +10329,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-data-cache"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "bytes",
  "criterion",
@@ -10346,7 +10346,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-obs"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -10404,7 +10404,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-policy"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -10435,7 +10435,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protocols"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -10497,7 +10497,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protos"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "flatbuffers",
  "hotpath",
@@ -10522,7 +10522,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-replication"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "byteorder",
  "bytes",
@@ -10540,7 +10540,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -10584,7 +10584,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio-v2"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -10607,7 +10607,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-client"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -10651,7 +10651,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-ops"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "hotpath",
  "rustfs-s3-types",
@@ -10659,7 +10659,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-types"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "hotpath",
  "serde",
@@ -10668,7 +10668,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-api"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "async-compression",
@@ -10703,7 +10703,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-query"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -10724,7 +10724,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10770,7 +10770,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner-metrics"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "chrono",
  "jiff",
@@ -10785,7 +10785,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-security-governance"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "hotpath",
  "thiserror 2.0.20",
@@ -10793,7 +10793,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-signer"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -10811,7 +10811,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-storage-api"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "async-trait",
  "hotpath",
@@ -10826,7 +10826,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-targets"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -10880,7 +10880,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-test-utils"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "hotpath",
  "rustfs-data-usage",
@@ -10896,7 +10896,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-tls-runtime"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "hotpath",
@@ -10917,7 +10917,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-trusted-proxies"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -10954,7 +10954,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-utils"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "base64-simd",
  "blake2",
@@ -10996,7 +10996,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-zip"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/rustfs/rustfs"
 rust-version = "1.98.0"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 homepage = "https://rustfs.com"
 description = "RustFS is a high-performance distributed object storage software built using Rust, one of the most popular languages worldwide. "
 keywords = ["RustFS", "Minio", "object-storage", "filesystem", "s3"]
@@ -90,56 +90,56 @@ redundant_clone = "warn"
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rustfs = { path = "./rustfs", version = "1.0.0-rc.5" }
-rustfs-heal = { path = "crates/heal", version = "1.0.0-rc.5" }
-rustfs-heal-contracts = { path = "crates/heal-contracts", version = "1.0.0-rc.5" }
-rustfs-scanner-metrics = { path = "crates/scanner-metrics", version = "1.0.0-rc.5" }
-rustfs-audit = { path = "crates/audit", version = "1.0.0-rc.5" }
-rustfs-checksums = { path = "crates/checksums", version = "1.0.0-rc.5" }
-rustfs-common = { path = "crates/common", version = "1.0.0-rc.5" }
-rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-rc.5" }
-rustfs-config = { path = "./crates/config", version = "1.0.0-rc.5" }
-rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-rc.5" }
-rustfs-credentials = { path = "crates/credentials", version = "1.0.0-rc.5" }
-rustfs-crypto = { path = "crates/crypto", version = "1.0.0-rc.5" }
-rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-rc.5" }
-rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-rc.5" }
-rustfs-iam = { path = "crates/iam", version = "1.0.0-rc.5" }
-rustfs-keystone = { path = "crates/keystone", version = "1.0.0-rc.5" }
-rustfs-license = { path = "crates/license", version = "1.0.0-rc.5" }
-rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-rc.5" }
-rustfs-kms = { path = "crates/kms", version = "1.0.0-rc.5" }
-rustfs-lock = { path = "crates/lock", version = "1.0.0-rc.5" }
-rustfs-madmin = { path = "crates/madmin", version = "1.0.0-rc.5" }
-rustfs-notify = { path = "crates/notify", version = "1.0.0-rc.5" }
-rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-rc.5" }
-rustfs-io-core = { path = "crates/io-core", version = "1.0.0-rc.5" }
-rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-rc.5" }
-rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-rc.5", default-features = false }
-rustfs-log-analyzer = { path = "crates/log-analyzer", version = "1.0.0-rc.5" }
-rustfs-obs = { path = "crates/obs", version = "1.0.0-rc.5" }
-rustfs-policy = { path = "crates/policy", version = "1.0.0-rc.5" }
-rustfs-protos = { path = "crates/protos", version = "1.0.0-rc.5" }
-rustfs-protocols = { path = "crates/protocols", version = "1.0.0-rc.5" }
-rustfs-replication = { path = "crates/replication", version = "1.0.0-rc.5" }
-rustfs-rio = { path = "crates/rio", version = "1.0.0-rc.5" }
-rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-rc.5" }
-rustfs-s3-client = { path = "crates/s3-client", version = "1.0.0-rc.5" }
-rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-rc.5" }
-rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-rc.5" }
-rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-rc.5" }
-rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-rc.5" }
-rustfs-scanner = { path = "crates/scanner", version = "1.0.0-rc.5" }
-rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-rc.5" }
-rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-rc.5" }
-rustfs-signer = { path = "crates/signer", version = "1.0.0-rc.5" }
-rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-rc.5" }
-rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-rc.5" }
-rustfs-targets = { path = "crates/targets", version = "1.0.0-rc.5" }
-rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-rc.5" }
-rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-rc.5" }
-rustfs-utils = { path = "crates/utils", version = "1.0.0-rc.5" }
-rustfs-zip = { path = "./crates/zip", version = "1.0.0-rc.5" }
+rustfs = { path = "./rustfs", version = "1.0.0-rc.6" }
+rustfs-heal = { path = "crates/heal", version = "1.0.0-rc.6" }
+rustfs-heal-contracts = { path = "crates/heal-contracts", version = "1.0.0-rc.6" }
+rustfs-scanner-metrics = { path = "crates/scanner-metrics", version = "1.0.0-rc.6" }
+rustfs-audit = { path = "crates/audit", version = "1.0.0-rc.6" }
+rustfs-checksums = { path = "crates/checksums", version = "1.0.0-rc.6" }
+rustfs-common = { path = "crates/common", version = "1.0.0-rc.6" }
+rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-rc.6" }
+rustfs-config = { path = "./crates/config", version = "1.0.0-rc.6" }
+rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-rc.6" }
+rustfs-credentials = { path = "crates/credentials", version = "1.0.0-rc.6" }
+rustfs-crypto = { path = "crates/crypto", version = "1.0.0-rc.6" }
+rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-rc.6" }
+rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-rc.6" }
+rustfs-iam = { path = "crates/iam", version = "1.0.0-rc.6" }
+rustfs-keystone = { path = "crates/keystone", version = "1.0.0-rc.6" }
+rustfs-license = { path = "crates/license", version = "1.0.0-rc.6" }
+rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-rc.6" }
+rustfs-kms = { path = "crates/kms", version = "1.0.0-rc.6" }
+rustfs-lock = { path = "crates/lock", version = "1.0.0-rc.6" }
+rustfs-madmin = { path = "crates/madmin", version = "1.0.0-rc.6" }
+rustfs-notify = { path = "crates/notify", version = "1.0.0-rc.6" }
+rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-rc.6" }
+rustfs-io-core = { path = "crates/io-core", version = "1.0.0-rc.6" }
+rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-rc.6" }
+rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-rc.6", default-features = false }
+rustfs-log-analyzer = { path = "crates/log-analyzer", version = "1.0.0-rc.6" }
+rustfs-obs = { path = "crates/obs", version = "1.0.0-rc.6" }
+rustfs-policy = { path = "crates/policy", version = "1.0.0-rc.6" }
+rustfs-protos = { path = "crates/protos", version = "1.0.0-rc.6" }
+rustfs-protocols = { path = "crates/protocols", version = "1.0.0-rc.6" }
+rustfs-replication = { path = "crates/replication", version = "1.0.0-rc.6" }
+rustfs-rio = { path = "crates/rio", version = "1.0.0-rc.6" }
+rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-rc.6" }
+rustfs-s3-client = { path = "crates/s3-client", version = "1.0.0-rc.6" }
+rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-rc.6" }
+rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-rc.6" }
+rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-rc.6" }
+rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-rc.6" }
+rustfs-scanner = { path = "crates/scanner", version = "1.0.0-rc.6" }
+rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-rc.6" }
+rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-rc.6" }
+rustfs-signer = { path = "crates/signer", version = "1.0.0-rc.6" }
+rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-rc.6" }
+rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-rc.6" }
+rustfs-targets = { path = "crates/targets", version = "1.0.0-rc.6" }
+rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-rc.6" }
+rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-rc.6" }
+rustfs-utils = { path = "crates/utils", version = "1.0.0-rc.6" }
+rustfs-zip = { path = "./crates/zip", version = "1.0.0-rc.6" }
 
 # Async Runtime and Networking
 async-channel = "2.5.0"

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # Using specific version
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.5
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.6
 ```
 
 If you use [podman](https://github.com/containers/podman) instead of docker, you can install the RustFS with the below command

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -138,7 +138,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # 使用指定版本运行
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.5
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.6
 ```
 
 如果您通过绑定挂载启用 TLS 证书目录，也请用同样方式准备该目录：

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
 
           rustfs = rustPlatform.buildRustPackage {
             pname = "rustfs";
-            version = "1.0.0-rc.5";
+            version = "1.0.0-rc.6";
 
             src = ./.;
 

--- a/helm/rustfs/Chart.yaml
+++ b/helm/rustfs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rustfs
 description: RustFS helm chart to deploy RustFS on kubernetes cluster.
 type: application
-version: "1.0.0-rc.5"
-appVersion: "1.0.0-rc.5"
+version: "1.0.0-rc.6"
+appVersion: "1.0.0-rc.6"
 home: https://rustfs.com
 icon: https://media.sys.truenas.net/apps/rustfs/icons/icon.svg
 maintainers:

--- a/rustfs.spec
+++ b/rustfs.spec
@@ -1,9 +1,9 @@
 %global _enable_debug_packages 0
 %global _empty_manifest_terminate_build 0
-%global prerelease rc.5
+%global prerelease rc.6
 Name:           rustfs
 Version:        1.0.0
-Release:        rc.5
+Release:        rc.6
 Summary:       High-performance distributed object storage for MinIO alternative
 
 License:        Apache-2.0
@@ -58,6 +58,9 @@ install %_builddir/%{name}-%{version}-%{prerelease}/target/%_arch/%_arch-unknown
 %_bindir/rustfs
 
 %changelog
+* Thu Sep 10 2026 overtrue <anzhengchao@gmail.com>
+- Update RPM package to RustFS 1.0.0-rc.6
+
 * Mon Aug 31 2026 overtrue <anzhengchao@gmail.com>
 - Update RPM package to RustFS 1.0.0-rc.5
 

--- a/scripts/ci_gate.py
+++ b/scripts/ci_gate.py
@@ -15,6 +15,7 @@ ROOT = Path(__file__).resolve().parent.parent
 ALWAYS_JOBS = ("classify-changes", "typos", "quick-checks")
 CODE_JOBS = (
     "test-and-lint", "test-ilm-integration-serial", "test-and-lint-rio-v2",
+    "offline-enrollment-root-boundary",
     "connect-short-credential-boundary", "test-and-lint-protocols",
     "build-rustfs-debug-binary", "uring-integration", "e2e-tests",
     "s3-implemented-tests", "s3-lifecycle-behavior-tests",


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Prepare RustFS 1.0.0-rc.6 by updating all 51 workspace package versions, internal dependencies, and matching lockfile entries. Align Docker examples, the Nix package, Helm chart and app versions, and RPM metadata in the same release preparation commit. Move the offline enrollment root-boundary check into its own required CI lane so its isolated builds run alongside workspace linting and tests.

## Verification
- `cargo metadata --locked --no-deps --format-version 1` and a version consistency check passed: all 51 workspace packages use 1.0.0-rc.6, and Cargo.lock changes only workspace package versions.
- All `make pre-commit` guards passed. Its compilation step initially found the local default Rust 1.97.1 below the repository minimum; rerunning `RUSTUP_TOOLCHAIN=1.98.0 make quick-check` passed. After refreshing the integration base, `RUSTUP_TOOLCHAIN=1.98.0 cargo check -p rustfs --bin rustfs` also passed.
- `git diff --check` passed. The final version patch is unchanged after the base refresh; no third-party dependency changes are included.

- CI follow-up: `python3 scripts/ci_gate.py --self-test` passed all 9 tests, including failure/cancellation/skipping/missing-result rejection for every required lane; `python3 scripts/ci_gate.py --check-workflow`, `actionlint .github/workflows/ci.yml`, and `git diff --check` passed.
- The previous workspace job completed Clippy, nextest, and documentation tests, then exceeded its 90-minute limit while compiling/linking the isolated offline enrollment integration test: https://github.com/rustfs/rustfs/actions/runs/34466008070/job/102836656593. This was a timeout, not an observed assertion failure. Fresh CI is required after the lane split.

## Impact
Version and packaging metadata plus CI scheduling. Helm preserves the existing rc mapping: both chart version and appVersion are 1.0.0-rc.6. Preview identifiers remain tag-only and do not appear in version files. The offline enrollment script, isolated target directory, fixture checks, production CLI rejection, and 90-minute per-job limit are unchanged; the aggregate gate requires the new lane to succeed, and scheduled failures include it.

## Additional Notes
Console v0.1.26 passed its full release workflow and its uploaded ZIP digest and latest Release endpoint were verified. Integration PR #7638 is merged; its unfinished full CI was cancelled on closure, so it is not counted as a complete CI pass. This PR runs fresh CI. Preview publication also waits for the heal recovery fix in #7642, and full end-to-end tests must pass on the combined source commit before final-tag confirmation. RustFS preview acceptance will validate the release artifact before final tagging. Correctness and simplicity checks found consistent version metadata and complete required-gate wiring for the moved check. Rollback: revert the version preparation commit if the release is abandoned; the CI scheduling follow-up is independently reversible.
