### PR TITLE
fix(pool): default the node-endpoints fallback to the 4-node fleet

### DIFF
--- a/.github/workflows/rustfs-pool-expand-test.yml
+++ b/.github/workflows/rustfs-pool-expand-test.yml
@@ -83,7 +83,7 @@ jobs:
       RUSTFS_POOL_PROXY_ENDPOINT: http://127.0.0.1:19000
       RUSTFS_POOL_WARP_ENDPOINT: http://127.0.0.1:19000
       RUSTFS_SHARED_PROXY_ENDPOINT: ${{ secrets.RUSTFS_API_ENDPOINT || vars.RUSTFS_API_ENDPOINT || vars.RUSTFS_RC_ENDPOINT }}
-      RUSTFS_POOL_NODE_ENDPOINTS: ${{ secrets.RUSTFS_POOL_NODE_ENDPOINTS || vars.RUSTFS_POOL_NODE_ENDPOINTS || 'http://rustfs-node1:9000 http://rustfs-node2:9000 http://rustfs-node3:9000' }}
+      RUSTFS_POOL_NODE_ENDPOINTS: ${{ secrets.RUSTFS_POOL_NODE_ENDPOINTS || vars.RUSTFS_POOL_NODE_ENDPOINTS || 'http://rustfs-node1:9000 http://rustfs-node2:9000 http://rustfs-node3:9000 http://rustfs-node4:9000' }}
     steps:
       # auto-testing is private: clone it with the dedicated PF token (not
       # GITHUB_TOKEN) and retry transient GitHub/network failures.


### PR DESCRIPTION
## Problem

Since the fleet grew to 4 nodes, every pool dispatch died at startup (84s) with:

```
ERROR: RUSTFS_POOL_NODE_ENDPOINTS ... must provide at least 4 direct node endpoints
```

Root cause: `RUSTFS_POOL_NODE_ENDPOINTS` has no secret/var configured, so the workflow's inline 3-endpoint fallback applied, and the explicit `--node-endpoints` flag overrides the script default that rustfs/auto-testing#61 already fixed. rustfs/backlog#2477/#2469 closed as config-gap; this is the workflow half of that fix.

## Change

Add `http://rustfs-node4:9000` to the `RUSTFS_POOL_NODE_ENDPOINTS` fallback. Explicit secret/var still wins when configured.