### PR TITLE
fix(scanner): wait for ABBA telemetry window

### DIFF
--- a/scripts/scanner_abba.py
+++ b/scripts/scanner_abba.py
@@ -654,9 +654,12 @@ def collect_live(prepared, request, request_path, adapter):
     if request.get("evidence") == "measured":
         expected_metrics_endpoints = request["release_evidence"]["distributed"]["metrics_endpoints"]
     output = request_path.parent / "telemetry"
+    interval_seconds = 60
+    sample_count = request["duration_seconds"] // interval_seconds + 1
+    collector_timeout_seconds = (sample_count - 1) * interval_seconds + 300
     args = ["bash", str(collector), "--alias", connection["alias"], "--endpoint", connection["endpoint"],
             "--metrics-endpoints", connection["metrics_endpoints"], "--deployment", "distributed",
-            "--samples", str(request["duration_seconds"] // 60 + 1), "--interval-secs", "60",
+            "--samples", str(sample_count), "--interval-secs", str(interval_seconds),
             "--out-dir", str(output)]
     with (request_path.parent / "collector.log").open("wb") as log:
         process = OwnedCommand(args, log)
@@ -664,10 +667,11 @@ def collect_live(prepared, request, request_path, adapter):
             started = time.monotonic()
             result = invoke(adapter, "measure", request_path, request["duration_seconds"] + 300)
             require(time.monotonic() - started >= request["duration_seconds"], "measurement ended before required window")
-            require(process.wait(120) == 0, "scanner collector failed")
+            require(process.wait(collector_timeout_seconds) == 0,
+                    f"scanner collector failed within {collector_timeout_seconds}s timeout")
             require(output.joinpath("scanner-summary.csv").stat().st_size > 0, "missing collector samples")
             samples = list((output / "status").glob("scanner-status.*.json"))
-            require(len(samples) == request["duration_seconds"] // 60 + 1, "missing scanner samples")
+            require(len(samples) == sample_count, "missing scanner samples")
             for sample in samples:
                 status = read_json(sample)
                 require(isinstance(status.get("metrics"), dict) and status["metrics"], "invalid scanner status response")


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#2428 and rustfs/backlog#2240.

## Summary of Changes
Measured scanner/heal ABBA runs start the telemetry collector before the workload window, then wait for the collector after the workload completes. The runner previously used a fixed 120 second collector wait, but a 7200 second measured run asks the harness for 121 samples at 60 second intervals. That makes the collector window about 7200 seconds plus command overhead, so the fixed wait can terminate the collector around the final sample boundary.

This change derives the collector wait budget from the requested sample count and interval, preserving the existing `duration / 60 + 1` sample requirement while allowing a 5 minute completion margin.

## Verification
- `PYTHONPYCACHEPREFIX=/tmp python3 -m py_compile scripts/scanner_abba.py` passed.
- `git diff --check` passed before commit.
- On the W13 Linux validation cluster, the failed measured run preserved `measure.json` for the first cell, collected 120 scanner samples, 480 background-heal samples, and 480 distributed metrics files, then failed with the fixed 120 second collector timeout before the expected 121st scanner sample.
- After applying this patch to the validation worktree, a direct distributed collector smoke with `--samples 2 --interval-secs 5` passed and produced 2 scanner snapshots, 8 background-heal snapshots, and 8 distributed metrics snapshots.

Relevant checks not run:
- Full measured ABBA matrix is being restarted separately because each measured cell is 7200 seconds and the full matrix is a long-running release evidence job.

## Impact
No RustFS service behavior or public API impact. This only changes the scanner/heal ABBA evidence runner timeout so long measured telemetry windows can complete.

## Additional Notes
The patch intentionally keeps the sample count unchanged instead of reducing telemetry coverage.
