### PR TITLE
fix(storage): alias legacy meta bucket over internode rpc

### DIFF
--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -17609,6 +17609,17 @@ impl ECStore {
         }
         self.persist_decommission_durable_ilm_receipt(source_pool_idx, target_pool_idx, &receipt)
             .await?;
+        self.decommission_durable_ilm_receipt_path_for_test(source_pool_idx, source_path, record)
+            .await
+    }
+
+    #[cfg(all(test, feature = "test-util"))]
+    pub(crate) async fn decommission_durable_ilm_receipt_path_for_test(
+        &self,
+        source_pool_idx: usize,
+        source_path: &str,
+        record: &ValidatedDurableIlmRecord,
+    ) -> Result<String> {
         let run_token = self.durable_ilm_receipt_run_token(source_pool_idx).await?;
         Ok(decommission_durable_ilm_receipt_path(&run_token, source_path, record.id_kind, &record.id))
     }

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -9643,7 +9643,13 @@ mod tests {
         com::save_config(store.pools[1].clone(), &manual_task_path, manual_task_bytes.clone())
             .await
             .expect("target task rewrite should invalidate cached metadata before the quorum check");
-        let target_task_set = store.pools[1].get_disks_by_key(&manual_task_path);
+        let manual_task_record =
+            validate_durable_ilm_record(&manual_task_path, &manual_task_bytes).expect("manual task should validate");
+        let manual_task_receipt_path = store
+            .decommission_durable_ilm_receipt_path_for_test(0, &manual_task_path, &manual_task_record)
+            .await
+            .expect("manual task receipt path should resolve");
+        let target_task_set = store.pools[1].get_disks_by_key(&manual_task_receipt_path);
         let original_target_task_disks = {
             let mut disks = target_task_set.disks.write().await;
             let original = disks.clone();

--- a/rustfs/src/storage/rpc/http_service.rs
+++ b/rustfs/src/storage/rpc/http_service.rs
@@ -14,7 +14,6 @@
 
 use crate::server::RPC_PREFIX;
 use crate::storage::request_context::spawn_traced;
-use crate::storage::storage_api::DiskError;
 use crate::storage::storage_api::rpc_consumer::http_service::{
     DEFAULT_READ_BUFFER_SIZE, DeleteOptions, DiskStore, NS_SCANNER_PROTOCOL_VERSION, NsScannerCapabilityResponse,
     PUT_FILE_AUTH_TRAILER_LEN, PUT_FILE_AUTH_V1, PUT_FILE_CAPABILITY_VERSION, PutFileCapabilityResponse, StorageDiskRpcExt as _,
@@ -31,6 +30,7 @@ use crate::storage::storage_api::rpc_consumer::http_service::{
 };
 use crate::storage::storage_api::runtime_sources_consumer::runtime_sources;
 use crate::storage::storage_api::tonic_rpc_auth_failure_reason;
+use crate::storage::storage_api::{DiskError, FileReader};
 use bytes::{Bytes, BytesMut};
 use futures_util::{Stream, StreamExt, TryStreamExt, stream};
 use http::{HeaderMap, HeaderValue, Method, Request, Response, StatusCode, Uri};
@@ -67,6 +67,8 @@ const LOG_SUBSYSTEM_NAMESPACE_SCANNER: &str = "namespace_scanner";
 const LOG_SUBSYSTEM_ROUTING: &str = "routing";
 const EVENT_RPC_REQUEST_REJECTED: &str = "rpc_request_rejected";
 const EVENT_RPC_REQUEST_FAILED: &str = "rpc_request_failed";
+const RUSTFS_META_BUCKET: &str = ".rustfs.sys";
+const MIGRATING_META_BUCKET: &str = ".minio.sys";
 const EVENT_RPC_BACKGROUND_TASK_FAILED: &str = "rpc_background_task_failed";
 const RPC_OPERATION_UNKNOWN: &str = "unknown";
 const READ_FILE_STREAM_PATH: &str = "/rustfs/rpc/read_file_stream";
@@ -633,34 +635,32 @@ async fn handle_read_file(req: Request<Incoming>) -> Response<Body> {
         return response_with_status(StatusCode::BAD_REQUEST, "disk not found");
     };
 
-    let file = match disk
-        .read_file_stream(&query.volume, &query.path, query.offset, query.length)
-        .await
-    {
-        Ok(file) => file,
-        Err(e) => {
-            let message = format!("read file err {e}");
-            error!(
-                event = EVENT_RPC_REQUEST_FAILED,
-                component = LOG_COMPONENT_INTERNODE_RPC,
-                subsystem = LOG_SUBSYSTEM_FILE_TRANSFER,
-                operation = INTERNODE_OPERATION_READ_FILE_STREAM,
-                result = "failed",
-                status_code = StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
-                rpc_path = req.uri().path(),
-                method = %req.method(),
-                reason = "read_file_failed",
-                disk = %query.disk,
-                volume = %query.volume,
-                path = %query.path,
-                offset = query.offset,
-                length = query.length,
-                error = %e,
-                "internode rpc request failed"
-            );
-            return response_with_disk_error(&e, message);
-        }
-    };
+    let file =
+        match read_file_stream_with_legacy_meta_fallback(&disk, &query.volume, &query.path, query.offset, query.length).await {
+            Ok(file) => file,
+            Err(e) => {
+                let message = format!("read file err {e}");
+                error!(
+                    event = EVENT_RPC_REQUEST_FAILED,
+                    component = LOG_COMPONENT_INTERNODE_RPC,
+                    subsystem = LOG_SUBSYSTEM_FILE_TRANSFER,
+                    operation = INTERNODE_OPERATION_READ_FILE_STREAM,
+                    result = "failed",
+                    status_code = StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+                    rpc_path = req.uri().path(),
+                    method = %req.method(),
+                    reason = "read_file_failed",
+                    disk = %query.disk,
+                    volume = %query.volume,
+                    path = %query.path,
+                    offset = query.offset,
+                    length = query.length,
+                    error = %e,
+                    "internode rpc request failed"
+                );
+                return response_with_disk_error(&e, message);
+            }
+        };
 
     runtime_sources::current_internode_metrics().record_incoming_request_for_operation_and_backend(
         INTERNODE_OPERATION_READ_FILE_STREAM,
@@ -800,28 +800,30 @@ async fn handle_walk_dir(req: Request<Incoming>) -> Response<Body> {
     let log_disk_id = args.disk_id.clone();
     let log_skip_total_timeout = args.skip_total_timeout;
     let body = walk_dir_response_body(propagate_completion_errors, move |mut writer| async move {
-        disk.walk_dir(args, &mut writer).await.map_err(|e| {
-            warn!(
-                event = EVENT_RPC_BACKGROUND_TASK_FAILED,
-                component = LOG_COMPONENT_INTERNODE_RPC,
-                subsystem = LOG_SUBSYSTEM_DIRECTORY_WALK,
-                operation = INTERNODE_OPERATION_WALK_DIR,
-                result = "failed",
-                disk = %log_disk,
-                bucket = %log_bucket,
-                base_dir = %log_base_dir,
-                recursive = log_recursive,
-                report_notfound = log_report_notfound,
-                filter_prefix = ?log_filter_prefix,
-                forward_to = ?log_forward_to,
-                limit = log_limit,
-                disk_id = %log_disk_id,
-                skip_total_timeout = log_skip_total_timeout,
-                error = %e,
-                "internode rpc background task failed"
-            );
-            io::Error::other("remote walk_dir failed")
-        })
+        walk_dir_with_legacy_meta_fallback(&disk, args, &mut writer)
+            .await
+            .map_err(|e| {
+                warn!(
+                    event = EVENT_RPC_BACKGROUND_TASK_FAILED,
+                    component = LOG_COMPONENT_INTERNODE_RPC,
+                    subsystem = LOG_SUBSYSTEM_DIRECTORY_WALK,
+                    operation = INTERNODE_OPERATION_WALK_DIR,
+                    result = "failed",
+                    disk = %log_disk,
+                    bucket = %log_bucket,
+                    base_dir = %log_base_dir,
+                    recursive = log_recursive,
+                    report_notfound = log_report_notfound,
+                    filter_prefix = ?log_filter_prefix,
+                    forward_to = ?log_forward_to,
+                    limit = log_limit,
+                    disk_id = %log_disk_id,
+                    skip_total_timeout = log_skip_total_timeout,
+                    error = %e,
+                    "internode rpc background task failed"
+                );
+                io::Error::other("remote walk_dir failed")
+            })
     });
 
     runtime_sources::current_internode_metrics()
@@ -831,6 +833,54 @@ async fn handle_walk_dir(req: Request<Incoming>) -> Response<Body> {
         .status(StatusCode::OK)
         .body(body)
         .expect("failed to build walk dir response")
+}
+
+fn legacy_meta_bucket_alias(volume: &str) -> Option<String> {
+    if volume == MIGRATING_META_BUCKET {
+        return Some(RUSTFS_META_BUCKET.to_string());
+    }
+    volume
+        .strip_prefix(MIGRATING_META_BUCKET)
+        .filter(|rest| rest.starts_with('/'))
+        .map(|rest| format!("{RUSTFS_META_BUCKET}{rest}"))
+}
+
+fn legacy_meta_alias_can_retry(error: &DiskError, volume: &str) -> bool {
+    matches!(error, DiskError::FileNotFound | DiskError::VolumeNotFound) && legacy_meta_bucket_alias(volume).is_some()
+}
+
+async fn read_file_stream_with_legacy_meta_fallback(
+    disk: &DiskStore,
+    volume: &str,
+    path: &str,
+    offset: usize,
+    length: usize,
+) -> Result<FileReader, DiskError> {
+    match disk.read_file_stream(volume, path, offset, length).await {
+        Ok(file) => Ok(file),
+        Err(error) if legacy_meta_alias_can_retry(&error, volume) => {
+            let alias = legacy_meta_bucket_alias(volume).expect("legacy meta alias checked before retry");
+            disk.read_file_stream(&alias, path, offset, length).await
+        }
+        Err(error) => Err(error),
+    }
+}
+
+async fn walk_dir_with_legacy_meta_fallback<W: tokio::io::AsyncWrite + Unpin + Send>(
+    disk: &DiskStore,
+    args: WalkDirOptions,
+    writer: &mut W,
+) -> Result<(), DiskError> {
+    let original_bucket = args.bucket.clone();
+    match disk.walk_dir(args.clone(), writer).await {
+        Ok(()) => Ok(()),
+        Err(error) if legacy_meta_alias_can_retry(&error, &original_bucket) => {
+            let mut retry_args = args;
+            retry_args.bucket = legacy_meta_bucket_alias(&original_bucket).expect("legacy meta alias checked before retry");
+            disk.walk_dir(retry_args, writer).await
+        }
+        Err(error) => Err(error),
+    }
 }
 
 async fn handle_ns_scanner(req: Request<Incoming>) -> Response<Body> {
@@ -1699,13 +1749,14 @@ mod tests {
         NS_SCANNER_SESSION_SEQUENCE_QUERY, NS_SCANNER_TIER_REGISTRY_GENERATION_QUERY, NsScannerCapabilityResponse,
         NsScannerQuery, PUT_FILE_AUTH_STREAM_PATH, PUT_FILE_CAPABILITY_PATH, PUT_FILE_STREAM_PATH, PutFileQuery,
         READ_FILE_STREAM_PATH, WALK_DIR_BODY_SHA256_QUERY, WALK_DIR_PATH, WalkDirQuery, append_walk_dir_completion,
-        internode_http_operation, internode_rpc_subsystem, is_internode_rpc_path, ns_scanner_response_body,
-        ns_scanner_server_epoch_matches, put_body_size_mismatch, put_file_auth_nonce, put_file_capability_response,
-        put_file_server_epoch_accepted, put_file_server_epoch_matches, put_file_stage_error_message, put_file_target_lock,
-        read_file_body_stream, read_file_stream_buffer_size, remote_scanner_claim_rejection, response_with_disk_error,
-        supports_walk_dir_stream_completion, validate_walk_dir_completion_request, verify_internode_rpc_signature,
-        verify_ns_scanner_body_digest, verify_walk_dir_body_digest, walk_dir_response_body, write_authenticated_put_file,
-        write_body_chunks_to_writer, write_put_file_body_chunks_to_writer,
+        internode_http_operation, internode_rpc_subsystem, is_internode_rpc_path, legacy_meta_bucket_alias,
+        ns_scanner_response_body, ns_scanner_server_epoch_matches, put_body_size_mismatch, put_file_auth_nonce,
+        put_file_capability_response, put_file_server_epoch_accepted, put_file_server_epoch_matches,
+        put_file_stage_error_message, put_file_target_lock, read_file_body_stream, read_file_stream_buffer_size,
+        remote_scanner_claim_rejection, response_with_disk_error, supports_walk_dir_stream_completion,
+        validate_walk_dir_completion_request, verify_internode_rpc_signature, verify_ns_scanner_body_digest,
+        verify_walk_dir_body_digest, walk_dir_response_body, write_authenticated_put_file, write_body_chunks_to_writer,
+        write_put_file_body_chunks_to_writer,
     };
     use crate::storage::storage_api::ecstore_rpc::{build_put_file_auth_trailer, gen_signature_headers};
     use crate::storage::storage_api::rpc_consumer::http_service::{DiskAPI as _, DiskOption, DiskStore, Endpoint, new_disk};
@@ -3012,5 +3063,16 @@ mod tests {
 
         let response = response_with_disk_error(&DiskError::DiskAccessDenied, "permission denied");
         assert!(response.headers().get(rustfs_rio::INTERNODE_DISK_ERROR_HEADER).is_none());
+    }
+
+    #[test]
+    fn legacy_meta_bucket_alias_maps_only_legacy_system_metadata() {
+        assert_eq!(legacy_meta_bucket_alias(".minio.sys").as_deref(), Some(".rustfs.sys"));
+        assert_eq!(
+            legacy_meta_bucket_alias(".minio.sys/config/iam").as_deref(),
+            Some(".rustfs.sys/config/iam")
+        );
+        assert_eq!(legacy_meta_bucket_alias(".minio.sys-lookalike"), None);
+        assert_eq!(legacy_meta_bucket_alias("user-bucket"), None);
     }
 }


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#2240, rustfs/backlog#2269, and rustfs/backlog#2428.

## Summary of Changes
During mixed-version rolling upgrades, previous-release peers can still ask a current node for system metadata through legacy `.minio.sys` internode RPC volume names. Current nodes store that metadata under `.rustfs.sys`, so read-only metadata RPCs could return `FileNotFound` or `VolumeNotFound`, which surfaced as quorum failures in the G09 mixed-version runner.

This change adds a narrow internode HTTP RPC compatibility fallback for read-only metadata access:

- `read_file_stream` retries legacy `.minio.sys` metadata reads against `.rustfs.sys` only after a missing-file or missing-volume error.
- `walk_dir` applies the same retry for legacy system metadata directory walks.
- User buckets and lookalike names such as `.minio.sys-lookalike` are not aliased.

The fallback stays above the disk layer so format migration can still inspect the real legacy `.minio.sys` layout when needed.

## Verification
- `git diff --check origin/release...HEAD` passed at commit `0db8bb39f`.
- `cargo fmt --all --check` passed at commit `0db8bb39f`.
- `cargo test --locked -p rustfs legacy_meta_bucket_alias_maps_only_legacy_system_metadata` passed at commit `0db8bb39f` with 1 test run.
- Azure Linux local diagnostic, using the same fix diff before PR commit cleanup, ran `scripts/run_scanner_heal_g09_upgrade_evidence.sh --test all --skip-download --allow-dirty` and passed `build-current`, `mixed-version`, `rollback`, and G09 descriptor verification. Diagnostic run id: `g09-all-fix-20260912T020505Z`.

Remaining risk: the Azure G09 run above is pre-merge local diagnostic evidence, not final release evidence. W13/G09 closure should rerun the clean current-head G09 evidence after this PR lands.

## Impact
Improves rolling-upgrade compatibility for previous-release peers reading system metadata from current nodes. The change is limited to internode HTTP RPC read paths and does not change user bucket addressing, write paths, or disk migration semantics.

## Additional Notes
N/A.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
