### PR TITLE
fix(ecstore): keep the clone-safety assertion without a redundant clone

### DIFF
--- a/crates/ecstore/src/disk/error.rs
+++ b/crates/ecstore/src/disk/error.rs
@@ -865,8 +865,9 @@ mod tests {
             io::ErrorKind::PermissionDenied,
             "staging rejected",
         )));
+        let cloned = marked.clone();
         assert!(marked.is_conditional_file_not_committed());
-        assert!(marked.clone().is_conditional_file_not_committed());
+        assert!(cloned.is_conditional_file_not_committed());
         assert!(!DiskError::Timeout.is_conditional_file_not_committed());
         assert!(
             !DiskError::Io(io::Error::new(io::ErrorKind::PermissionDenied, "rename rejected"))


### PR DESCRIPTION
## Problem

Since #7668 (commit c478a392e), `cargo clippy --tests` fails on release with:

```
error: redundant clone
   --> crates/ecstore/src/disk/error.rs:869:23
869 |         assert!(marked.clone().is_conditional_file_not_committed());
    |                       ^^^^^^^^ help: remove this
```

`-D warnings` turns this into a hard error, so the **Workspace Test and Lint** lane is red for every PR branched off the current release head — unrelated workflow-only PRs are blocked by it.

## Change

Bind the clone to a variable and assert on both values:

```rust
let cloned = marked.clone();
assert!(marked.is_conditional_file_not_committed());
assert!(cloned.is_conditional_file_not_committed());
```

This satisfies clippy (the clone is no longer the final use of `marked`) and actually strengthens the test's stated intent (`..._clone_safe`): it now proves the original still carries the marker *after* being cloned **and** that the clone carries it too.

## Verification

No local Rust toolchain on the authoring machine, so this needs the clippy lane to confirm — the change is mechanical and exactly scoped to the flagged line. Once this merges, PRs #7669/#7680 will need a branch update to pick it up.