### PR TITLE
fix: restore list versions policy compatibility

### DIFF
--- a/crates/e2e_test/src/delete_authorization_test.rs
+++ b/crates/e2e_test/src/delete_authorization_test.rs
@@ -119,7 +119,11 @@ async fn versions(client: &Client, bucket: &str, prefix: &str) -> TestResult<Ver
     }
 }
 
-async fn force_delete(client: &Client, bucket: &str, prefix: &str) -> Result<DeleteObjectOutput, SdkError<DeleteObjectError>> {
+async fn force_delete(
+    client: &Client,
+    bucket: &str,
+    prefix: &str,
+) -> Result<DeleteObjectOutput, Box<SdkError<DeleteObjectError>>> {
     client
         .delete_object()
         .bucket(bucket)
@@ -130,13 +134,14 @@ async fn force_delete(client: &Client, bucket: &str, prefix: &str) -> Result<Del
         })
         .send()
         .await
+        .map_err(Box::new)
 }
 
 async fn replica_force_delete(
     client: &Client,
     bucket: &str,
     prefix: &str,
-) -> Result<DeleteObjectOutput, SdkError<DeleteObjectError>> {
+) -> Result<DeleteObjectOutput, Box<SdkError<DeleteObjectError>>> {
     client
         .delete_object()
         .bucket(bucket)
@@ -148,6 +153,7 @@ async fn replica_force_delete(
         })
         .send()
         .await
+        .map_err(Box::new)
 }
 
 fn assert_denied<T, E>(result: Result<T, SdkError<E>>)
@@ -161,6 +167,14 @@ where
         Some("AccessDenied"),
         "expected an S3 authorization denial, got {error:?}"
     );
+}
+
+fn assert_boxed_denied<T, E>(result: Result<T, Box<SdkError<E>>>)
+where
+    T: std::fmt::Debug,
+    E: ProvideErrorMetadata + std::fmt::Debug,
+{
+    assert_denied(result.map_err(|error| *error));
 }
 
 #[tokio::test]
@@ -436,13 +450,13 @@ async fn force_delete_denied_child_preserves_every_object_despite_bucket_allow()
         ]}).to_string())
         .send().await?;
     let before = versions(&root, bucket, "folder/").await?;
-    assert_denied(force_delete(&user, bucket, "folder/").await);
+    assert_boxed_denied(force_delete(&user, bucket, "folder/").await);
     assert_eq!(
         versions(&root, bucket, "folder/").await?,
         before,
         "a denied descendant must prevent every mutation in the force scope"
     );
-    assert_denied(replica_force_delete(&user, bucket, "folder/").await);
+    assert_boxed_denied(replica_force_delete(&user, bucket, "folder/").await);
     assert_eq!(
         versions(&root, bucket, "folder/").await?,
         before,
@@ -495,7 +509,7 @@ async fn force_delete_denied_historical_version_preserves_versions_and_markers()
     let before = versions(&root, bucket, "folder/").await?;
     for version in [protected_version.as_str(), "null", marker_version] {
         set_policy(&env, "version-denier", &policy(version)).await?;
-        assert_denied(force_delete(&user, bucket, "folder/").await);
+        assert_boxed_denied(force_delete(&user, bucket, "folder/").await);
         assert_eq!(
             versions(&root, bucket, "folder/").await?,
             before,
@@ -625,7 +639,7 @@ async fn force_delete_checks_every_version_page_before_mutation() -> TestResult 
     .await?;
     let before = versions(&root, bucket, "folder/").await?;
     assert_eq!(before.len(), 1001, "the denied key must be beyond one default versions page");
-    assert_denied(force_delete(&user, bucket, "folder/").await);
+    assert_boxed_denied(force_delete(&user, bucket, "folder/").await);
     assert_eq!(
         versions(&root, bucket, "folder/").await?,
         before,

--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -1258,6 +1258,25 @@ pub async fn authorize_request<T>(req: &mut S3Request<T>, action: Action) -> S3R
             .await
             .map_err(ApiError::from)?;
 
+            // A bucket policy granting s3:ListBucket also covers listing versions.
+            // Keep this compatibility fallback inside the same public-access gate.
+            let policy_allowed = policy_allowed
+                || (action == Action::S3Action(S3Action::ListBucketVersionsAction)
+                    && PolicySys::try_is_allowed_for_store(
+                        store.as_ref(),
+                        &BucketPolicyArgs {
+                            bucket: bucket.as_str(),
+                            action: Action::S3Action(S3Action::ListBucketAction),
+                            is_owner: false,
+                            account: "",
+                            groups: &None,
+                            conditions: &conditions,
+                            object: "",
+                        },
+                    )
+                    .await
+                    .map_err(ApiError::from)?);
+
             if policy_allowed {
                 deny_anonymous_table_data_plane_if_needed(req, action, bucket.as_str(), object.as_str()).await?;
                 // RestrictPublicBuckets: when true, deny public access even if bucket policy allows it.


### PR DESCRIPTION
## Related Issues
#7661

## Summary of Changes
Restore the `s3:ListBucket` compatibility fallback for `ListObjectVersions` authorization while keeping the `RestrictPublicBuckets` gate intact. Box the E2E SDK errors used by force-delete authorization checks so the workspace Clippy gate passes.

## Verification
- `cargo fmt --all --check` and `git diff --check` passed on commit `9d35fdc21`.
- `cargo clippy -p e2e_test --tests -- -D warnings` passed.
- `cargo build -p rustfs` passed, followed by `cargo test -p e2e_test --lib ghsa_x298_anonymous_list_object_versions_denied_when_restrict_public_buckets_enabled -- --nocapture`: 1 passed, 0 failed, using the current source-built binary.
- Full workspace CI and the complete E2E suite were not run locally; GitHub Actions will provide those checks.

## Impact
Restores existing bucket-policy compatibility for version listing without changing the `RestrictPublicBuckets` behavior or public API.

## Additional Notes
This PR targets `fix/force-delete-authorization` so it can be merged independently of the changes already present in #7661.
