### PR TITLE
test(heal): label G14 recovery read failures

### DIFF
--- a/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
+++ b/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
@@ -601,7 +601,9 @@ mod tests {
                         .set_continuation_token(continuation_token.clone())
                         .send(),
                 )
-                .await??;
+                .await
+                .map_err(|error| format!("node {node_index} recovery listing timed out for bucket {bucket}: {error}"))?
+                .map_err(|error| format!("node {node_index} recovery listing failed for bucket {bucket}: {error}"))?;
                 listed_keys.extend(
                     response
                         .contents()
@@ -707,8 +709,14 @@ mod tests {
                 Ok(Err(error)) if is_retryable_recovery_get(&error) && Instant::now() < deadline => {
                     sleep(Duration::from_millis(250)).await;
                 }
-                Ok(Err(error)) => return Err(error.into()),
-                Err(error) => return Err(error.into()),
+                Ok(Err(error)) => {
+                    return Err(
+                        format!("recovery GET failed for {bucket}/{key} after waiting up to {timeout_secs}s: {error}").into(),
+                    );
+                }
+                Err(error) => {
+                    return Err(format!("recovery GET timed out for {bucket}/{key} after 30s attempt: {error}").into());
+                }
             }
         }
     }


### PR DESCRIPTION
## Related Issues
rustfs/backlog#2488, rustfs/backlog#2428, rustfs/backlog#2240

## Summary of Changes
- Add explicit recovery-stage context to the G14 scanner/heal e2e runner when post-recovery namespace listing fails.
- Add explicit bucket/key and wait-window context when recovery GET still fails after the bounded retry loop.
- Keep the existing gate behavior unchanged: failures remain failures, but the next measured run can distinguish a namespace listing quorum failure from a target GET quorum failure.

## Verification
- `cargo check -p e2e_test` passed.
- `cargo fmt --all --check` passed.
- `git diff --check` passed.

Remaining risk: this is diagnostic hardening only. It does not fix the G14 multi-pool `SlowDownRead` blocker and does not provide bundle-ready release evidence.

## Impact
No product behavior change. Failed Scanner/Heal G14 evidence runs will produce more actionable failure context.

## Additional Notes
N/A
