### PR TITLE
fix(scanner): require ABBA collector credentials

### DIFF
--- a/scripts/scanner_abba.py
+++ b/scripts/scanner_abba.py
@@ -650,6 +650,8 @@ def collect_live(prepared, request, request_path, adapter):
     connection = prepared["collector"]
     require(set(connection) == {"alias", "endpoint", "metrics_endpoints"}, "invalid collector connection")
     require(all(isinstance(value, str) and value for value in connection.values()), "missing collector endpoint")
+    require(os.environ.get("RUSTFS_ACCESS_KEY"), "collector requires RUSTFS_ACCESS_KEY")
+    require(os.environ.get("RUSTFS_SECRET_KEY"), "collector requires RUSTFS_SECRET_KEY")
     expected_metrics_endpoints = None
     if request.get("evidence") == "measured":
         expected_metrics_endpoints = request["release_evidence"]["distributed"]["metrics_endpoints"]

--- a/scripts/test_scanner_abba.py
+++ b/scripts/test_scanner_abba.py
@@ -278,7 +278,8 @@ class ScannerAbbaTest(unittest.TestCase):
         try:
             with patch.dict(os.environ, {"SCANNER_ABBA_TEST_FAULT": "stubborn-child"}), \
                  patch.object(harness, "__file__", str(self.root / "scanner_abba.py")), \
-                 patch.object(harness, "invoke", side_effect=failed_measure):
+                 patch.object(harness, "invoke", side_effect=failed_measure), \
+                 patch.dict(os.environ, {"RUSTFS_ACCESS_KEY": "test", "RUSTFS_SECRET_KEY": "test"}):
                 with self.assertRaisesRegex(ValueError, "injected measurement failure"):
                     harness.collect_live({"collector": {"alias": "fixture", "endpoint": "fixture", "metrics_endpoints": "fixture"}},
                                          {"duration_seconds": 900}, request, self.adapter)
@@ -537,7 +538,8 @@ class ScannerAbbaTest(unittest.TestCase):
                 process = Mock(pid=123, wait=Mock(return_value=1 if name == "collector-exit" else 0))
                 with patch.object(harness, "OwnedCommand", return_value=process), \
                         patch.object(harness, "invoke", return_value={"sample_count": 10}), \
-                        patch.object(harness.time, "monotonic", side_effect=(0, 900)):
+                        patch.object(harness.time, "monotonic", side_effect=(0, 900)), \
+                        patch.dict(os.environ, {"RUSTFS_ACCESS_KEY": "test", "RUSTFS_SECRET_KEY": "test"}):
                     if error:
                         with self.assertRaisesRegex(ValueError, error):
                             harness.collect_live(prepared, {"duration_seconds": 900}, self.root / "request.json", self.adapter)
@@ -546,6 +548,19 @@ class ScannerAbbaTest(unittest.TestCase):
                                                              self.root / "request.json", self.adapter), {"sample_count": 10})
 
                 process.finish.assert_called_once_with(terminate=True)
+
+    def test_live_collector_requires_credentials_before_measurement(self):
+        request = self.root / "request.json"
+        harness.write_json(request, {})
+        prepared = {"collector": {"alias": "test", "endpoint": "http://node-a:9000",
+                                  "metrics_endpoints": "http://node-a:9000"}}
+        with patch.object(harness, "OwnedCommand") as command, \
+                patch.object(harness, "invoke") as invoke, \
+                patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(ValueError, "collector requires RUSTFS_ACCESS_KEY"):
+                harness.collect_live(prepared, {"duration_seconds": 900}, request, self.adapter)
+        command.assert_not_called()
+        invoke.assert_not_called()
 
     def test_live_collector_binds_release_evidence_metrics_endpoints(self):
         telemetry = self.root / "telemetry"
@@ -570,7 +585,8 @@ class ScannerAbbaTest(unittest.TestCase):
         process = Mock(pid=123, wait=Mock(return_value=0))
         with patch.object(harness, "OwnedCommand", return_value=process), \
                 patch.object(harness, "invoke", return_value={"sample_count": 10}), \
-                patch.object(harness.time, "monotonic", side_effect=(0, 900)):
+                patch.object(harness.time, "monotonic", side_effect=(0, 900)), \
+                patch.dict(os.environ, {"RUSTFS_ACCESS_KEY": "test", "RUSTFS_SECRET_KEY": "test"}):
             with self.assertRaisesRegex(ValueError, "collector metrics endpoints"):
                 harness.collect_live(prepared, request, self.root / "request.json", self.adapter)
         process.finish.assert_called_once_with(terminate=True)


### PR DESCRIPTION
## Related Issues
rustfs/backlog#2428, rustfs/backlog#2240

## Summary of Changes
- Require `RUSTFS_ACCESS_KEY` and `RUSTFS_SECRET_KEY` before the Scanner ABBA live collector starts.
- Keep live measured collection from launching a metrics/adapter run that cannot authenticate distributed endpoints.
- Extend the scanner ABBA harness tests so existing live-collector paths provide explicit test credentials, and add a regression test that missing credentials fail before starting the collector or measurement adapter.

## Verification
- `python3 scripts/test_scanner_abba.py` passed: 29 tests.
- `git diff --check` passed.

Remaining risk: this only hardens the live collector preflight. It does not provide G10/P1/P2/P3 ABBA measured evidence, and it does not unblock the final W13 release gate by itself.

## Impact
Live Scanner ABBA collection now fails fast when the required RustFS credentials are missing instead of starting an unauthenticated measured run.

## Additional Notes
N/A
