### PR TITLE
test(ilm): restore noncurrent compensation tests to serial CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,11 +335,7 @@ jobs:
       # re-enabled by backlog#1304 (restore accepts serialize on a short CAS
       # guard; the copy-back no longer holds the #4877 whole-copy-back lock,
       # so the mid-restore ongoing read and fast 409 rejection it asserts are
-      # the implemented contract). The remaining exclusions each hit a
-      # DIFFERENT, independent issue (all tracked under rustfs/backlog#1148;
-      # they keep #[ignore] with a backlog reference):
-      #   - test_noncurrent_{expiry,transition}_still_works_after_immediate_compensation_transition:
-      #     noncurrent transition/expiry after an immediate compensation transition.
+      # the implemented contract).
       - name: Run ignored ILM integration tests serially
         env:
           # Match the measured Test and Lint link budget. The default exposed
@@ -352,7 +348,7 @@ jobs:
           NEXTEST_HIDE_PROGRESS_BAR=1 timeout --verbose --signal=TERM --kill-after=30s 80m \
             cargo nextest run -j1 --run-ignored ignored-only \
             -p rustfs-scanner -p rustfs \
-            -E '(binary(lifecycle_integration_test) or (package(rustfs) and test(lifecycle_transition_api_test))) and not (test(test_noncurrent_expiry_still_works_after_immediate_compensation_transition) or test(test_noncurrent_transition_still_works_after_immediate_compensation_transition))' \
+            -E 'binary(lifecycle_integration_test) or (package(rustfs) and test(lifecycle_transition_api_test))' \
             --status-level all --final-status-level all \
             2>&1 | tee artifacts/ilm-integration/nextest.log
           status=${PIPESTATUS[0]}

--- a/crates/scanner/tests/lifecycle_integration_test.rs
+++ b/crates/scanner/tests/lifecycle_integration_test.rs
@@ -1691,7 +1691,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial]
-    #[ignore = "FAILING on main: excluded from the serial ILM lane pending a fix, see rustfs/backlog#1148 (ilm-1 partial)"]
+    #[ignore = "global-state ILM integration test: runs serialized in the CI ILM Integration (serial) lane, see ci.yml test-ilm-integration-serial and rustfs/backlog#1148 (ilm-1)"]
     async fn test_noncurrent_expiry_still_works_after_immediate_compensation_transition() {
         let (disk_paths, ecstore) = setup_isolated_test_env(true).await;
 
@@ -1775,7 +1775,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial]
-    #[ignore = "FAILING on main: excluded from the serial ILM lane pending a fix, see rustfs/backlog#1148 (ilm-1 partial)"]
+    #[ignore = "global-state ILM integration test: runs serialized in the CI ILM Integration (serial) lane, see ci.yml test-ilm-integration-serial and rustfs/backlog#1148 (ilm-1)"]
     async fn test_noncurrent_transition_still_works_after_immediate_compensation_transition() {
         let (disk_paths, ecstore) = setup_isolated_test_env(true).await;
 


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1148 (ilm-1).

## Summary of Changes

The ILM serial lane still excluded the noncurrent expiration and noncurrent transition regressions after immediate compensation, even though both now pass on release. Remove those two name exclusions and update their obsolete failure annotations so they run with the other ignored ILM integration tests.

## Verification

Validated commit: `942836639b3a11cbd3d02def41dbc93eca007a75`, based on `release` at `00aeb1291470bb6a0f2099cb62e6d1a91b6d2d26`.

- Ran the scanner integration portion with the workflow's exact filter, `-j1`, and `--run-ignored ignored-only`: **20 passed in 22.443 seconds**. This includes both restored regressions; one non-ignored test remains in the default lane.
- Compared actual nextest listings using the old and new workflow filters: the scanner selection grows from **18 to 20**, adding exactly the two intended tests and removing none.
- `actionlint`, `cargo fmt --all --check`, `python3 scripts/check_test_wiring.py`, and `git diff --check` passed.

Local execution was on macOS. The combined Linux ILM lane, including the unchanged rustfs application tests, remains for CI validation. Full-workspace checks were not run for this two-file test-wiring change.

## Impact

Restores PR-gate coverage for noncurrent lifecycle behavior after compensation. The existing serial lane and process isolation remain in use; `#[ignore]` keeps these global-state tests out of the default parallel suite. Test bodies and product behavior are unchanged.

Rollback: revert this PR.

## Additional Notes

Correctness and simplicity review found no issues. The new filter is exactly the previous positive selection with the two exclusions removed. Normalizing the ignore-reason strings makes the Rust test file identical to its base version.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.`

