### PR TITLE
fix(tables): isolate protected S3 listings

### DIFF
--- a/docs/architecture/s3-tables-support-matrix.md
+++ b/docs/architecture/s3-tables-support-matrix.md
@@ -25,6 +25,7 @@ RustFS S3 Tables is an Iceberg REST Catalog and table-bucket implementation on t
 | `/iceberg/v1` | Supported | Canonical REST Catalog prefix; default REST signing name `s3`. |
 | `/_iceberg/v1` | Supported compatibility alias | MinIO AIStor-style alias; smoke profile defaults to signing name `s3tables`. |
 | S3 object data plane | Supported | Data, metadata, manifest, and delete files are ordinary S3 objects with table-aware policy checks on warehouse paths. |
+| S3 table-bucket listings | Supported | `ListObjects`, `ListObjectsV2`, `ListObjectVersions`, metadata-list extensions, and multipart-upload listings omit warehouse objects unless the caller has `admin:GetTableMetadata` for that table, and always omit internal `.rustfs-table` keys. Protected cursors are encrypted with a key derived from the cluster root credentials, so rotating those credentials invalidates cursors already issued. |
 | Table bucket enablement | Supported | A regular bucket is enabled for catalog use and addressed as the REST catalog warehouse. |
 | Catalog-vended table credentials | Automated when enabled | Disabled by default. LoadTable vends credentials only when `X-Iceberg-Access-Delegation` contains the exact `vended-credentials` token; the dedicated credentials endpoint uses the same issuer path. |
 | AWS S3 Tables endpoint shape | Profile generator | Generates the AWS catalog URI and warehouse ARN shape for migration docs. API parity not claimed. |

--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -19,7 +19,7 @@ use super::storage_api::bucket_usecase::StorageObjectInfo as ObjectInfo;
 #[cfg(test)]
 use super::storage_api::bucket_usecase::access::ReqInfo;
 use super::storage_api::bucket_usecase::access::{
-    authorize_request, bucket_config_mutation_incarnation, log_list_buckets_iam_implicit_deny,
+    TableDataPlaneListAccess, authorize_request, bucket_config_mutation_incarnation, log_list_buckets_iam_implicit_deny,
     prepare_list_buckets_iam_authorization, prepare_odm_read_generation, req_info_ref,
 };
 #[cfg(test)]
@@ -71,6 +71,7 @@ use crate::app::runtime_sources::{
     AppContext, current_app_context, current_encryption_service, current_notification_system,
     current_notify_interface_for_context, current_object_data_cache_for_context, current_object_store_handle_for_context,
 };
+use crate::app::table_list_isolation;
 use crate::auth::get_condition_values_with_client_info;
 use crate::error::ApiError;
 use crate::shared_types::RemoteAddr;
@@ -2780,6 +2781,7 @@ impl DefaultBucketUsecase {
         let incl_deleted = get_header(&req.headers, rustfs_utils::http::SUFFIX_INCLUDE_DELETED)
             .map(|v| v.as_ref() == "true")
             .unwrap_or_default();
+        let table_list_access = req.extensions.get::<TableDataPlaneListAccess>().cloned();
 
         // The on-demand migration envelope is decoded whether or not this
         // bucket still merges: a token handed out under `list_through` must keep
@@ -2788,55 +2790,87 @@ impl DefaultBucketUsecase {
             prepare_odm_read_generation(&store, &mut req, &bucket).await;
         }
         let (merged_token, source_state) = if allow_list_through {
-            (
-                list_through::decode_list_cursor(params.decoded_continuation_token.as_deref())?,
-                list_through::list_through_state(&store, &bucket, &req, &params).await?,
-            )
+            let source_state = list_through::list_through_state(&store, &bucket, &req, &params).await?;
+            if table_list_access.is_some() {
+                if source_state.is_some() {
+                    return Err(S3Error::with_message(
+                        S3ErrorCode::ServiceUnavailable,
+                        "protected table listings are unavailable while on-demand migration list-through is active".to_string(),
+                    ));
+                }
+                (None, None)
+            } else {
+                (
+                    list_through::decode_list_cursor(params.decoded_continuation_token.as_deref())?,
+                    source_state,
+                )
+            }
         } else {
             (None, None)
         };
-        let (object_infos, degraded) = match (source_state, merged_token.as_ref()) {
-            (None, Some(token)) if params.max_keys == 0 => {
-                // No source was consulted, so retain every unconsumed side and
-                // the original wire format without spending its progress budget.
-                let is_truncated = !token.local_done || !token.source_done;
-                (
-                    StorageListObjectsV2Info {
-                        is_truncated,
-                        next_continuation_token: params.decoded_continuation_token.clone().filter(|_| is_truncated),
-                        ..Default::default()
-                    },
-                    false,
-                )
-            }
-            (None, None) => {
-                let infos = store
-                    .list_objects_v2(
-                        &bucket,
-                        &params.prefix,
-                        params.decoded_continuation_token.clone(),
-                        params.delimiter.clone(),
-                        params.max_keys,
-                        fetch_owner.unwrap_or_default(),
-                        params.start_after_for_query.clone(),
+        let (object_infos, degraded) = if let Some(access) = table_list_access.as_ref() {
+            (
+                table_list_isolation::list_objects_v2(
+                    store.clone(),
+                    access,
+                    table_list_isolation::ListObjectsV2Request {
+                        bucket: &bucket,
+                        prefix: &params.prefix,
+                        continuation_token: params.decoded_continuation_token.as_deref(),
+                        delimiter: params.delimiter.as_deref(),
+                        max_keys: params.max_keys,
+                        start_after: params.start_after_for_query.as_deref(),
                         incl_deleted,
-                    )
-                    .await
-                    .map_err(ApiError::from)?;
-                (infos, false)
-            }
-            (state, token) => {
-                let outcome = list_through::merged_list_objects_v2(
-                    &store,
-                    state.as_ref(),
-                    &bucket,
-                    &params,
-                    fetch_owner.unwrap_or_default(),
-                    incl_deleted,
-                    token,
+                        opaque_cursor_supported: allow_list_through,
+                    },
                 )
-                .await?;
-                (outcome.info, outcome.degraded)
+                .await?,
+                false,
+            )
+        } else {
+            match (source_state, merged_token.as_ref()) {
+                (None, Some(token)) if params.max_keys == 0 => {
+                    // No source was consulted, so retain every unconsumed side and
+                    // the original wire format without spending its progress budget.
+                    let is_truncated = !token.local_done || !token.source_done;
+                    (
+                        StorageListObjectsV2Info {
+                            is_truncated,
+                            next_continuation_token: params.decoded_continuation_token.clone().filter(|_| is_truncated),
+                            ..Default::default()
+                        },
+                        false,
+                    )
+                }
+                (None, None) => {
+                    let infos = store
+                        .list_objects_v2(
+                            &bucket,
+                            &params.prefix,
+                            params.decoded_continuation_token.clone(),
+                            params.delimiter.clone(),
+                            params.max_keys,
+                            fetch_owner.unwrap_or_default(),
+                            params.start_after_for_query.clone(),
+                            incl_deleted,
+                        )
+                        .await
+                        .map_err(ApiError::from)?;
+                    (infos, false)
+                }
+                (state, token) => {
+                    let outcome = list_through::merged_list_objects_v2(
+                        &store,
+                        state.as_ref(),
+                        &bucket,
+                        &params,
+                        fetch_owner.unwrap_or_default(),
+                        incl_deleted,
+                        token,
+                    )
+                    .await?;
+                    (outcome.info, outcome.degraded)
+                }
             }
         };
 
@@ -2885,19 +2919,38 @@ impl DefaultBucketUsecase {
             .map(|value| value.as_ref() == "true")
             .unwrap_or_default();
 
-        let object_infos = store
-            .list_objects_v2(
-                &bucket,
-                &params.prefix,
-                params.decoded_continuation_token.clone(),
-                params.delimiter.clone(),
-                params.max_keys,
-                fetch_owner.unwrap_or_default(),
-                params.start_after_for_query.clone(),
-                incl_deleted,
-            )
-            .await
-            .map_err(ApiError::from)?;
+        let object_infos = match req.extensions.get::<TableDataPlaneListAccess>() {
+            Some(access) => {
+                table_list_isolation::list_objects_v2(
+                    store.clone(),
+                    access,
+                    table_list_isolation::ListObjectsV2Request {
+                        bucket: &bucket,
+                        prefix: &params.prefix,
+                        continuation_token: params.decoded_continuation_token.as_deref(),
+                        delimiter: params.delimiter.as_deref(),
+                        max_keys: params.max_keys,
+                        start_after: params.start_after_for_query.as_deref(),
+                        incl_deleted,
+                        opaque_cursor_supported: true,
+                    },
+                )
+                .await?
+            }
+            None => store
+                .list_objects_v2(
+                    &bucket,
+                    &params.prefix,
+                    params.decoded_continuation_token.clone(),
+                    params.delimiter.clone(),
+                    params.max_keys,
+                    fetch_owner.unwrap_or_default(),
+                    params.start_after_for_query.clone(),
+                    incl_deleted,
+                )
+                .await
+                .map_err(ApiError::from)?,
+        };
 
         let permissions = collect_list_objects_metadata_permissions(&req, &bucket, &object_infos.objects).await?;
         let output = build_list_objects_v2_metadata_output(
@@ -2916,6 +2969,7 @@ impl DefaultBucketUsecase {
         &self,
         req: S3Request<ListObjectVersionsInput>,
     ) -> S3Result<S3Response<ListObjectVersionsOutput>> {
+        let table_list_access = req.extensions.get::<TableDataPlaneListAccess>().cloned();
         let ListObjectVersionsInput {
             bucket,
             delimiter,
@@ -2931,17 +2985,34 @@ impl DefaultBucketUsecase {
 
         let store = get_validated_store(&bucket).await?;
 
-        let object_infos = store
-            .list_object_versions(
-                &bucket,
-                &params.prefix,
-                params.key_marker.clone(),
-                params.version_id_marker.clone(),
-                params.delimiter.clone(),
-                params.max_keys,
-            )
-            .await
-            .map_err(ApiError::from)?;
+        let object_infos = match table_list_access.as_ref() {
+            Some(access) => {
+                table_list_isolation::list_object_versions(
+                    store.clone(),
+                    access,
+                    table_list_isolation::ListObjectVersionsRequest {
+                        bucket: &bucket,
+                        prefix: &params.prefix,
+                        key_marker: params.key_marker.as_deref(),
+                        version_id_marker: params.version_id_marker.as_deref(),
+                        delimiter: params.delimiter.as_deref(),
+                        max_keys: params.max_keys,
+                    },
+                )
+                .await?
+            }
+            None => store
+                .list_object_versions(
+                    &bucket,
+                    &params.prefix,
+                    params.key_marker.clone(),
+                    params.version_id_marker.clone(),
+                    params.delimiter.clone(),
+                    params.max_keys,
+                )
+                .await
+                .map_err(ApiError::from)?,
+        };
 
         let output = build_list_object_versions_output(object_infos, bucket, &params, encoding_type.as_ref());
 
@@ -2967,17 +3038,34 @@ impl DefaultBucketUsecase {
         let params = parse_list_object_versions_params(prefix, delimiter, key_marker, version_id_marker, max_keys)?;
 
         let store = get_validated_store(&bucket).await?;
-        let object_infos = store
-            .list_object_versions(
-                &bucket,
-                &params.prefix,
-                params.key_marker.clone(),
-                params.version_id_marker.clone(),
-                params.delimiter.clone(),
-                params.max_keys,
-            )
-            .await
-            .map_err(ApiError::from)?;
+        let object_infos = match req.extensions.get::<TableDataPlaneListAccess>() {
+            Some(access) => {
+                table_list_isolation::list_object_versions(
+                    store.clone(),
+                    access,
+                    table_list_isolation::ListObjectVersionsRequest {
+                        bucket: &bucket,
+                        prefix: &params.prefix,
+                        key_marker: params.key_marker.as_deref(),
+                        version_id_marker: params.version_id_marker.as_deref(),
+                        delimiter: params.delimiter.as_deref(),
+                        max_keys: params.max_keys,
+                    },
+                )
+                .await?
+            }
+            None => store
+                .list_object_versions(
+                    &bucket,
+                    &params.prefix,
+                    params.key_marker.clone(),
+                    params.version_id_marker.clone(),
+                    params.delimiter.clone(),
+                    params.max_keys,
+                )
+                .await
+                .map_err(ApiError::from)?,
+        };
 
         let permissions = collect_list_objects_metadata_permissions(&req, &bucket, &object_infos.objects).await?;
         let output =
@@ -2989,9 +3077,13 @@ impl DefaultBucketUsecase {
     #[instrument(level = "debug", skip(self, req))]
     pub async fn execute_list_objects(&self, req: S3Request<ListObjectsInput>) -> S3Result<S3Response<ListObjectsOutput>> {
         let request_marker = req.input.marker.clone();
+        let protected_table_list = req.extensions.get::<TableDataPlaneListAccess>().is_some();
         // V1 markers are object keys, so they cannot carry the opaque merged
         // pagination state used by V2 list-through.
-        let v2_resp = self.execute_list_objects_v2_inner(req.map_input(Into::into), false).await?;
+        let mut v2_resp = self.execute_list_objects_v2_inner(req.map_input(Into::into), false).await?;
+        if protected_table_list {
+            v2_resp.output.next_continuation_token = None;
+        }
 
         Ok(v2_resp.map_output(|v2| build_list_objects_output(v2, request_marker)))
     }

--- a/rustfs/src/app/mod.rs
+++ b/rustfs/src/app/mod.rs
@@ -28,6 +28,7 @@ pub mod object_usecase;
 pub(crate) mod runtime_sources;
 mod select_object;
 pub(crate) mod storage_api;
+pub(crate) mod table_list_isolation;
 
 #[cfg(test)]
 mod capacity_dirty_scope_test;

--- a/rustfs/src/app/multipart_usecase.rs
+++ b/rustfs/src/app/multipart_usecase.rs
@@ -16,8 +16,8 @@
 
 use super::storage_api::multipart_usecase::ECStore;
 use super::storage_api::multipart_usecase::access::{
-    apply_bucket_generation_guard, apply_copy_source_bucket_generation_guard, has_bypass_governance_header,
-    replication_request_authorized,
+    TableDataPlaneListAccess, apply_bucket_generation_guard, apply_copy_source_bucket_generation_guard,
+    has_bypass_governance_header, replication_request_authorized,
 };
 use super::storage_api::multipart_usecase::bucket::quota::checker::QuotaChecker;
 use super::storage_api::multipart_usecase::bucket::{
@@ -82,6 +82,7 @@ use crate::app::object_usecase::{
 use crate::app::runtime_sources::{
     AppContext, current_app_context, current_object_data_cache_for_context, current_object_store_handle_for_context,
 };
+use crate::app::table_list_isolation;
 use crate::auth::{
     VerifiedPresignedRequest, VerifiedSigV4Request, parse_presigned_multipart_max_total_object_size,
     reject_presigned_multipart_max_total_object_size_for_other_operation,
@@ -1468,6 +1469,7 @@ impl DefaultMultipartUsecase {
         &self,
         req: S3Request<ListMultipartUploadsInput>,
     ) -> S3Result<S3Response<ListMultipartUploadsOutput>> {
+        let table_list_access = req.extensions.get::<TableDataPlaneListAccess>().cloned();
         reject_presigned_multipart_max_total_object_size_for_other_operation(
             &req.headers,
             req.uri.query(),
@@ -1508,18 +1510,36 @@ impl DefaultMultipartUsecase {
             None => store.bucket_incarnation_id_from_disk(&bucket).await.map_err(ApiError::from)?,
         };
 
-        let result = store
-            .list_multipart_uploads_for_bucket_incarnation(
-                &bucket,
-                &prefix,
-                key_marker,
-                upload_id_marker,
-                delimiter,
-                max_uploads,
-                expected_incarnation_id,
-            )
-            .await
-            .map_err(ApiError::from)?;
+        let result = match table_list_access.as_ref() {
+            Some(access) => {
+                table_list_isolation::list_multipart_uploads(
+                    store.clone(),
+                    access,
+                    table_list_isolation::ListMultipartUploadsRequest {
+                        bucket: &bucket,
+                        prefix: &prefix,
+                        key_marker: key_marker.as_deref(),
+                        upload_id_marker: upload_id_marker.as_deref(),
+                        delimiter: delimiter.as_deref(),
+                        max_uploads,
+                        expected_incarnation_id,
+                    },
+                )
+                .await?
+            }
+            None => store
+                .list_multipart_uploads_for_bucket_incarnation(
+                    &bucket,
+                    &prefix,
+                    key_marker,
+                    upload_id_marker,
+                    delimiter,
+                    max_uploads,
+                    expected_incarnation_id,
+                )
+                .await
+                .map_err(ApiError::from)?,
+        };
 
         Ok(S3Response::new(build_list_multipart_uploads_output(bucket, prefix, result)))
     }

--- a/rustfs/src/app/storage_api.rs
+++ b/rustfs/src/app/storage_api.rs
@@ -265,7 +265,8 @@ pub(crate) mod access {
     #[cfg(test)]
     pub(crate) use crate::storage::storage_api::access_consumer::ReqInfo;
     pub(crate) use crate::storage::storage_api::access_consumer::{
-        PostObjectRequestMarker, apply_bucket_generation_guard, apply_copy_source_bucket_generation_guard, authorize_request,
+        PostObjectRequestMarker, TABLE_DATA_PLANE_LIST_CURSOR_PREFIX, TableDataPlaneListAccess, TableDataPlaneListCursorPosition,
+        apply_bucket_generation_guard, apply_copy_source_bucket_generation_guard, authorize_request,
         bucket_config_mutation_incarnation, has_bypass_governance_header, load_bucket_generation_from_store,
         log_list_buckets_iam_implicit_deny, odm_read_generation, prepare_list_buckets_iam_authorization,
         prepare_odm_read_generation, recursive_force_delete_is_authorized, replication_request_authorized, req_info_mut,
@@ -1225,7 +1226,9 @@ pub(crate) mod multipart_usecase {
         }
 
         pub(crate) mod multipart {
-            pub(crate) use super::super::super::storage_contracts::{CompletePart, MultipartOperations, MultipartUploadResult};
+            pub(crate) use super::super::super::storage_contracts::{
+                CompletePart, ListMultipartsInfo, MultipartInfo, MultipartOperations, MultipartUploadResult,
+            };
             pub(crate) use crate::storage::storage_api::s3_api_consumer::multipart::contract::multipart::MAX_MULTIPART_PART_NUMBER;
         }
 

--- a/rustfs/src/app/table_list_isolation.rs
+++ b/rustfs/src/app/table_list_isolation.rs
@@ -1,0 +1,672 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::app::storage_api::bucket_usecase::access::{
+    TABLE_DATA_PLANE_LIST_CURSOR_PREFIX, TableDataPlaneListAccess, TableDataPlaneListCursorPosition,
+};
+use crate::app::storage_api::bucket_usecase::contract::list::{ListObjectVersionsInfo, ListObjectsV2Info, ListOperations as _};
+use crate::app::storage_api::bucket_usecase::{ECStore, StorageObjectInfo as ObjectInfo};
+use crate::app::storage_api::multipart_usecase::contract::multipart::{ListMultipartsInfo, MultipartInfo};
+use crate::app::storage_api::s3::{S3Error, S3ErrorCode, S3Result};
+use crate::error::ApiError;
+use std::collections::HashSet;
+use std::sync::Arc;
+use uuid::Uuid;
+
+const TABLE_LIST_RAW_PAGE_SIZE: i32 = 1000;
+const TABLE_LIST_RAW_PAGE_SIZE_USIZE: usize = 1000;
+const TABLE_LIST_MAX_RAW_PAGES: usize = 16;
+const LIST_OBJECTS_V2_OPERATION: &str = "ListObjectsV2";
+const LIST_OBJECTS_V2_INCLUDE_DELETED_OPERATION: &str = "ListObjectsV2:include-deleted";
+const LIST_OBJECT_VERSIONS_OPERATION: &str = "ListObjectVersions";
+const LIST_MULTIPART_UPLOADS_OPERATION: &str = "ListMultipartUploads";
+
+enum ObjectListEntry {
+    Object,
+    Prefix(String),
+}
+
+pub(crate) struct ListObjectsV2Request<'a> {
+    pub(crate) bucket: &'a str,
+    pub(crate) prefix: &'a str,
+    pub(crate) continuation_token: Option<&'a str>,
+    pub(crate) delimiter: Option<&'a str>,
+    pub(crate) max_keys: i32,
+    pub(crate) start_after: Option<&'a str>,
+    pub(crate) incl_deleted: bool,
+    pub(crate) opaque_cursor_supported: bool,
+}
+
+pub(crate) struct ListObjectVersionsRequest<'a> {
+    pub(crate) bucket: &'a str,
+    pub(crate) prefix: &'a str,
+    pub(crate) key_marker: Option<&'a str>,
+    pub(crate) version_id_marker: Option<&'a str>,
+    pub(crate) delimiter: Option<&'a str>,
+    pub(crate) max_keys: i32,
+}
+
+pub(crate) struct ListMultipartUploadsRequest<'a> {
+    pub(crate) bucket: &'a str,
+    pub(crate) prefix: &'a str,
+    pub(crate) key_marker: Option<&'a str>,
+    pub(crate) upload_id_marker: Option<&'a str>,
+    pub(crate) delimiter: Option<&'a str>,
+    pub(crate) max_uploads: usize,
+    pub(crate) expected_incarnation_id: Uuid,
+}
+
+fn table_list_scan_limit_error() -> S3Error {
+    S3Error::with_message(
+        S3ErrorCode::SlowDown,
+        "Table listing exceeded the protected scan limit; retry with a narrower prefix".to_string(),
+    )
+}
+
+fn invalid_table_list_cursor() -> S3Error {
+    S3Error::with_message(S3ErrorCode::InvalidArgument, "Invalid table listing continuation token".to_string())
+}
+
+fn list_objects_v2_operation(incl_deleted: bool) -> &'static str {
+    if incl_deleted {
+        LIST_OBJECTS_V2_INCLUDE_DELETED_OPERATION
+    } else {
+        LIST_OBJECTS_V2_OPERATION
+    }
+}
+
+fn object_list_entry(object: &ObjectInfo, prefix: &str, delimiter: Option<&str>) -> Option<ObjectListEntry> {
+    if object.name.is_empty() {
+        return None;
+    }
+    let Some(delimiter) = delimiter else {
+        return Some(ObjectListEntry::Object);
+    };
+    let suffix = object.name.strip_prefix(prefix)?;
+    match suffix.find(delimiter) {
+        Some(index) => Some(ObjectListEntry::Prefix(format!("{prefix}{}", &suffix[..index + delimiter.len()]))),
+        None => Some(ObjectListEntry::Object),
+    }
+}
+
+fn multipart_list_entry(upload: MultipartInfo, prefix: &str, delimiter: Option<&str>) -> Option<MultipartListEntry> {
+    if upload.object.is_empty() {
+        return None;
+    }
+    let Some(delimiter) = delimiter else {
+        return Some(MultipartListEntry::Upload(upload));
+    };
+    let suffix = upload.object.strip_prefix(prefix)?;
+    match suffix.find(delimiter) {
+        Some(index) => Some(MultipartListEntry::Prefix(format!("{prefix}{}", &suffix[..index + delimiter.len()]))),
+        None => Some(MultipartListEntry::Upload(upload)),
+    }
+}
+
+enum MultipartListEntry {
+    Upload(MultipartInfo),
+    Prefix(String),
+}
+
+fn table_list_cursor_from_markers(
+    access: &TableDataPlaneListAccess,
+    operation: &str,
+    prefix: &str,
+    delimiter: Option<&str>,
+    max_keys: usize,
+    marker: Option<&str>,
+    version_marker: Option<&str>,
+) -> S3Result<(Option<String>, Option<String>, Option<String>)> {
+    let Some(marker) = marker else {
+        return Ok((None, None, None));
+    };
+    if !marker.starts_with(TABLE_DATA_PLANE_LIST_CURSOR_PREFIX) || version_marker != Some(marker) {
+        return Ok((Some(marker.to_string()), version_marker.map(str::to_string), None));
+    }
+    let cursor = access.decode_cursor(operation, prefix, delimiter, max_keys, marker)?;
+    Ok((
+        cursor.marker().map(str::to_string),
+        cursor.version_marker().map(str::to_string),
+        cursor.common_prefix().map(str::to_string),
+    ))
+}
+
+pub(crate) async fn list_objects_v2(
+    store: Arc<ECStore>,
+    access: &TableDataPlaneListAccess,
+    request: ListObjectsV2Request<'_>,
+) -> S3Result<ListObjectsV2Info<ObjectInfo>> {
+    let ListObjectsV2Request {
+        bucket,
+        prefix,
+        continuation_token,
+        delimiter,
+        max_keys,
+        start_after,
+        incl_deleted,
+        opaque_cursor_supported,
+    } = request;
+    if max_keys == 0 {
+        return Ok(ListObjectsV2Info::default());
+    }
+    let max_keys = usize::try_from(max_keys).map_err(|_| invalid_table_list_cursor())?;
+    let operation = list_objects_v2_operation(incl_deleted);
+    let (mut marker, mut last_visible_common_prefix) = match continuation_token {
+        Some(token) => {
+            if !token.starts_with(TABLE_DATA_PLANE_LIST_CURSOR_PREFIX) {
+                return Err(invalid_table_list_cursor());
+            }
+            let cursor = access.decode_cursor(operation, prefix, delimiter, max_keys, token)?;
+            (cursor.marker().map(str::to_string), cursor.common_prefix().map(str::to_string))
+        }
+        None => (None, None),
+    };
+    let common_prefix_floor = continuation_token.is_none().then_some(start_after).flatten();
+    let mut raw_start_after = continuation_token
+        .is_none()
+        .then(|| start_after.map(str::to_string))
+        .flatten();
+    let mut objects = Vec::new();
+    let mut prefixes = Vec::new();
+    let mut emitted_prefixes = HashSet::new();
+    if let Some(common_prefix) = &last_visible_common_prefix {
+        emitted_prefixes.insert(common_prefix.clone());
+    }
+
+    for page_index in 0..TABLE_LIST_MAX_RAW_PAGES {
+        let raw = store
+            .clone()
+            .list_objects_v2(
+                bucket,
+                prefix,
+                marker.clone(),
+                None,
+                TABLE_LIST_RAW_PAGE_SIZE,
+                false,
+                raw_start_after.take(),
+                incl_deleted,
+            )
+            .await
+            .map_err(ApiError::from)?;
+
+        let mut marker_after_visible = marker.clone();
+        let mut marker_after_scanned = marker.clone();
+        let mut found_more = false;
+        for object in raw.objects {
+            let object_name = object.name.clone();
+            let next_marker = Some(object_name.clone());
+            marker_after_scanned.clone_from(&next_marker);
+            let Some(entry) = object_list_entry(&object, prefix, delimiter) else {
+                continue;
+            };
+            if matches!(&entry, ObjectListEntry::Prefix(prefix) if common_prefix_floor.is_some_and(|floor| prefix.as_str() <= floor))
+            {
+                marker_after_visible.clone_from(&next_marker);
+                continue;
+            }
+            if matches!(&entry, ObjectListEntry::Prefix(prefix) if emitted_prefixes.contains(prefix)) {
+                marker_after_visible.clone_from(&next_marker);
+                continue;
+            }
+            if !access.allows_object(&object_name) {
+                continue;
+            }
+            match entry {
+                ObjectListEntry::Object if objects.len() + prefixes.len() < max_keys => {
+                    objects.push(object);
+                    marker_after_visible.clone_from(&next_marker);
+                    last_visible_common_prefix = None;
+                }
+                ObjectListEntry::Prefix(prefix) if objects.len() + prefixes.len() < max_keys => {
+                    emitted_prefixes.insert(prefix.clone());
+                    prefixes.push(prefix);
+                    marker_after_visible.clone_from(&next_marker);
+                    last_visible_common_prefix = prefixes.last().cloned();
+                }
+                _ => {
+                    found_more = true;
+                    break;
+                }
+            }
+        }
+
+        if found_more {
+            let next_continuation_token = access.encode_cursor(
+                operation,
+                prefix,
+                delimiter,
+                max_keys,
+                TableDataPlaneListCursorPosition {
+                    marker: marker_after_visible,
+                    version_marker: None,
+                    common_prefix: last_visible_common_prefix,
+                },
+            )?;
+            return Ok(ListObjectsV2Info {
+                is_truncated: true,
+                next_continuation_token: Some(next_continuation_token),
+                objects,
+                prefixes,
+                ..Default::default()
+            });
+        }
+        if !raw.is_truncated {
+            return Ok(ListObjectsV2Info {
+                objects,
+                prefixes,
+                ..Default::default()
+            });
+        }
+        if marker_after_scanned == marker {
+            return Err(table_list_scan_limit_error());
+        }
+        marker = marker_after_scanned;
+        if page_index + 1 == TABLE_LIST_MAX_RAW_PAGES {
+            if !opaque_cursor_supported {
+                return Err(table_list_scan_limit_error());
+            }
+            let next_continuation_token = access.encode_cursor(
+                operation,
+                prefix,
+                delimiter,
+                max_keys,
+                TableDataPlaneListCursorPosition {
+                    marker,
+                    version_marker: None,
+                    common_prefix: last_visible_common_prefix,
+                },
+            )?;
+            return Ok(ListObjectsV2Info {
+                is_truncated: true,
+                next_continuation_token: Some(next_continuation_token),
+                objects,
+                prefixes,
+                ..Default::default()
+            });
+        }
+    }
+
+    Err(table_list_scan_limit_error())
+}
+
+pub(crate) async fn list_object_versions(
+    store: Arc<ECStore>,
+    access: &TableDataPlaneListAccess,
+    request: ListObjectVersionsRequest<'_>,
+) -> S3Result<ListObjectVersionsInfo<ObjectInfo>> {
+    let ListObjectVersionsRequest {
+        bucket,
+        prefix,
+        key_marker,
+        version_id_marker,
+        delimiter,
+        max_keys,
+    } = request;
+    if max_keys == 0 {
+        return Ok(ListObjectVersionsInfo::default());
+    }
+    let max_keys = usize::try_from(max_keys).map_err(|_| invalid_table_list_cursor())?;
+    let (mut marker, mut version_marker, mut last_visible_common_prefix) = table_list_cursor_from_markers(
+        access,
+        LIST_OBJECT_VERSIONS_OPERATION,
+        prefix,
+        delimiter,
+        max_keys,
+        key_marker,
+        version_id_marker,
+    )?;
+    let common_prefix_floor = key_marker.filter(|marker| !marker.starts_with(TABLE_DATA_PLANE_LIST_CURSOR_PREFIX));
+    let mut objects = Vec::new();
+    let mut prefixes = Vec::new();
+    let mut emitted_prefixes = HashSet::new();
+    if let Some(common_prefix) = &last_visible_common_prefix {
+        emitted_prefixes.insert(common_prefix.clone());
+    }
+
+    for page_index in 0..TABLE_LIST_MAX_RAW_PAGES {
+        let raw = store
+            .clone()
+            .list_object_versions(bucket, prefix, marker.clone(), version_marker.clone(), None, TABLE_LIST_RAW_PAGE_SIZE)
+            .await
+            .map_err(ApiError::from)?;
+
+        let mut marker_after_visible = marker.clone();
+        let mut version_after_visible = version_marker.clone();
+        let mut marker_after_scanned = marker.clone();
+        let mut version_after_scanned = version_marker.clone();
+        let mut found_more = false;
+        for object in raw.objects {
+            let object_name = object.name.clone();
+            let next_marker = Some(object_name.clone());
+            let next_version = Some(
+                object
+                    .version_id
+                    .map(|id| id.to_string())
+                    .unwrap_or_else(|| "null".to_string()),
+            );
+            marker_after_scanned.clone_from(&next_marker);
+            version_after_scanned.clone_from(&next_version);
+            let Some(entry) = object_list_entry(&object, prefix, delimiter) else {
+                continue;
+            };
+            if matches!(&entry, ObjectListEntry::Prefix(prefix) if common_prefix_floor.is_some_and(|floor| prefix.as_str() <= floor))
+            {
+                marker_after_visible.clone_from(&next_marker);
+                version_after_visible.clone_from(&next_version);
+                continue;
+            }
+            if matches!(&entry, ObjectListEntry::Prefix(prefix) if emitted_prefixes.contains(prefix)) {
+                marker_after_visible.clone_from(&next_marker);
+                version_after_visible.clone_from(&next_version);
+                continue;
+            }
+            if !access.allows_object(&object_name) {
+                continue;
+            }
+            match entry {
+                ObjectListEntry::Object if objects.len() + prefixes.len() < max_keys => {
+                    objects.push(object);
+                    marker_after_visible.clone_from(&next_marker);
+                    version_after_visible.clone_from(&next_version);
+                    last_visible_common_prefix = None;
+                }
+                ObjectListEntry::Prefix(prefix) if objects.len() + prefixes.len() < max_keys => {
+                    emitted_prefixes.insert(prefix.clone());
+                    prefixes.push(prefix);
+                    marker_after_visible.clone_from(&next_marker);
+                    version_after_visible.clone_from(&next_version);
+                    last_visible_common_prefix = prefixes.last().cloned();
+                }
+                _ => {
+                    found_more = true;
+                    break;
+                }
+            }
+        }
+
+        if found_more {
+            let token = access.encode_cursor(
+                LIST_OBJECT_VERSIONS_OPERATION,
+                prefix,
+                delimiter,
+                max_keys,
+                TableDataPlaneListCursorPosition {
+                    marker: marker_after_visible,
+                    version_marker: version_after_visible,
+                    common_prefix: last_visible_common_prefix,
+                },
+            )?;
+            return Ok(ListObjectVersionsInfo {
+                is_truncated: true,
+                next_marker: Some(token.clone()),
+                next_version_idmarker: Some(token),
+                objects,
+                prefixes,
+            });
+        }
+        if !raw.is_truncated {
+            return Ok(ListObjectVersionsInfo {
+                objects,
+                prefixes,
+                ..Default::default()
+            });
+        }
+        if marker_after_scanned == marker && version_after_scanned == version_marker {
+            return Err(table_list_scan_limit_error());
+        }
+        marker = marker_after_scanned;
+        version_marker = version_after_scanned;
+        if page_index + 1 == TABLE_LIST_MAX_RAW_PAGES {
+            let token = access.encode_cursor(
+                LIST_OBJECT_VERSIONS_OPERATION,
+                prefix,
+                delimiter,
+                max_keys,
+                TableDataPlaneListCursorPosition {
+                    marker,
+                    version_marker,
+                    common_prefix: last_visible_common_prefix,
+                },
+            )?;
+            return Ok(ListObjectVersionsInfo {
+                is_truncated: true,
+                next_marker: Some(token.clone()),
+                next_version_idmarker: Some(token),
+                objects,
+                prefixes,
+            });
+        }
+    }
+
+    Err(table_list_scan_limit_error())
+}
+
+pub(crate) async fn list_multipart_uploads(
+    store: Arc<ECStore>,
+    access: &TableDataPlaneListAccess,
+    request: ListMultipartUploadsRequest<'_>,
+) -> S3Result<ListMultipartsInfo> {
+    let ListMultipartUploadsRequest {
+        bucket,
+        prefix,
+        key_marker,
+        upload_id_marker,
+        delimiter,
+        max_uploads,
+        expected_incarnation_id,
+    } = request;
+    if max_uploads == 0 {
+        return Ok(ListMultipartsInfo {
+            key_marker: key_marker.map(str::to_string),
+            upload_id_marker: upload_id_marker.map(str::to_string),
+            max_uploads,
+            prefix: prefix.to_string(),
+            delimiter: delimiter.map(str::to_string),
+            ..Default::default()
+        });
+    }
+    let (mut marker, mut upload_marker, mut last_visible_common_prefix) = table_list_cursor_from_markers(
+        access,
+        &format!("{LIST_MULTIPART_UPLOADS_OPERATION}:{expected_incarnation_id}"),
+        prefix,
+        delimiter,
+        max_uploads,
+        key_marker,
+        upload_id_marker,
+    )?;
+    let common_prefix_floor = key_marker.filter(|marker| !marker.starts_with(TABLE_DATA_PLANE_LIST_CURSOR_PREFIX));
+    let mut uploads = Vec::new();
+    let mut common_prefixes = Vec::new();
+    let mut emitted_prefixes = HashSet::new();
+    if let Some(common_prefix) = &last_visible_common_prefix {
+        emitted_prefixes.insert(common_prefix.clone());
+    }
+
+    for page_index in 0..TABLE_LIST_MAX_RAW_PAGES {
+        let raw = store
+            .list_multipart_uploads_for_bucket_incarnation(
+                bucket,
+                prefix,
+                marker.clone(),
+                upload_marker.clone(),
+                None,
+                TABLE_LIST_RAW_PAGE_SIZE_USIZE,
+                expected_incarnation_id,
+            )
+            .await
+            .map_err(ApiError::from)?;
+
+        let mut marker_after_visible = marker.clone();
+        let mut upload_after_visible = upload_marker.clone();
+        let mut marker_after_scanned = marker.clone();
+        let mut upload_after_scanned = upload_marker.clone();
+        let mut found_more = false;
+        for upload in raw.uploads {
+            let object_name = upload.object.clone();
+            let next_marker = Some(object_name.clone());
+            let next_upload = Some(upload.upload_id.clone());
+            marker_after_scanned.clone_from(&next_marker);
+            upload_after_scanned.clone_from(&next_upload);
+            let Some(entry) = multipart_list_entry(upload, prefix, delimiter) else {
+                continue;
+            };
+            if matches!(&entry, MultipartListEntry::Prefix(prefix) if common_prefix_floor.is_some_and(|floor| prefix.as_str() <= floor))
+            {
+                marker_after_visible.clone_from(&next_marker);
+                upload_after_visible.clone_from(&next_upload);
+                continue;
+            }
+            if matches!(&entry, MultipartListEntry::Prefix(prefix) if emitted_prefixes.contains(prefix)) {
+                marker_after_visible.clone_from(&next_marker);
+                upload_after_visible.clone_from(&next_upload);
+                continue;
+            }
+            if !access.allows_object(&object_name) {
+                continue;
+            }
+            match entry {
+                MultipartListEntry::Upload(upload) if uploads.len() + common_prefixes.len() < max_uploads => {
+                    uploads.push(upload);
+                    marker_after_visible.clone_from(&next_marker);
+                    upload_after_visible.clone_from(&next_upload);
+                    last_visible_common_prefix = None;
+                }
+                MultipartListEntry::Prefix(prefix) if uploads.len() + common_prefixes.len() < max_uploads => {
+                    emitted_prefixes.insert(prefix.clone());
+                    common_prefixes.push(prefix);
+                    marker_after_visible.clone_from(&next_marker);
+                    upload_after_visible.clone_from(&next_upload);
+                    last_visible_common_prefix = common_prefixes.last().cloned();
+                }
+                _ => {
+                    found_more = true;
+                    break;
+                }
+            }
+        }
+
+        if found_more {
+            let token = access.encode_cursor(
+                &format!("{LIST_MULTIPART_UPLOADS_OPERATION}:{expected_incarnation_id}"),
+                prefix,
+                delimiter,
+                max_uploads,
+                TableDataPlaneListCursorPosition {
+                    marker: marker_after_visible,
+                    version_marker: upload_after_visible,
+                    common_prefix: last_visible_common_prefix,
+                },
+            )?;
+            return Ok(ListMultipartsInfo {
+                key_marker: key_marker.map(str::to_string),
+                upload_id_marker: upload_id_marker.map(str::to_string),
+                next_key_marker: Some(token.clone()),
+                next_upload_id_marker: Some(token),
+                max_uploads,
+                is_truncated: true,
+                uploads,
+                prefix: prefix.to_string(),
+                delimiter: delimiter.map(str::to_string),
+                common_prefixes,
+            });
+        }
+        if !raw.is_truncated {
+            return Ok(ListMultipartsInfo {
+                key_marker: key_marker.map(str::to_string),
+                upload_id_marker: upload_id_marker.map(str::to_string),
+                max_uploads,
+                uploads,
+                prefix: prefix.to_string(),
+                delimiter: delimiter.map(str::to_string),
+                common_prefixes,
+                ..Default::default()
+            });
+        }
+        if marker_after_scanned == marker && upload_after_scanned == upload_marker {
+            return Err(table_list_scan_limit_error());
+        }
+        marker = marker_after_scanned;
+        upload_marker = upload_after_scanned;
+        if page_index + 1 == TABLE_LIST_MAX_RAW_PAGES {
+            let token = access.encode_cursor(
+                &format!("{LIST_MULTIPART_UPLOADS_OPERATION}:{expected_incarnation_id}"),
+                prefix,
+                delimiter,
+                max_uploads,
+                TableDataPlaneListCursorPosition {
+                    marker,
+                    version_marker: upload_marker,
+                    common_prefix: last_visible_common_prefix,
+                },
+            )?;
+            return Ok(ListMultipartsInfo {
+                key_marker: key_marker.map(str::to_string),
+                upload_id_marker: upload_id_marker.map(str::to_string),
+                next_key_marker: Some(token.clone()),
+                next_upload_id_marker: Some(token),
+                max_uploads,
+                is_truncated: true,
+                uploads,
+                prefix: prefix.to_string(),
+                delimiter: delimiter.map(str::to_string),
+                common_prefixes,
+            });
+        }
+    }
+
+    Err(table_list_scan_limit_error())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MultipartListEntry, ObjectListEntry, multipart_list_entry, object_list_entry};
+    use crate::app::storage_api::bucket_usecase::StorageObjectInfo as ObjectInfo;
+    use crate::app::storage_api::multipart_usecase::contract::multipart::MultipartInfo;
+
+    #[test]
+    fn object_list_entry_keeps_an_object_without_a_delimiter() {
+        let object = ObjectInfo {
+            name: "tables/orders/data/file.parquet".to_string(),
+            ..Default::default()
+        };
+        let entry = object_list_entry(&object, "tables/", None);
+
+        assert!(matches!(entry, Some(ObjectListEntry::Object)));
+    }
+
+    #[test]
+    fn object_list_entry_folds_only_visible_keys_into_common_prefixes() {
+        let object = ObjectInfo {
+            name: "tables/orders/data/file.parquet".to_string(),
+            ..Default::default()
+        };
+        let entry = object_list_entry(&object, "tables/", Some("/"));
+
+        assert!(matches!(entry, Some(ObjectListEntry::Prefix(prefix)) if prefix == "tables/orders/"));
+    }
+
+    #[test]
+    fn multipart_list_entry_folds_only_visible_uploads_into_common_prefixes() {
+        let entry = multipart_list_entry(
+            MultipartInfo {
+                object: "tables/orders/data/file.parquet".to_string(),
+                ..Default::default()
+            },
+            "tables/",
+            Some("/"),
+        );
+
+        assert!(matches!(entry, Some(MultipartListEntry::Prefix(prefix)) if prefix == "tables/orders/"));
+    }
+}

--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -30,8 +30,13 @@ use crate::storage::storage_api::contract::bucket::BUCKET_LIFECYCLE_LOCK_OBJECT;
 use crate::storage::storage_api::contract::namespace::NamespaceLocking as _;
 use crate::storage::storage_api::runtime_sources_consumer::ServerContextSlot;
 use crate::storage::storage_api::runtime_sources_consumer::runtime_sources;
+use chacha20poly1305::{
+    ChaCha20Poly1305, KeyInit,
+    aead::{Aead, Payload},
+};
 use http::HeaderMap;
 use metrics::counter;
+use rand::Rng;
 use rustfs_iam::{
     error::Error as IamError,
     store::object::ObjectStore,
@@ -50,6 +55,8 @@ use rustfs_utils::http::{
 };
 use s3s::access::{S3Access, S3AccessContext};
 use s3s::{S3Error, S3ErrorCode, S3Request, S3Result, dto::*, s3_error};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 #[cfg(test)]
@@ -128,6 +135,179 @@ struct TableDataPlanePublicationState {
     guards: Vec<Box<dyn Send>>,
     resources: HashMap<(String, String), crate::table_catalog::TableDataPlaneResource>,
     missing_resources: BTreeSet<(String, String)>,
+}
+
+pub(crate) const TABLE_DATA_PLANE_LIST_CURSOR_PREFIX: &str = "rustfs-table-list:v1:";
+const TABLE_DATA_PLANE_LIST_CURSOR_VERSION: u8 = 1;
+const TABLE_DATA_PLANE_LIST_CURSOR_KEY_CONTEXT: &[u8] = b"rustfs-table-list-cursor-key:v1";
+const TABLE_DATA_PLANE_LIST_CURSOR_MAX_ENCODED_LEN: usize = 16 * 1024;
+
+fn table_data_plane_list_internal_error(message: impl Into<String>) -> S3Error {
+    S3Error::with_message(S3ErrorCode::InternalError, message.into())
+}
+
+#[derive(Clone)]
+struct TableDataPlaneListResource {
+    resource: crate::table_catalog::TableDataPlaneResource,
+    allowed: bool,
+}
+
+#[derive(Clone)]
+pub(crate) struct TableDataPlaneListAccess {
+    bucket: String,
+    principal_fingerprint: String,
+    snapshot_fingerprint: String,
+    cursor_key: [u8; 32],
+    resources: Vec<TableDataPlaneListResource>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TableDataPlaneListCursor {
+    version: u8,
+    bucket: String,
+    principal_fingerprint: String,
+    snapshot_fingerprint: String,
+    operation: String,
+    prefix: String,
+    delimiter: Option<String>,
+    max_keys: usize,
+    marker: Option<String>,
+    version_marker: Option<String>,
+    common_prefix: Option<String>,
+}
+
+pub(crate) struct TableDataPlaneListCursorPosition {
+    pub(crate) marker: Option<String>,
+    pub(crate) version_marker: Option<String>,
+    pub(crate) common_prefix: Option<String>,
+}
+
+impl TableDataPlaneListCursor {
+    pub(crate) fn marker(&self) -> Option<&str> {
+        self.marker.as_deref()
+    }
+
+    pub(crate) fn version_marker(&self) -> Option<&str> {
+        self.version_marker.as_deref()
+    }
+
+    pub(crate) fn common_prefix(&self) -> Option<&str> {
+        self.common_prefix.as_deref()
+    }
+}
+
+impl TableDataPlaneListAccess {
+    pub(crate) fn allows_object(&self, object: &str) -> bool {
+        if crate::table_catalog::is_reserved_table_object_key(object) {
+            return false;
+        }
+        self.resources
+            .iter()
+            .find(|entry| object.starts_with(&entry.resource.warehouse_object_prefix))
+            .is_none_or(|entry| entry.allowed)
+    }
+
+    pub(crate) fn encode_cursor(
+        &self,
+        operation: &str,
+        prefix: &str,
+        delimiter: Option<&str>,
+        max_keys: usize,
+        position: TableDataPlaneListCursorPosition,
+    ) -> S3Result<String> {
+        let cursor = TableDataPlaneListCursor {
+            version: TABLE_DATA_PLANE_LIST_CURSOR_VERSION,
+            bucket: self.bucket.clone(),
+            principal_fingerprint: self.principal_fingerprint.clone(),
+            snapshot_fingerprint: self.snapshot_fingerprint.clone(),
+            operation: operation.to_string(),
+            prefix: prefix.to_string(),
+            delimiter: delimiter.map(str::to_string),
+            max_keys,
+            marker: position.marker,
+            version_marker: position.version_marker,
+            common_prefix: position.common_prefix,
+        };
+        let plaintext = serde_json::to_vec(&cursor).map_err(|err| {
+            table_data_plane_list_internal_error(format!("failed to encode protected table list cursor: {err}"))
+        })?;
+        let cipher = ChaCha20Poly1305::new_from_slice(&self.cursor_key)
+            .map_err(|_| table_data_plane_list_internal_error("failed to initialize protected table list cursor cipher"))?;
+        let mut nonce_bytes = [0u8; 12];
+        rand::rng().fill_bytes(&mut nonce_bytes);
+        let nonce = chacha20poly1305::Nonce::from(nonce_bytes);
+        let ciphertext = cipher
+            .encrypt(
+                &nonce,
+                Payload {
+                    msg: &plaintext,
+                    aad: TABLE_DATA_PLANE_LIST_CURSOR_PREFIX.as_bytes(),
+                },
+            )
+            .map_err(|_| table_data_plane_list_internal_error("failed to seal protected table list cursor"))?;
+        let mut token = Vec::with_capacity(nonce_bytes.len() + ciphertext.len());
+        token.extend_from_slice(&nonce_bytes);
+        token.extend_from_slice(&ciphertext);
+        Ok(format!(
+            "{}{}",
+            TABLE_DATA_PLANE_LIST_CURSOR_PREFIX,
+            base64_simd::URL_SAFE_NO_PAD.encode_to_string(token)
+        ))
+    }
+
+    pub(crate) fn decode_cursor(
+        &self,
+        operation: &str,
+        prefix: &str,
+        delimiter: Option<&str>,
+        max_keys: usize,
+        token: &str,
+    ) -> S3Result<TableDataPlaneListCursor> {
+        if token.len() > TABLE_DATA_PLANE_LIST_CURSOR_MAX_ENCODED_LEN {
+            return Err(invalid_table_data_plane_list_cursor());
+        }
+        let encoded = token
+            .strip_prefix(TABLE_DATA_PLANE_LIST_CURSOR_PREFIX)
+            .ok_or_else(invalid_table_data_plane_list_cursor)?;
+        let sealed = base64_simd::URL_SAFE_NO_PAD
+            .decode_to_vec(encoded.as_bytes())
+            .map_err(|_| invalid_table_data_plane_list_cursor())?;
+        let (nonce_bytes, ciphertext) = sealed
+            .split_at_checked(12)
+            .filter(|(_, ciphertext)| ciphertext.len() >= 16)
+            .ok_or_else(invalid_table_data_plane_list_cursor)?;
+        let cipher = ChaCha20Poly1305::new_from_slice(&self.cursor_key)
+            .map_err(|_| table_data_plane_list_internal_error("failed to initialize protected table list cursor cipher"))?;
+        let nonce = chacha20poly1305::Nonce::try_from(nonce_bytes).map_err(|_| invalid_table_data_plane_list_cursor())?;
+        let plaintext = cipher
+            .decrypt(
+                &nonce,
+                Payload {
+                    msg: ciphertext,
+                    aad: TABLE_DATA_PLANE_LIST_CURSOR_PREFIX.as_bytes(),
+                },
+            )
+            .map_err(|_| invalid_table_data_plane_list_cursor())?;
+        let cursor: TableDataPlaneListCursor =
+            serde_json::from_slice(&plaintext).map_err(|_| invalid_table_data_plane_list_cursor())?;
+        if cursor.version != TABLE_DATA_PLANE_LIST_CURSOR_VERSION
+            || cursor.bucket != self.bucket
+            || cursor.principal_fingerprint != self.principal_fingerprint
+            || cursor.snapshot_fingerprint != self.snapshot_fingerprint
+            || cursor.operation != operation
+            || cursor.prefix != prefix
+            || cursor.delimiter.as_deref() != delimiter
+            || cursor.max_keys != max_keys
+        {
+            return Err(invalid_table_data_plane_list_cursor());
+        }
+        Ok(cursor)
+    }
+}
+
+fn invalid_table_data_plane_list_cursor() -> S3Error {
+    S3Error::with_message(S3ErrorCode::InvalidArgument, "Invalid table listing continuation token".to_string())
 }
 
 #[derive(Clone, Debug)]
@@ -1628,6 +1808,150 @@ async fn table_bucket_enabled_for_data_plane<T>(req: &S3Request<T>, bucket: &str
     }
 }
 
+fn update_table_list_fingerprint_field(hasher: &mut Sha256, value: &[u8]) {
+    hasher.update((value.len() as u64).to_be_bytes());
+    hasher.update(value);
+}
+
+fn table_list_principal_fingerprint(cred: Option<&rustfs_credentials::Credentials>, is_owner: bool) -> String {
+    let mut hasher = Sha256::new();
+    update_table_list_fingerprint_field(
+        &mut hasher,
+        cred.map_or(b"anonymous".as_slice(), |credential| credential.access_key.as_bytes()),
+    );
+    hasher.update([u8::from(is_owner)]);
+    hex_simd::encode_to_string(hasher.finalize(), hex_simd::AsciiCase::Lower)
+}
+
+fn table_list_snapshot_fingerprint(resources: &[TableDataPlaneListResource]) -> String {
+    let mut hasher = Sha256::new();
+    for entry in resources {
+        for value in [
+            entry.resource.table_bucket.as_bytes(),
+            entry.resource.namespace.as_bytes(),
+            entry.resource.table.as_bytes(),
+            entry.resource.table_id.as_bytes(),
+            entry.resource.warehouse_object_prefix.as_bytes(),
+        ] {
+            update_table_list_fingerprint_field(&mut hasher, value);
+        }
+        hasher.update([u8::from(entry.allowed)]);
+    }
+    hex_simd::encode_to_string(hasher.finalize(), hex_simd::AsciiCase::Lower)
+}
+
+fn table_list_cursor_key<T>(req: &S3Request<T>) -> S3Result<[u8; 32]> {
+    let credentials = match req.extensions.get::<Arc<ServerContextSlot>>() {
+        Some(server_ctx) => server_ctx
+            .installed_app_context()
+            .and_then(|context| context.action_credentials().get()),
+        None => runtime_sources::current_action_credentials(),
+    }
+    .ok_or_else(|| table_data_plane_list_internal_error("action credentials are not initialized"))?;
+    let mut hasher = Sha256::new();
+    update_table_list_fingerprint_field(&mut hasher, TABLE_DATA_PLANE_LIST_CURSOR_KEY_CONTEXT);
+    update_table_list_fingerprint_field(&mut hasher, credentials.access_key.as_bytes());
+    update_table_list_fingerprint_field(&mut hasher, credentials.secret_key.as_bytes());
+    Ok(hasher.finalize().into())
+}
+
+fn table_list_catalog_error(err: crate::table_catalog::TableCatalogStoreError) -> S3Error {
+    if matches!(err, crate::table_catalog::TableCatalogStoreError::Unavailable(_)) {
+        S3Error::from(ApiError::service_unavailable())
+    } else {
+        S3Error::from(ApiError::access_denied())
+    }
+}
+
+async fn prepare_table_data_plane_list_access<T>(req: &mut S3Request<T>, bucket: &str, action: S3Action) -> S3Result<()> {
+    if !table_bucket_enabled_for_data_plane(req, bucket).await? {
+        return Ok(());
+    }
+    retain_table_bucket_publication_guard(req, bucket).await?;
+    if !table_bucket_enabled_for_data_plane(req, bucket).await? {
+        return Err(S3Error::from(ApiError::access_denied()));
+    }
+
+    let (cred, is_owner) = {
+        let req_info = req_info_ref(req)?;
+        (req_info.cred.clone(), req_info.is_owner)
+    };
+    let remote_addr = req
+        .extensions
+        .get::<Option<RemoteAddr>>()
+        .and_then(|value| value.map(|address| address.0));
+    let client_info = req.extensions.get::<ClientInfo>();
+    let default_cred = rustfs_credentials::Credentials::default();
+    let condition_cred = cred.as_ref().unwrap_or(&default_cred);
+    let conditions = authorization_conditions(
+        req,
+        condition_cred,
+        None,
+        req.region.clone(),
+        remote_addr,
+        client_info,
+        Action::S3Action(action),
+    )?;
+    let iam_store = cred.as_ref().map(|_| request_iam_store(req)).transpose()?;
+    let store = table_catalog_store_for_data_plane(req)?;
+    let tables = crate::table_catalog::TableCatalogStore::list_all_tables(&store, bucket)
+        .await
+        .map_err(table_list_catalog_error)?;
+    let default_claims = HashMap::new();
+    let claims = cred
+        .as_ref()
+        .and_then(|credential| credential.claims.as_ref())
+        .unwrap_or(&default_claims);
+    let mut resources = Vec::with_capacity(tables.len());
+    for table in tables {
+        let warehouse_object_prefix =
+            crate::table_catalog::table_warehouse_object_prefix(&table).map_err(table_list_catalog_error)?;
+        let resource = crate::table_catalog::table_data_plane_resource_from_entry(table.clone(), warehouse_object_prefix);
+        let allowed = match (cred.as_ref(), iam_store.as_ref()) {
+            (Some(credential), Some(iam_store)) => {
+                let resource_object = resource.catalog_resource_object();
+                iam_store
+                    .is_allowed(&Args {
+                        account: &credential.access_key,
+                        groups: &credential.groups,
+                        action: Action::AdminAction(AdminAction::GetTableMetadataAction),
+                        bucket,
+                        conditions: &conditions,
+                        is_owner,
+                        object: &resource_object,
+                        claims,
+                        deny_only: false,
+                    })
+                    .await
+            }
+            _ => false,
+        };
+        resources.push(TableDataPlaneListResource { resource, allowed });
+    }
+    resources.sort_by(|left, right| {
+        left.resource
+            .warehouse_object_prefix
+            .cmp(&right.resource.warehouse_object_prefix)
+    });
+    if resources.windows(2).any(|window| {
+        crate::table_catalog::warehouse_object_prefixes_overlap(
+            &window[0].resource.warehouse_object_prefix,
+            &window[1].resource.warehouse_object_prefix,
+        )
+    }) {
+        return Err(S3Error::from(ApiError::access_denied()));
+    }
+    let access = TableDataPlaneListAccess {
+        bucket: bucket.to_string(),
+        principal_fingerprint: table_list_principal_fingerprint(cred.as_ref(), is_owner),
+        snapshot_fingerprint: table_list_snapshot_fingerprint(&resources),
+        cursor_key: table_list_cursor_key(req)?,
+        resources,
+    };
+    req.extensions.insert(access);
+    Ok(())
+}
+
 async fn table_data_plane_resource_for_request<T>(
     req: &mut S3Request<T>,
     bucket: &str,
@@ -2645,6 +2969,7 @@ impl S3Access for FS {
         req_info.bucket = Some(req.input.bucket.clone());
 
         authorize_request(req, Action::S3Action(S3Action::ListBucketMultipartUploadsAction)).await?;
+        prepare_table_data_plane_list_access(req, &bucket, S3Action::ListBucketMultipartUploadsAction).await?;
         req.extensions.insert(bucket_generation?);
         Ok(())
     }
@@ -2654,19 +2979,23 @@ impl S3Access for FS {
     /// Returns `Ok(())` if the request is allowed, or an error if access is denied or another
     /// authorization-related issue occurs.
     async fn list_object_versions(&self, req: &mut S3Request<ListObjectVersionsInput>) -> S3Result<()> {
+        let bucket = req.input.bucket.clone();
         let req_info = ext_req_info_mut(&mut req.extensions)?;
         req_info.bucket = Some(req.input.bucket.clone());
-        authorize_request(req, Action::S3Action(S3Action::ListBucketVersionsAction)).await
+        authorize_request(req, Action::S3Action(S3Action::ListBucketVersionsAction)).await?;
+        prepare_table_data_plane_list_access(req, &bucket, S3Action::ListBucketVersionsAction).await
     }
 
     /// Checks whether the ListObjects request has accesses to the resources.
     ///
     /// This method returns `Ok(())` by default.
     async fn list_objects(&self, req: &mut S3Request<ListObjectsInput>) -> S3Result<()> {
+        let bucket = req.input.bucket.clone();
         let req_info = ext_req_info_mut(&mut req.extensions)?;
         req_info.bucket = Some(req.input.bucket.clone());
 
-        authorize_request(req, Action::S3Action(S3Action::ListBucketAction)).await
+        authorize_request(req, Action::S3Action(S3Action::ListBucketAction)).await?;
+        prepare_table_data_plane_list_access(req, &bucket, S3Action::ListBucketAction).await
     }
 
     /// Checks whether the ListObjectsV2 request has accesses to the resources.
@@ -2679,6 +3008,7 @@ impl S3Access for FS {
         req_info.bucket = Some(req.input.bucket.clone());
 
         authorize_request(req, Action::S3Action(S3Action::ListBucketAction)).await?;
+        prepare_table_data_plane_list_access(req, &bucket, S3Action::ListBucketAction).await?;
         req.extensions.insert(source_generation);
         Ok(())
     }
@@ -3105,15 +3435,16 @@ mod tests {
     use super::{
         AMZ_WRITE_OFFSET_BYTES_HEADER, BucketGenerationGuard, BucketPolicyArgs, BucketPolicyExistingObjectTagHint,
         BucketPolicyRawLoadErrorKind, DenialContext, FS, InternalObjectAuthorization, ObjectTagConditions,
-        PostObjectRequestMarker, ReqInfo, S3Access, StorageError, TableDataPlanePublicationGuards, apply_bucket_generation_guard,
-        apply_copy_source_bucket_generation_guard, authorization_conditions, bucket_policy_needs_existing_object_tag_from_hint,
-        bucket_website_config_authorize_action, classify_bucket_policy_raw_load_error,
-        complete_multipart_upload_authorize_action, get_bucket_policy_authorize_action, has_write_offset_bytes_header,
-        install_restore_authorization_test_hook, legal_hold_write_requested, list_parts_authorize_action,
-        load_bucket_policy_existing_object_tag_hint, maybe_merge_object_tag_conditions, merge_list_bucket_query_conditions,
-        merge_request_object_tag_conditions, owner_can_bypass_policy_deny, post_object_authorize_action,
-        put_bucket_policy_authorize_action, request_context_from_req, request_object_store, retention_write_requested,
-        secondary_tag_hint_action, table_data_plane_admin_action, table_data_plane_content_mutation,
+        PostObjectRequestMarker, ReqInfo, S3Access, StorageError, TABLE_DATA_PLANE_LIST_CURSOR_MAX_ENCODED_LEN,
+        TableDataPlaneListAccess, TableDataPlaneListCursorPosition, TableDataPlaneListResource, TableDataPlanePublicationGuards,
+        apply_bucket_generation_guard, apply_copy_source_bucket_generation_guard, authorization_conditions,
+        bucket_policy_needs_existing_object_tag_from_hint, bucket_website_config_authorize_action,
+        classify_bucket_policy_raw_load_error, complete_multipart_upload_authorize_action, get_bucket_policy_authorize_action,
+        has_write_offset_bytes_header, install_restore_authorization_test_hook, legal_hold_write_requested,
+        list_parts_authorize_action, load_bucket_policy_existing_object_tag_hint, maybe_merge_object_tag_conditions,
+        merge_list_bucket_query_conditions, merge_request_object_tag_conditions, owner_can_bypass_policy_deny,
+        post_object_authorize_action, put_bucket_policy_authorize_action, request_context_from_req, request_object_store,
+        retention_write_requested, secondary_tag_hint_action, table_data_plane_admin_action, table_data_plane_content_mutation,
         table_data_plane_resource_for_request, table_publication_guard_error, validate_post_object_success_controls,
         versioned_read_action,
     };
@@ -3252,6 +3583,99 @@ mod tests {
             Some(rustfs_policy::policy::action::AdminAction::GetTableMetadataAction)
         );
         assert_eq!(table_data_plane_admin_action(Action::S3Action(S3Action::ListBucketAction)), None);
+    }
+
+    fn table_list_access(allowed: bool) -> TableDataPlaneListAccess {
+        TableDataPlaneListAccess {
+            bucket: "analytics".to_string(),
+            principal_fingerprint: "principal".to_string(),
+            snapshot_fingerprint: "snapshot".to_string(),
+            cursor_key: [0x42; 32],
+            resources: vec![TableDataPlaneListResource {
+                resource: crate::table_catalog::TableDataPlaneResource {
+                    table_bucket: "analytics".to_string(),
+                    namespace: "sales".to_string(),
+                    table: "orders".to_string(),
+                    table_id: "table-id".to_string(),
+                    warehouse_object_prefix: "tables/table-id/".to_string(),
+                },
+                allowed,
+            }],
+        }
+    }
+
+    #[test]
+    fn table_list_access_hides_unauthorized_table_objects_and_reserved_metadata() {
+        let denied = table_list_access(false);
+        assert!(!denied.allows_object("tables/table-id/data/file.parquet"));
+        assert!(
+            !denied.allows_object(".rustfs-table/warehouses/default/namespaces/sales/tables/orders/metadata/00001.metadata.json")
+        );
+        assert!(!denied.allows_object(".rustfs-table/private/catalog.json"));
+        assert!(denied.allows_object("ordinary/file.txt"));
+
+        let allowed = table_list_access(true);
+        assert!(allowed.allows_object("tables/table-id/data/file.parquet"));
+        assert!(
+            !allowed
+                .allows_object(".rustfs-table/warehouses/default/namespaces/sales/tables/orders/metadata/00001.metadata.json")
+        );
+        assert!(!allowed.allows_object(".rustfs-table/private/catalog.json"));
+    }
+
+    #[test]
+    fn table_list_cursor_is_confidential_and_bound_to_the_request_snapshot() {
+        let access = table_list_access(true);
+        let marker = "tables/hidden/data/file.parquet";
+        let token = access
+            .encode_cursor(
+                "ListObjectsV2",
+                "tables/",
+                Some("/"),
+                1000,
+                TableDataPlaneListCursorPosition {
+                    marker: Some(marker.to_string()),
+                    version_marker: None,
+                    common_prefix: None,
+                },
+            )
+            .expect("cursor should encode");
+        assert!(!token.contains(marker));
+        let decoded = access
+            .decode_cursor("ListObjectsV2", "tables/", Some("/"), 1000, &token)
+            .expect("cursor should decode");
+        assert_eq!(decoded.marker(), Some(marker));
+
+        let mut changed = access.clone();
+        changed.snapshot_fingerprint = "changed".to_string();
+        assert!(
+            changed
+                .decode_cursor("ListObjectsV2", "tables/", Some("/"), 1000, &token)
+                .is_err()
+        );
+        assert!(
+            access
+                .decode_cursor("ListObjectsV2", "other/", Some("/"), 1000, &token)
+                .is_err()
+        );
+        let mut rotated_key = access.clone();
+        rotated_key.cursor_key[0] ^= 1;
+        assert!(
+            rotated_key
+                .decode_cursor("ListObjectsV2", "tables/", Some("/"), 1000, &token)
+                .is_err()
+        );
+        assert!(
+            access
+                .decode_cursor(
+                    "ListObjectsV2",
+                    "tables/",
+                    Some("/"),
+                    1000,
+                    &"x".repeat(TABLE_DATA_PLANE_LIST_CURSOR_MAX_ENCODED_LEN + 1),
+                )
+                .is_err()
+        );
     }
 
     #[test]

--- a/rustfs/src/storage/storage_api.rs
+++ b/rustfs/src/storage/storage_api.rs
@@ -118,7 +118,8 @@ pub(crate) use super::sse::{
 
 pub(crate) mod access_consumer {
     pub(crate) use super::super::access::{
-        PostObjectRequestMarker, ReqInfo, apply_bucket_generation_guard, apply_copy_source_bucket_generation_guard,
+        PostObjectRequestMarker, ReqInfo, TABLE_DATA_PLANE_LIST_CURSOR_PREFIX, TableDataPlaneListAccess,
+        TableDataPlaneListCursorPosition, apply_bucket_generation_guard, apply_copy_source_bucket_generation_guard,
         authorize_internal_object_request, authorize_request, bucket_config_mutation_incarnation, has_bypass_governance_header,
         load_bucket_generation_from_store, log_list_buckets_iam_implicit_deny, odm_read_generation,
         prepare_list_buckets_iam_authorization, prepare_odm_read_generation, recursive_force_delete_is_authorized,


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Apply table-aware filtering to `ListObjects`, `ListObjectsV2`, `ListObjectVersions`, both metadata-list extensions, and `ListMultipartUploads` for table-enabled buckets.
- Omit warehouse objects unless the caller has `admin:GetTableMetadata` on the owning table, and always omit internal `.rustfs-table` keys from S3 discovery.
- Paginate over raw storage pages before emitting visible objects/common prefixes, with authenticated encryption for cursors so skipped object names are never exposed in continuation markers.
- Bind cursors to the bucket, principal, effective table-permission snapshot, operation, prefix, delimiter, limit, and multipart bucket incarnation; derive the cursor key from existing cluster root credentials.
- Bound hidden-object scanning per request and return encrypted progress for V2/version/multipart APIs; fail closed for table-bucket V2 list-through while on-demand migration is active.

## Verification

- `cargo +1.98.0 fmt --all --check`, `git diff --check`, and `scripts/check_doc_paths.sh` — passed.
- `scripts/check_s3s_footprint.sh`, `scripts/check_architecture_migration_rules.sh`, `scripts/check_layer_dependencies.sh`, `scripts/check_unsafe_code_allowances.sh`, and `scripts/check_logging_guardrails.sh` — passed.
- `cargo +1.98.0 clippy -p rustfs --lib --features swift -- -D warnings` — passed after replacing oversized function signatures with typed request/position parameters and keeping object entries borrowed rather than boxed; no lint allowance was added.
- `cargo +1.98.0 test -p rustfs --lib table_list_access_hides_unauthorized_table_objects_and_reserved_metadata` — passed; verifies table-object denial/allow and unconditional internal-key hiding.
- `... table_list_cursor_is_confidential_and_bound_to_the_request_snapshot` and `... table_list_isolation::tests` — passed; verify encrypted marker recovery, context/key-rotation/oversize rejection, and delimiter folding for object and multipart entries.

Updated through merge commit `6c6169f421` on upstream `release` at `e4031940e2` after #7677 merged. Conflicts in the S3 Tables support matrix and the app/storage access facades were resolved by retaining the table-list types and cursor exports alongside release's current delete-object authorization, recursive-force-delete, and reserved-table ownership helpers. The resulting tree exactly matched an independently resolved and formatted local tree; the focused RustFS test target compiled and all five `table_list` tests passed.

### Adversarial validation verdicts

- **Correctness:** Pass — all five list surfaces preserve visible ordering, delimiter folding, pagination progress, and fail-closed behavior.
- **Simplicity:** Pass — the bounded filtering and cursor logic remains isolated in one module with typed request and cursor-position structures.
- **Test coverage:** Pass with a documented gap — focused cursor, access, and delimiter tests pass; wire-level multi-page ECStore coverage remains absent.
- **Security:** Pass — unauthorized warehouse objects and all reserved keys stay hidden, and authenticated cursors bind identity, permission snapshot, operation, and request shape.
- **Concurrency and durability:** Pass — the table-bucket publication read guard stabilizes the catalog snapshot, and multipart cursors bind bucket incarnation.
- **Compatibility:** Pass — non-table buckets keep the existing path, V1 emits public key markers, and credential rotation intentionally invalidates protected cursors.
- **Performance:** Pass — raw scanning is capped at 16 pages of 1,000 entries with monotonic progress checks and retryable fail-closed errors.

Adversarial validation used two fresh sequential passes. Pass 1 covered authorization, object/common-prefix leakage, pagination progress, marker namespace collisions, root-key deployment compatibility, on-demand migration, and all five list surfaces. It removed a new required environment secret, rejected unsafe list-through composition, added encrypted progress across long hidden ranges, and preserved legitimate plain version/multipart markers that share the cursor prefix. Pass 2 covered cursor cryptography and input bounds, policy/table snapshot changes, V1 compatibility, non-table isolation, performance, and tests; it added a 16 KiB sealed-token input limit. Final feature-CI revalidation replaced oversized function signatures with typed request/position structs, removed the large enum variant without adding per-object allocation, and removed the remaining `too_many_arguments` lint allowance. No unresolved finding remains within this branch.

An end-to-end ECStore request test was not added because the focused library build exercises every changed handler and storage signature, while the pure tests cover the new filtering/cursor primitives. Wire-level multi-page coverage remains the principal verification gap for this draft.

## Impact

No object is deleted, moved, rewritten, or made unreadable by storage. The change affects discovery: S3-only principals without table permission no longer see protected warehouse keys, and no S3 principal sees `.rustfs-table` internal keys in a listing. Direct access remains governed by the existing point-operation authorization path.

Spark and other Iceberg clients using RustFS-vended credentials continue to list their table warehouse because those credentials already include `admin:GetTableMetadata`. Clients must treat continuation tokens as opaque, as required by S3. Rotating cluster root credentials invalidates in-flight protected cursors, so callers must restart the listing.

For ListObjects V1, an authorized result separated by more than 16 raw pages of hidden keys returns `SlowDown` and requires a narrower prefix because V1 has no safe opaque marker channel. Protected V2 listing returns `ServiceUnavailable` while on-demand migration list-through applies to the requested prefix; this avoids silently leaking source keys or returning an incomplete local-only result.

Rollback is a revert of this commit; doing so restores the listing disclosure and must not be used as a security boundary.

## Additional Notes

This draft targets `release`. If dropped-prefix tombstones from #7675 land first, this branch must be rebased and the list authorization snapshot extended to include deleted warehouse prefixes before merge; otherwise residual dropped-table objects would still be discoverable as ordinary objects.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.

