### PR TITLE
fix(tables): authorize reserved metadata reads

### DIFF
--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -1638,6 +1638,8 @@ async fn table_data_plane_resource_for_request<T>(
         return Ok(None);
     }
 
+    let catalog_metadata = crate::table_catalog::is_reserved_table_object_key(object)
+        && crate::table_catalog::table_identity_from_metadata_object_key(object).is_some();
     let key = (bucket.to_string(), object.to_string());
     let retained = req
         .extensions
@@ -1649,38 +1651,50 @@ async fn table_data_plane_resource_for_request<T>(
         if state.missing_resources.contains(&key) {
             return Ok(None);
         }
-        if let Some(resource) = state
-            .resources
-            .values()
-            .find(|resource| resource.table_bucket == bucket && object.starts_with(&resource.warehouse_object_prefix))
-            .cloned()
+        if !catalog_metadata
+            && let Some(resource) = state
+                .resources
+                .values()
+                .find(|resource| resource.table_bucket == bucket && object.starts_with(&resource.warehouse_object_prefix))
+                .cloned()
         {
             return Ok(Some(resource));
         }
     }
 
     let store = table_catalog_store_for_data_plane(req)?;
-    let resource = crate::table_catalog::table_data_plane_resource_for_object(&store, bucket, object)
-        .await
-        .map_err(|err| {
-            tracing::warn!(
-                bucket = %bucket,
-                object = %object,
-                error = %err,
-                "failed to resolve table data-plane resource"
-            );
-            if matches!(err, crate::table_catalog::TableCatalogStoreError::Unavailable(_)) {
-                S3Error::from(ApiError::service_unavailable())
-            } else {
-                s3_error!(AccessDenied, "Access Denied")
-            }
-        })?;
+    let resource = if catalog_metadata {
+        crate::table_catalog::table_metadata_data_plane_resource_for_object(&store, bucket, object).await
+    } else {
+        crate::table_catalog::table_data_plane_resource_for_object(&store, bucket, object).await
+    }
+    .map_err(|err| {
+        tracing::warn!(
+            bucket = %bucket,
+            object = %object,
+            error = %err,
+            "failed to resolve table data-plane resource"
+        );
+        if matches!(err, crate::table_catalog::TableCatalogStoreError::Unavailable(_)) {
+            S3Error::from(ApiError::service_unavailable())
+        } else {
+            s3_error!(AccessDenied, "Access Denied")
+        }
+    })?;
+    let resource = require_owned_reserved_table_object(object, resource)?;
     let bucket_fence_key = (bucket.to_string(), crate::table_catalog::default_table_bucket_publication_lock_path());
     let mut state = retained.state.lock();
     if resource.is_none() && state.keys.contains(&bucket_fence_key) {
         state.missing_resources.insert(key);
         drop(state);
         req.extensions.insert(retained);
+    }
+    Ok(resource)
+}
+
+fn require_owned_reserved_table_object<T>(object: &str, resource: Option<T>) -> S3Result<Option<T>> {
+    if crate::table_catalog::is_reserved_table_object_key(object) && resource.is_none() {
+        return Err(S3Error::from(ApiError::access_denied()));
     }
     Ok(resource)
 }
@@ -3112,8 +3126,8 @@ mod tests {
         install_restore_authorization_test_hook, legal_hold_write_requested, list_parts_authorize_action,
         load_bucket_policy_existing_object_tag_hint, maybe_merge_object_tag_conditions, merge_list_bucket_query_conditions,
         merge_request_object_tag_conditions, owner_can_bypass_policy_deny, post_object_authorize_action,
-        put_bucket_policy_authorize_action, request_context_from_req, request_object_store, retention_write_requested,
-        secondary_tag_hint_action, table_data_plane_admin_action, table_data_plane_content_mutation,
+        put_bucket_policy_authorize_action, request_context_from_req, request_object_store, require_owned_reserved_table_object,
+        retention_write_requested, secondary_tag_hint_action, table_data_plane_admin_action, table_data_plane_content_mutation,
         table_data_plane_resource_for_request, table_publication_guard_error, validate_post_object_success_controls,
         versioned_read_action,
     };
@@ -3252,6 +3266,27 @@ mod tests {
             Some(rustfs_policy::policy::action::AdminAction::GetTableMetadataAction)
         );
         assert_eq!(table_data_plane_admin_action(Action::S3Action(S3Action::ListBucketAction)), None);
+    }
+
+    #[test]
+    fn reserved_table_metadata_requires_an_active_table_owner() {
+        let error = require_owned_reserved_table_object::<()>(
+            ".rustfs-table/warehouses/default/namespaces/analytics/tables/events/metadata/00001.metadata.json",
+            None,
+        )
+        .expect_err("unowned reserved metadata must fail closed");
+        assert_eq!(error.code(), &S3ErrorCode::AccessDenied);
+
+        assert!(
+            require_owned_reserved_table_object("objects/data.parquet", None::<()>)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            require_owned_reserved_table_object(".rustfs-table/metadata.json", Some(()))
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[test]
@@ -3591,6 +3626,35 @@ mod tests {
             .await
             .expect("commit should continue after the request releases its publication guard")
             .expect("commit task should join");
+    }
+
+    #[tokio::test]
+    async fn table_data_plane_request_reuses_reserved_warehouse_resource() {
+        let resource = crate::table_catalog::TableDataPlaneResource {
+            table_bucket: "warehouse".to_string(),
+            namespace: "analytics".to_string(),
+            table: "events".to_string(),
+            table_id: "table-id".to_string(),
+            warehouse_object_prefix: ".rustfs-table/custom-warehouse/events/".to_string(),
+        };
+        let retained = TableDataPlanePublicationGuards::default();
+        retained.state.lock().resources.insert(
+            (resource.table_bucket.clone(), resource.warehouse_object_prefix.clone()),
+            resource.clone(),
+        );
+        let mut req = build_request((), Method::GET);
+        req.extensions.insert(retained);
+
+        let resolved = table_data_plane_resource_for_request(
+            &mut req,
+            "warehouse",
+            ".rustfs-table/custom-warehouse/events/data/part-00001.parquet",
+            true,
+        )
+        .await
+        .expect("a reserved-prefix warehouse object should use ordinary table resolution");
+
+        assert_eq!(resolved, Some(resource));
     }
 
     #[tokio::test]

--- a/rustfs/src/table_catalog/iceberg/validation.rs
+++ b/rustfs/src/table_catalog/iceberg/validation.rs
@@ -281,6 +281,54 @@ where
     store.resolve_table_data_plane_resource(bucket, object).await
 }
 
+fn table_entry_owns_current_metadata_object(entry: &TableEntry, object: &str) -> bool {
+    entry.state == TableCatalogEntryState::Active
+        && table_catalog_object_key_from_location(&entry.table_bucket, &entry.metadata_location).as_deref() == Some(object)
+}
+
+pub(crate) fn table_metadata_data_plane_resource_from_entries<'a>(
+    entries: impl IntoIterator<Item = &'a TableEntry>,
+    bucket: &str,
+    object: &str,
+) -> TableCatalogStoreResult<Option<TableDataPlaneResource>> {
+    if bucket.is_empty() || table_identity_from_metadata_object_key(object).is_none() {
+        return Ok(None);
+    }
+
+    let mut matched = None;
+    for entry in entries {
+        if entry.table_bucket != bucket {
+            return Err(TableCatalogStoreError::Invalid(format!(
+                "metadata ownership scan for {bucket} returned a table from {}",
+                entry.table_bucket
+            )));
+        }
+        if !table_entry_owns_current_metadata_object(entry, object) {
+            continue;
+        }
+        let warehouse_object_prefix = table_warehouse_object_prefix(entry)?;
+        let resource = table_data_plane_resource_from_entry(entry.clone(), warehouse_object_prefix);
+        if matched.is_some() {
+            return Err(TableCatalogStoreError::Invalid(format!(
+                "reserved metadata object {object} is owned by multiple active tables"
+            )));
+        }
+        matched = Some(resource);
+    }
+    Ok(matched)
+}
+
+pub(crate) async fn table_metadata_data_plane_resource_for_object<S>(
+    store: &S,
+    bucket: &str,
+    object: &str,
+) -> TableCatalogStoreResult<Option<TableDataPlaneResource>>
+where
+    S: TableCatalogStore + ?Sized,
+{
+    store.resolve_table_metadata_data_plane_resource(bucket, object).await
+}
+
 pub(crate) async fn scan_table_data_plane_resource_for_object<S>(
     store: &S,
     bucket: &str,

--- a/rustfs/src/table_catalog/identifier.rs
+++ b/rustfs/src/table_catalog/identifier.rs
@@ -316,6 +316,19 @@ pub(crate) fn metadata_location_from_metadata_file_path(
         .map(|_| object_key.to_string())
 }
 
+pub(crate) fn table_identity_from_metadata_object_key(object_key: &str) -> Option<(Namespace, IdentifierSegment)> {
+    let namespace_root = default_namespace_root_prefix();
+    let relative = object_key.strip_prefix(&namespace_root)?;
+    let (namespace_storage_id, table_path) = relative.rsplit_once(&format!("/{TABLE_ROOT}/"))?;
+    let namespace = Namespace::from_segments(namespace_storage_id.split('/').map(str::to_string).collect()).ok()?;
+    let (table_name, metadata_file_name) = table_path.split_once(&format!("/{METADATA_DIR}/"))?;
+    let table = IdentifierSegment::parse(table_name).ok()?;
+    if !is_valid_table_metadata_file_name(metadata_file_name) {
+        return None;
+    }
+    Some((namespace, table))
+}
+
 fn table_metadata_dir_from_object_key(object_key: &str) -> Option<String> {
     let namespace_root = default_namespace_root_prefix();
     let relative = object_key.strip_prefix(&namespace_root)?;

--- a/rustfs/src/table_catalog/mod.rs
+++ b/rustfs/src/table_catalog/mod.rs
@@ -73,8 +73,8 @@ pub(crate) use identifier::{
     default_table_bucket_publication_lock_path, default_table_data_dir_path, default_table_delete_dir_path,
     default_table_metadata_dir_path, default_table_metadata_file_path, default_table_publication_lock_path,
     default_view_metadata_file_path, is_valid_table_metadata_location, is_valid_table_metadata_location_for_entry,
-    is_valid_view_metadata_location, metadata_location_from_metadata_file_path, table_metadata_dir_path_for_entry,
-    table_metadata_file_path_for_entry, validate_bucket_object_mutation,
+    is_valid_view_metadata_location, metadata_location_from_metadata_file_path, table_identity_from_metadata_object_key,
+    table_metadata_dir_path_for_entry, table_metadata_file_path_for_entry, validate_bucket_object_mutation,
 };
 pub(crate) use maintenance::*;
 pub(crate) use model::*;

--- a/rustfs/src/table_catalog/store/mod.rs
+++ b/rustfs/src/table_catalog/store/mod.rs
@@ -282,6 +282,24 @@ pub(crate) trait TableCatalogStore: Send + Sync {
         scan_table_data_plane_resource_for_object(self, table_bucket, object).await
     }
 
+    async fn resolve_table_metadata_data_plane_resource(
+        &self,
+        table_bucket: &str,
+        object: &str,
+    ) -> TableCatalogStoreResult<Option<TableDataPlaneResource>> {
+        if table_bucket.is_empty() || table_identity_from_metadata_object_key(object).is_none() {
+            return Ok(None);
+        }
+        let Some(table_bucket_entry) = self.get_table_bucket(table_bucket).await? else {
+            return Ok(None);
+        };
+        if table_bucket_entry.state != TableCatalogEntryState::Active {
+            return Ok(None);
+        }
+        let entries = self.list_all_tables(table_bucket).await?;
+        table_metadata_data_plane_resource_from_entries(&entries, table_bucket, object)
+    }
+
     /// Atomically advances a validated table metadata pointer.
     ///
     /// Callers publishing client-supplied Iceberg metadata must validate its logical shape and the physical graph of
@@ -1272,6 +1290,17 @@ where
         match self {
             Self::ObjectBacked(store) => store.resolve_table_data_plane_resource(table_bucket, object).await,
             Self::DurableStrong(store) => store.resolve_table_data_plane_resource(table_bucket, object).await,
+        }
+    }
+
+    async fn resolve_table_metadata_data_plane_resource(
+        &self,
+        table_bucket: &str,
+        object: &str,
+    ) -> TableCatalogStoreResult<Option<TableDataPlaneResource>> {
+        match self {
+            Self::ObjectBacked(store) => store.resolve_table_metadata_data_plane_resource(table_bucket, object).await,
+            Self::DurableStrong(store) => store.resolve_table_metadata_data_plane_resource(table_bucket, object).await,
         }
     }
 

--- a/rustfs/src/table_catalog/store/object.rs
+++ b/rustfs/src/table_catalog/store/object.rs
@@ -804,6 +804,20 @@ where
         Ok(Some((entry, etag)))
     }
 
+    async fn table_data_plane_read_version(&self, table_bucket: &str) -> TableCatalogStoreResult<String> {
+        let Some((entry, etag)) = self.table_rename_read_snapshot(table_bucket).await? else {
+            return Err(TableCatalogStoreError::Internal(format!(
+                "object-backed catalog has no entry for table-enabled bucket {table_bucket}"
+            )));
+        };
+        if entry.state != TableCatalogEntryState::Active {
+            return Err(TableCatalogStoreError::Internal(format!(
+                "table-enabled bucket {table_bucket} has an inactive object-backed catalog entry"
+            )));
+        }
+        Ok(etag)
+    }
+
     async fn finish_table_rename_read(&self, table_bucket: &str, expected_version: Option<&str>) -> TableCatalogStoreResult<()> {
         let object = self.paths.table_bucket_entry_path(table_bucket);
         let current_version =
@@ -5102,16 +5116,7 @@ where
         if table_bucket.is_empty() || object.is_empty() {
             return Ok(None);
         }
-        let Some((table_bucket_entry, read_version)) = self.table_rename_read_snapshot(table_bucket).await? else {
-            return Err(TableCatalogStoreError::Internal(format!(
-                "object-backed catalog has no entry for table-enabled bucket {table_bucket}"
-            )));
-        };
-        if table_bucket_entry.state != TableCatalogEntryState::Active {
-            return Err(TableCatalogStoreError::Internal(format!(
-                "table-enabled bucket {table_bucket} has an inactive object-backed catalog entry"
-            )));
-        }
+        let read_version = self.table_data_plane_read_version(table_bucket).await?;
 
         let resource = if self.warehouse_index_ready(table_bucket).await? {
             match self
@@ -5141,6 +5146,21 @@ where
                 Err(err) => Err(err),
             }
         }?;
+        self.finish_table_rename_read(table_bucket, Some(&read_version)).await?;
+        Ok(resource)
+    }
+
+    async fn resolve_table_metadata_data_plane_resource(
+        &self,
+        table_bucket: &str,
+        object: &str,
+    ) -> TableCatalogStoreResult<Option<TableDataPlaneResource>> {
+        if table_bucket.is_empty() || table_identity_from_metadata_object_key(object).is_none() {
+            return Ok(None);
+        }
+        let read_version = self.table_data_plane_read_version(table_bucket).await?;
+        let entries = self.list_all_table_entries(table_bucket).await?;
+        let resource = table_metadata_data_plane_resource_from_entries(&entries, table_bucket, object)?;
         self.finish_table_rename_read(table_bucket, Some(&read_version)).await?;
         Ok(resource)
     }

--- a/rustfs/src/table_catalog/store/strong.rs
+++ b/rustfs/src/table_catalog/store/strong.rs
@@ -1531,6 +1531,33 @@ where
         Ok(())
     }
 
+    fn require_data_plane_ready_locked(
+        &self,
+        state: &StrongTableCatalogState,
+        table_bucket: &str,
+    ) -> TableCatalogStoreResult<()> {
+        let Some(bucket_entry) = state.table_buckets.get(table_bucket) else {
+            return Err(TableCatalogStoreError::Internal(format!(
+                "durable strong catalog has no entry for table-enabled bucket {table_bucket}"
+            )));
+        };
+        if bucket_entry.state != TableCatalogEntryState::Active {
+            return Err(TableCatalogStoreError::Internal(format!(
+                "table-enabled bucket {table_bucket} has an inactive durable strong catalog entry"
+            )));
+        }
+        if self.snapshot_write_version >= STRONG_TABLE_CATALOG_SNAPSHOT_VERSION
+            && state
+                .snapshot_version
+                .is_none_or(|version| version < STRONG_TABLE_CATALOG_SNAPSHOT_VERSION)
+        {
+            return Err(TableCatalogStoreError::Internal(
+                "durable strong catalog data-plane access requires a version 2 snapshot after fleet confirmation".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     fn ensure_table_warehouse_prefix_available_locked(
         state: &StrongTableCatalogState,
         candidate: &TableEntry,
@@ -2390,25 +2417,7 @@ where
 
         self.hydrate_state().await?;
         let state = self.state.lock().await;
-        let Some(bucket_entry) = state.table_buckets.get(table_bucket) else {
-            return Err(TableCatalogStoreError::Internal(format!(
-                "durable strong catalog has no entry for table-enabled bucket {table_bucket}"
-            )));
-        };
-        if bucket_entry.state != TableCatalogEntryState::Active {
-            return Err(TableCatalogStoreError::Internal(format!(
-                "table-enabled bucket {table_bucket} has an inactive durable strong catalog entry"
-            )));
-        }
-        if self.snapshot_write_version >= STRONG_TABLE_CATALOG_SNAPSHOT_VERSION
-            && state
-                .snapshot_version
-                .is_none_or(|version| version < STRONG_TABLE_CATALOG_SNAPSHOT_VERSION)
-        {
-            return Err(TableCatalogStoreError::Internal(
-                "durable strong catalog data-plane access requires a version 2 snapshot after fleet confirmation".to_string(),
-            ));
-        }
+        self.require_data_plane_ready_locked(&state, table_bucket)?;
 
         let Some(bucket_index) = state.warehouse_index.get(table_bucket) else {
             return Ok(None);
@@ -2427,6 +2436,27 @@ where
             }
         }
         Ok(None)
+    }
+
+    async fn resolve_table_metadata_data_plane_resource(
+        &self,
+        table_bucket: &str,
+        object: &str,
+    ) -> TableCatalogStoreResult<Option<TableDataPlaneResource>> {
+        if table_bucket.is_empty() || table_identity_from_metadata_object_key(object).is_none() {
+            return Ok(None);
+        }
+
+        self.hydrate_state().await?;
+        let state = self.state.lock().await;
+        self.require_data_plane_ready_locked(&state, table_bucket)?;
+        Self::ensure_table_bucket_identifiers_are_unambiguous_locked(&state, table_bucket)?;
+        let entries = state
+            .tables
+            .range((table_bucket.to_string(), String::new(), String::new())..)
+            .take_while(|((bucket, _, _), _)| bucket == table_bucket)
+            .map(|(_, entry)| entry);
+        table_metadata_data_plane_resource_from_entries(entries, table_bucket, object)
     }
 
     async fn commit_table(&self, request: TableCommitRequest) -> TableCatalogStoreResult<TableCommitResult> {

--- a/rustfs/src/table_catalog/tests.rs
+++ b/rustfs/src/table_catalog/tests.rs
@@ -3880,6 +3880,96 @@ async fn table_data_plane_resource_resolves_registered_warehouse_prefix() {
 }
 
 #[tokio::test]
+async fn table_metadata_data_plane_resource_resolves_only_current_metadata() {
+    let backend = TestCatalogObjectBackend::default();
+    let store = ObjectTableCatalogStore::new(backend.clone());
+    let bucket = "analytics";
+    let namespace = Namespace::parse("sales").unwrap();
+    let table = IdentifierSegment::parse("orders").unwrap();
+    let current = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+
+    seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
+    backend.reset_call_counts().await;
+
+    let resource = table_metadata_data_plane_resource_for_object(&store, bucket, &current)
+        .await
+        .expect("metadata ownership lookup should succeed")
+        .expect("current metadata should resolve to its table");
+    assert_eq!(resource.namespace, "sales");
+    assert_eq!(resource.table, "orders");
+    assert_eq!(backend.list_call_count().await, 1);
+    assert_eq!(backend.read_call_count().await, 2);
+    assert_eq!(backend.metadata_call_count().await, 1);
+
+    let historical = default_table_metadata_file_path(&namespace, &table, "00000.metadata.json");
+    assert!(
+        table_metadata_data_plane_resource_for_object(&store, bucket, &historical)
+            .await
+            .expect("historical metadata lookup should succeed")
+            .is_none()
+    );
+    assert!(
+        table_metadata_data_plane_resource_for_object(&store, bucket, "tables/table-id/data/file.parquet")
+            .await
+            .expect("ordinary object lookup should succeed")
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn table_metadata_data_plane_resource_follows_a_renamed_table() {
+    let backend = TestCatalogObjectBackend::default();
+    let store = ObjectTableCatalogStore::new(backend);
+    let bucket = "analytics";
+    let namespace = Namespace::parse("sales").unwrap();
+    let table = IdentifierSegment::parse("orders").unwrap();
+    let current = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+
+    seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
+    store
+        .rename_table(bucket, "sales", "orders", "sales", "archived_orders")
+        .await
+        .expect("table rename should succeed");
+
+    let resource = table_metadata_data_plane_resource_for_object(&store, bucket, &current)
+        .await
+        .expect("renamed metadata ownership lookup should succeed")
+        .expect("current metadata should remain owned after rename");
+    assert_eq!(resource.namespace, "sales");
+    assert_eq!(resource.table, "archived_orders");
+}
+
+#[tokio::test]
+async fn table_metadata_data_plane_resource_rejects_multiple_active_owners() {
+    let backend = TestCatalogObjectBackend::default();
+    let store = ObjectTableCatalogStore::new(backend);
+    let bucket = "analytics";
+    let namespace = Namespace::parse("sales").unwrap();
+    let table = IdentifierSegment::parse("orders").unwrap();
+    let current = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+
+    seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
+    store
+        .rename_table(bucket, "sales", "orders", "sales", "archived_orders")
+        .await
+        .expect("table rename should succeed");
+
+    let mut replacement = test_table_entry(bucket, &namespace, &table, current.clone());
+    replacement.table_id = "replacement-table-id".to_string();
+    replacement.table_uuid = "replacement-table-uuid".to_string();
+    replacement.warehouse_location = format!("s3://{bucket}/tables/replacement-table-id");
+    store
+        .create_table(replacement)
+        .await
+        .expect("replacement table should be created");
+
+    assert_matches!(
+        table_metadata_data_plane_resource_for_object(&store, bucket, &current).await,
+        Err(TableCatalogStoreError::Invalid(message)) if message.contains("multiple active tables")
+    );
+}
+
+#[tokio::test]
 async fn table_data_plane_resource_does_not_match_sibling_prefix() {
     let backend = TestCatalogObjectBackend::default();
     let store = ObjectTableCatalogStore::new(backend.clone());
@@ -12482,24 +12572,78 @@ async fn strong_catalog_backing_resolves_data_plane_resource_without_catalog_sca
 }
 
 #[tokio::test]
+async fn strong_catalog_table_metadata_data_plane_resource_resolves_only_current_metadata() {
+    let backend = TestCatalogObjectBackend::default();
+    let store = StrongTableCatalogStore::new(backend);
+    let bucket = "analytics";
+    let namespace = Namespace::parse("sales").expect("namespace should parse");
+    let table = IdentifierSegment::parse("orders").expect("table should parse");
+    let current = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+
+    store
+        .put_table_bucket(test_bucket_entry(bucket))
+        .await
+        .expect("table bucket should be created");
+    store
+        .create_namespace(test_namespace_entry(bucket, &namespace))
+        .await
+        .expect("namespace should be created");
+    store
+        .create_table(test_table_entry(bucket, &namespace, &table, current.clone()))
+        .await
+        .expect("table should be created");
+
+    let resource = table_metadata_data_plane_resource_for_object(&store, bucket, &current)
+        .await
+        .expect("metadata ownership lookup should succeed")
+        .expect("current metadata should resolve to its table");
+    assert_eq!(resource.namespace, "sales");
+    assert_eq!(resource.table, "orders");
+
+    let historical = default_table_metadata_file_path(&namespace, &table, "00000.metadata.json");
+    assert!(
+        table_metadata_data_plane_resource_for_object(&store, bucket, &historical)
+            .await
+            .expect("historical metadata lookup should succeed")
+            .is_none()
+    );
+}
+
+#[tokio::test]
 async fn strong_catalog_data_plane_fails_closed_for_missing_bucket_snapshot() {
     let store = StrongTableCatalogStore::new(TestCatalogObjectBackend::default());
+    let namespace = Namespace::parse("sales").expect("namespace should parse");
+    let table = IdentifierSegment::parse("orders").expect("table should parse");
+    let metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
 
     let error = table_data_plane_resource_for_object(&store, "analytics", "tables/table-id/data/file.parquet")
         .await
         .expect_err("a table-enabled bucket missing from the strong snapshot must fail closed");
 
     assert_matches!(error, TableCatalogStoreError::Internal(message) if message.contains("no entry for table-enabled bucket"));
+
+    let error = table_metadata_data_plane_resource_for_object(&store, "analytics", &metadata)
+        .await
+        .expect_err("metadata access must reject a missing strong bucket snapshot");
+    assert_matches!(error, TableCatalogStoreError::Internal(message) if message.contains("no entry for table-enabled bucket"));
 }
 
 #[tokio::test]
 async fn object_catalog_data_plane_fails_closed_for_missing_bucket_entry() {
     let store = ObjectTableCatalogStore::new(TestCatalogObjectBackend::default());
+    let namespace = Namespace::parse("sales").expect("namespace should parse");
+    let table = IdentifierSegment::parse("orders").expect("table should parse");
+    let metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
 
     let error = table_data_plane_resource_for_object(&store, "analytics", "tables/table-id/data/file.parquet")
         .await
         .expect_err("a table-enabled bucket missing from the object catalog must fail closed");
 
+    assert_matches!(error, TableCatalogStoreError::Internal(message) if message.contains("no entry for table-enabled bucket"));
+
+    let error = table_metadata_data_plane_resource_for_object(&store, "analytics", &metadata)
+        .await
+        .expect_err("metadata access must reject a missing object-backed bucket entry");
     assert_matches!(error, TableCatalogStoreError::Internal(message) if message.contains("no entry for table-enabled bucket"));
 }
 
@@ -12507,6 +12651,9 @@ async fn object_catalog_data_plane_fails_closed_for_missing_bucket_entry() {
 async fn catalog_backings_fail_closed_for_inactive_table_bucket_data_plane() {
     let bucket = "analytics";
     let object = "tables/table-id/data/file.parquet";
+    let namespace = Namespace::parse("sales").expect("namespace should parse");
+    let table = IdentifierSegment::parse("orders").expect("table should parse");
+    let metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
     let mut inactive = test_bucket_entry(bucket);
     inactive.state = TableCatalogEntryState::Deleted;
 
@@ -12518,6 +12665,13 @@ async fn catalog_backings_fail_closed_for_inactive_table_bucket_data_plane() {
     let object_error = table_data_plane_resource_for_object(&object_store, bucket, object)
         .await
         .expect_err("inactive object-backed table buckets must fail closed");
+    assert_matches!(
+        object_error,
+        TableCatalogStoreError::Internal(message) if message.contains("inactive object-backed catalog entry")
+    );
+    let object_error = table_metadata_data_plane_resource_for_object(&object_store, bucket, &metadata)
+        .await
+        .expect_err("metadata access must reject an inactive object-backed table bucket");
     assert_matches!(
         object_error,
         TableCatalogStoreError::Internal(message) if message.contains("inactive object-backed catalog entry")
@@ -12535,6 +12689,13 @@ async fn catalog_backings_fail_closed_for_inactive_table_bucket_data_plane() {
         strong_error,
         TableCatalogStoreError::Internal(message) if message.contains("inactive durable strong catalog entry")
     );
+    let strong_error = table_metadata_data_plane_resource_for_object(&strong_store, bucket, &metadata)
+        .await
+        .expect_err("metadata access must reject an inactive durable strong table bucket");
+    assert_matches!(
+        strong_error,
+        TableCatalogStoreError::Internal(message) if message.contains("inactive durable strong catalog entry")
+    );
 }
 
 #[tokio::test]
@@ -12543,18 +12704,19 @@ async fn strong_catalog_data_plane_requires_v2_snapshot_after_fleet_confirmation
     let bucket = "analytics";
     let namespace = Namespace::parse("sales").expect("namespace should parse");
     let table = IdentifierSegment::parse("orders").expect("table should parse");
-    let table_entry = test_table_entry(
-        bucket,
-        &namespace,
-        &table,
-        default_table_metadata_file_path(&namespace, &table, "00001.metadata.json"),
-    );
+    let metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+    let table_entry = test_table_entry(bucket, &namespace, &table, metadata.clone());
     seed_strong_snapshot(&backend, &test_strong_snapshot(bucket, &namespace, vec![table_entry], Vec::new())).await;
     let store = StrongTableCatalogStore::new_with_snapshot_write_version(backend.clone(), STRONG_TABLE_CATALOG_SNAPSHOT_VERSION);
 
     let error = table_data_plane_resource_for_object(&store, bucket, "tables/table-id/data/file.parquet")
         .await
         .expect_err("fleet-confirmed readers must reject a version 1 snapshot on the data plane");
+    assert_matches!(error, TableCatalogStoreError::Internal(message) if message.contains("requires a version 2 snapshot"));
+
+    let error = table_metadata_data_plane_resource_for_object(&store, bucket, &metadata)
+        .await
+        .expect_err("fleet-confirmed readers must reject metadata from a version 1 snapshot");
     assert_matches!(error, TableCatalogStoreError::Internal(message) if message.contains("requires a version 2 snapshot"));
 
     store
@@ -12566,6 +12728,12 @@ async fn strong_catalog_data_plane_requires_v2_snapshot_after_fleet_confirmation
         table_data_plane_resource_for_object(&store, bucket, "tables/table-id/data/file.parquet")
             .await
             .expect("version 2 data-plane lookup should succeed")
+            .is_some()
+    );
+    assert!(
+        table_metadata_data_plane_resource_for_object(&store, bucket, &metadata)
+            .await
+            .expect("version 2 metadata lookup should succeed")
             .is_some()
     );
 }


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Resolve catalog-owned `.rustfs-table` metadata objects to the active table that currently owns the exact metadata location.
- Require the existing `admin:GetTableMetadata` data-plane authorization for that table before S3 GET/HEAD-style reads proceed.
- Deny historical, malformed, unowned, or multiply-owned reserved metadata paths instead of allowing broad S3 credentials to read them.
- Preserve renamed-table access by resolving exact current metadata ownership from one backing-consistent active-table snapshot.
- Keep non-metadata objects in accepted `.rustfs-table` warehouse locations on the existing warehouse data-plane resolver.
- Apply the object-backed bucket-version guard and the durable-strong active-bucket/v2-snapshot gates to metadata ownership resolution.

## Verification

- `cargo +1.98.0 fmt --all -- --check` and `git diff --check` — passed.
- `cargo +1.98.0 clippy -p rustfs --all-targets -- -D warnings` — passed; the final hot-path-only edit was also rechecked with the `--lib` target.
- `cargo +1.98.0 test -p rustfs --lib table_metadata_data_plane_resource` — passed 4 tests covering object-backed and strong-backed catalogs, renamed tables, current versus historical metadata, and ambiguous ownership.
- Focused inactive-bucket, missing-bucket, durable-strong v1/v2 snapshot, and reserved-prefix warehouse resolver tests — passed 5 tests.
- `make architecture-migration-check`, `scripts/check_layer_dependencies.sh`, and `make embedded-secrets-check` — passed.

Tested change is commit `9e5aed0f1` on upstream `release` at `684900fbb`, with no local tracked changes. The final rebase was conflict-free, and `range-diff` confirmed that the tested patch was unchanged.

Adversarial validation used two fresh sequential passes. Correctness and security verified exact metadata routing, request-local cache isolation, fail-closed missing/inactive/ambiguous ownership, and both catalog backings. Concurrency and durability verified that object-backed resolution uses one bucket-versioned ownership scan and durable-strong resolution holds one hydrated snapshot lock without awaits. Compatibility verified that Iceberg REST payloads, metadata JSON, manifests, snapshots, object locations, and IAM action names are unchanged. Performance verified that ordinary table reads short-circuit before metadata parsing and that the object-backed metadata path removes the former point lookup before its required ownership scan. Simplicity and test coverage verified that backing-specific readiness stays behind the catalog store interface and that every review regression has a focused test. No unresolved findings remain.

The object-backed catalog performs a complete active-table ownership check for a reserved current-metadata read. This is deliberate fail-closed behavior for rename/name-reuse ambiguity; a future metadata ownership index could remove that scan without weakening the invariant.

## Impact

This does not change the Iceberg REST protocol or table metadata format, and it does not delete, move, or rewrite user objects. Spark and other Iceberg clients using RustFS-vended table credentials retain access because those credentials already grant the exact metadata object and `admin:GetTableMetadata` for the table resource.

Static credentials that previously had only broad S3 permissions will receive `AccessDenied` for `.rustfs-table` metadata until the corresponding table permission is granted. Historical or unowned reserved metadata remains denied by design. Ordinary buckets, non-reserved objects, and current warehouse data keep their existing behavior.

Rollback is a revert of this commit. Reverting would restore broad-S3 access to catalog-owned metadata and should only be used with an equivalent authorization control in place.

## Additional Notes

This PR intentionally does not change warehouse-location validation. Accepted warehouse locations under `.rustfs-table` retain their existing data-read behavior; catalog metadata still requires exact current ownership.

The previous release-based head passed workspace tests/lints, swift, sftp, S3, and end-to-end jobs. Its rio-v2 matrix had one unrelated `rustfs-ecstore::store::init::tests::tier_overwrite_put_and_self_copy_recover_persisted_cleanup_owners` timeout after 32.571 seconds (`cleanup must converge: Elapsed(())`); this PR does not change `crates/ecstore`. The rebased review-fix head receives a fresh CI run.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
