### PR TITLE
fix(tables): reject reserved warehouse locations

### DIFF
--- a/rustfs/src/admin/handlers/table_catalog/mod.rs
+++ b/rustfs/src/admin/handlers/table_catalog/mod.rs
@@ -2515,6 +2515,11 @@ fn normalize_table_credential_object_prefix(object_prefix: &str) -> S3Result<Str
     if object_prefix.is_empty() {
         return Err(s3_error!(InvalidRequest, "table credential scope prefix is empty"));
     }
+    if crate::table_catalog::is_reserved_table_object_key(object_prefix) {
+        return Err(S3Error::from(ApiError::invalid_request(
+            "table credential scope overlaps the reserved table catalog prefix",
+        )));
+    }
     if object_prefix.contains('\\') {
         return Err(s3_error!(
             InvalidRequest,

--- a/rustfs/src/admin/handlers/table_catalog/tests.rs
+++ b/rustfs/src/admin/handlers/table_catalog/tests.rs
@@ -10619,6 +10619,10 @@ fn table_credential_scope_rejects_cross_bucket_or_unsafe_prefix() {
     assert!(table_credential_scope(&entry).is_err());
 
     let mut entry = table_entry_for_credentials();
+    entry.warehouse_location = "s3://warehouse/.rustfs-table".to_string();
+    assert!(table_credential_scope(&entry).is_err());
+
+    let mut entry = table_entry_for_credentials();
     entry.metadata_location = "s3://other/.rustfs-table/metadata/00001.metadata.json".to_string();
     assert!(table_credential_scope(&entry).is_err());
 

--- a/rustfs/src/table_catalog/iceberg/validation.rs
+++ b/rustfs/src/table_catalog/iceberg/validation.rs
@@ -69,6 +69,11 @@ fn warehouse_object_prefix_from_location(
             "table warehouse location must be inside the table bucket".to_string(),
         ));
     }
+    if is_reserved_table_object_key(object_prefix.strip_suffix('/').unwrap_or(object_prefix)) {
+        return Err(TableCatalogStoreError::Invalid(
+            "table warehouse location overlaps the reserved table catalog prefix".to_string(),
+        ));
+    }
     normalize_warehouse_object_prefix(object_prefix, max_prefix_depth)
 }
 

--- a/rustfs/src/table_catalog/tests.rs
+++ b/rustfs/src/table_catalog/tests.rs
@@ -5579,6 +5579,30 @@ async fn object_table_catalog_store_rejects_invalid_table_warehouse_location() {
     ));
 }
 
+#[test]
+fn warehouse_locations_reject_the_reserved_catalog_prefix() {
+    for location in [
+        "s3://analytics/.rustfs-table",
+        "s3://analytics/.rustfs-table/",
+        "s3://analytics/.rustfs-table/warehouses/default",
+    ] {
+        let table_error = validate_table_warehouse_location("analytics", location).unwrap_err();
+        assert!(matches!(
+            table_error,
+            TableCatalogStoreError::Invalid(message) if message.contains("reserved table catalog prefix")
+        ));
+
+        let view_error = validate_view_warehouse_location("analytics", location).unwrap_err();
+        assert!(matches!(
+            view_error,
+            TableCatalogStoreError::Invalid(message) if message.contains("reserved table catalog prefix")
+        ));
+    }
+
+    assert!(validate_table_warehouse_location("analytics", "s3://analytics/.rustfs-table-other/table-id").is_ok());
+    assert!(validate_table_warehouse_location("analytics", "s3://analytics/user/.rustfs-table/table-id").is_ok());
+}
+
 #[tokio::test]
 async fn object_table_catalog_store_rejects_deep_table_warehouse_location() {
     let backend = TestCatalogObjectBackend::default();


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Reject table and view warehouse locations that equal or descend from the `.rustfs-table` catalog-reserved prefix.
- Apply the same fail-closed check when deriving a table credential scope, preventing vended credentials from covering catalog metadata owned by other tables.
- Preserve valid sibling and nested user prefixes such as `.rustfs-table-other` and `user/.rustfs-table`.

## Verification

- `cargo +1.98.0 fmt --all --check` — passed.
- `CARGO_TARGET_DIR=/data/my/rustfs/target cargo +1.98.0 test -p rustfs --lib warehouse_locations_reject_the_reserved_catalog_prefix` — passed; covers the exact prefix, descendants, trailing slash, sibling, nested-user, table, and view cases.
- `CARGO_TARGET_DIR=/data/my/rustfs/target cargo +1.98.0 test -p rustfs --lib table_credential_scope_rejects_cross_bucket_or_unsafe_prefix` — failed before the credential-boundary check and passed after it was added.
- `scripts/check_s3s_footprint.sh` and `git diff --check` — passed on the final change.

Tested change is commit `d90075dfc` on upstream `d20059ab5`, with no local tracked changes. The final credential-scope test was rerun after replacing the new direct `s3_error!` call with the existing gateway error abstraction.

Adversarial validation used two fresh sequential passes. Pass 1 covered correctness and security by attacking root/descendant prefix capture, boundary lookalikes, persisted entry validation, and credential vending; it found and fixed the independent credential normalization path. Pass 2 covered simplicity, test coverage, and compatibility; the shared catalog validator remains canonical, credential issuance revalidates its own trust boundary, and normal Iceberg/Spark warehouse locations retain their existing behavior. No unresolved findings remain.

## Impact

New create, register, relocation, hydration, and credential-vending operations reject locations under `.rustfs-table`. Existing catalog entries using that invalid reserved location fail closed until moved or repaired. Ordinary warehouse locations and object data are unchanged.

Rollback is a revert of this commit. Reverting would restore the reserved-prefix credential escalation and should only be used after affected invalid entries are remediated by another mechanism.

## Additional Notes

This PR intentionally does not change authorization for reading catalog-owned metadata objects; that is handled independently to keep the compatibility boundary reviewable.

The current upstream `main` Quick Checks baseline fails `scripts/test_security_workflow.py` because the referenced fault-tolerance workflow and handoff step are absent. This branch does not change `.github/workflows` or that script; the shared baseline fix is tracked in #7682, whose Quick Checks pass.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
