### PR TITLE
ci: stop defaulting suite dispatches to a pinned release

### DIFF
--- a/.github/workflows/rustfs-kms-test.yml
+++ b/.github/workflows/rustfs-kms-test.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       rustfs_version:
-        description: 'RustFS release tag to test (e.g. 1.0.0-rc.4-preview.1)'
+        description: 'RustFS release tag to test (leave empty to use the latest nightly deb)'
         required: false
-        default: '1.0.0-rc.4-preview.1'
       package_url:
         description: 'Direct .deb URL (nightly/R2/dev). Overrides rustfs_version.'
         required: false

--- a/.github/workflows/rustfs-replication-test.yml
+++ b/.github/workflows/rustfs-replication-test.yml
@@ -18,9 +18,8 @@ on:
   workflow_dispatch:
     inputs:
       rustfs_version:
-        description: 'RustFS release tag to test (e.g. 1.0.0-rc.4-preview.1)'
+        description: 'RustFS release tag to test (leave empty to use the latest nightly deb)'
         required: false
-        default: '1.0.0-rc.4-preview.1'
       package_url:
         description: 'Direct .deb URL (nightly/R2/dev). Overrides rustfs_version.'
         required: false

--- a/.github/workflows/rustfs-s3-compat-test.yml
+++ b/.github/workflows/rustfs-s3-compat-test.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       rustfs_version:
-        description: 'RustFS release tag to test (e.g. 1.0.0-rc.4-preview.1)'
+        description: 'RustFS release tag to test (leave empty to use the latest nightly deb)'
         required: false
-        default: '1.0.0-rc.4-preview.1'
       package_url:
         description: 'Direct .deb URL (nightly/R2/dev). Overrides rustfs_version.'
         required: false

--- a/.github/workflows/rustfs-security-test.yml
+++ b/.github/workflows/rustfs-security-test.yml
@@ -18,9 +18,8 @@ on:
   workflow_dispatch:
     inputs:
       rustfs_version:
-        description: 'RustFS release tag to test (e.g. 1.0.0-rc.4-preview.1)'
+        description: 'RustFS release tag to test (leave empty to use the latest nightly deb)'
         required: false
-        default: '1.0.0-rc.4-preview.1'
       package_url:
         description: 'Direct .deb URL (nightly/R2/dev). Overrides rustfs_version.'
         required: false

--- a/.github/workflows/rustfs-storage-test.yml
+++ b/.github/workflows/rustfs-storage-test.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       rustfs_version:
-        description: 'RustFS release tag to test (e.g. 1.0.0-rc.4-preview.1)'
+        description: 'RustFS release tag to test (leave empty to use the latest nightly deb)'
         required: false
-        default: '1.0.0-rc.4-preview.1'
       package_url:
         description: 'Direct .deb URL (nightly/R2/dev). Overrides rustfs_version.'
         required: false

--- a/.github/workflows/rustfs-tier-test.yml
+++ b/.github/workflows/rustfs-tier-test.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       rustfs_version:
-        description: 'RustFS release tag to test (e.g. 1.0.0-rc.4-preview.1)'
+        description: 'RustFS release tag to test (leave empty to use the latest nightly deb)'
         required: false
-        default: '1.0.0-rc.4-preview.1'
       package_url:
         description: 'Direct .deb URL (nightly/R2/dev). Overrides rustfs_version.'
         required: false


### PR DESCRIPTION
## Problem

Six suite workflows (s3, kms, tier, storage, security, replication) defaulted the `rustfs_version` dispatch input to `1.0.0-rc.4-preview.1`. That default shadowed the nightly fallback in the package-resolution chain, and once the `1.0.0-rc.4-preview.1` release was deleted, every manual dispatch without an explicit input 404'd on the package download before any case ran (10 backlog issues came from exactly this).

## Change

Remove the default (and align the input description with the pool suite's wording). Package resolution after this:

- `package_url` given → that exact deb
- `rustfs_version` given → that exact release
- **neither → latest nightly deb** (was: pinned deleted release)

Chain (`repository_dispatch`) runs are unaffected — the inputs context is empty there, so they always resolved to the nightly fallback. The `upgrade` suite's from/to version inputs are intentionally untouched (its `from_version: 1.0.0-rc.3` default is a meaningful upgrade base and that release still exists).

Manual verification recipe after merge: `gh workflow run rustfs-s3-compat-test.yml` with no inputs, then check the run log line `package:` shows the nightly URL.