### PR TITLE
test(heal): retry G14 deferred outage put

### DIFF
--- a/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
+++ b/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
@@ -685,6 +685,13 @@ mod tests {
         error.as_service_error().and_then(ProvideErrorMetadata::code) == Some("ServiceUnavailable")
     }
 
+    fn is_retryable_deferred_put_after_rejoin(error: &SdkError<PutObjectError>) -> bool {
+        matches!(
+            error.as_service_error().and_then(ProvideErrorMetadata::code),
+            Some("SlowDownRead" | "ServiceUnavailable")
+        )
+    }
+
     fn is_service_unavailable_delete(error: &SdkError<DeleteObjectError>) -> bool {
         error.as_service_error().and_then(ProvideErrorMetadata::code) == Some("ServiceUnavailable")
     }
@@ -2181,11 +2188,21 @@ mod tests {
                 .await;
                 match put_result {
                     Ok(Ok(_)) => break,
-                    Ok(Err(error)) if is_service_unavailable_put(&error) && Instant::now() < deferred_deadline => {
+                    Ok(Err(error)) if is_retryable_deferred_put_after_rejoin(&error) && Instant::now() < deferred_deadline => {
                         sleep(Duration::from_secs(1)).await;
                     }
-                    Ok(Err(error)) => return Err(error.into()),
-                    Err(error) => return Err(error.into()),
+                    Ok(Err(error)) => {
+                        return Err(format!(
+                            "deferred outage PUT failed for {bucket}/{outage_key} after target rejoin and up to 60s wait: {error}"
+                        )
+                        .into());
+                    }
+                    Err(error) => {
+                        return Err(format!(
+                            "deferred outage PUT timed out for {bucket}/{outage_key} after 30s attempt: {error}"
+                        )
+                        .into());
+                    }
                 }
             }
             info!(


### PR DESCRIPTION
## Related Issues
rustfs/backlog#2488

## Summary of Changes
- Treat `SlowDownRead` as a bounded retryable response for the G14 deferred outage PUT that runs after the target pool rejoins.
- Add explicit `deferred outage PUT` stage context for terminal send failures and per-attempt timeouts.

This keeps the initial whole-pool outage probe unchanged while making the post-rejoin write phase produce actionable evidence instead of an unlabeled S3 service error.

## Verification
- `cargo fmt --all --check` passed.
- `cargo check -p e2e_test` passed.
- `git diff --check` passed.

Remaining risk: the latest release G14 measured run still fails before this patch with an unlabeled `SlowDownRead` during the deferred outage PUT phase. A follow-up G14 run on this PR or after merge is still required before the release bundle can consume G14 evidence.

## Impact
Test-only change. No production runtime behavior, API, deployment, or configuration impact is expected.

## Additional Notes
N/A
