### PR TITLE
test(heal): retry G14 outage put probes

### DIFF
--- a/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
+++ b/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
@@ -685,7 +685,7 @@ mod tests {
         error.as_service_error().and_then(ProvideErrorMetadata::code) == Some("ServiceUnavailable")
     }
 
-    fn is_retryable_deferred_put_after_rejoin(error: &SdkError<PutObjectError>) -> bool {
+    fn is_retryable_outage_put(error: &SdkError<PutObjectError>) -> bool {
         matches!(
             error.as_service_error().and_then(ProvideErrorMetadata::code),
             Some("SlowDownRead" | "ServiceUnavailable")
@@ -1602,12 +1602,19 @@ mod tests {
                     outage_key = Some(candidate_key);
                     break;
                 }
-                Ok(Err(error)) if is_service_unavailable_put(&error) => {
+                Ok(Err(error)) if is_retryable_outage_put(&error) => {
                     service_unavailable_outage_writes += 1;
                     last_service_unavailable = Some(format!("{error:?}"));
                 }
-                Ok(Err(error)) => return Err(error.into()),
-                Err(error) => return Err(error.into()),
+                Ok(Err(error)) => {
+                    return Err(format!("outage PUT candidate {candidate_key} failed before target rejoin: {error}").into());
+                }
+                Err(error) => {
+                    return Err(format!(
+                        "outage PUT candidate {candidate_key} timed out before target rejoin after 30s: {error}"
+                    )
+                    .into());
+                }
             }
         }
         let outage_key = match outage_key {
@@ -2188,7 +2195,7 @@ mod tests {
                 .await;
                 match put_result {
                     Ok(Ok(_)) => break,
-                    Ok(Err(error)) if is_retryable_deferred_put_after_rejoin(&error) && Instant::now() < deferred_deadline => {
+                    Ok(Err(error)) if is_retryable_outage_put(&error) && Instant::now() < deferred_deadline => {
                         sleep(Duration::from_secs(1)).await;
                     }
                     Ok(Err(error)) => {


### PR DESCRIPTION
## Related Issues
rustfs/backlog#2488

## Summary of Changes
- Treat `SlowDownRead` as a retryable unavailable response for the G14 outage PUT candidate probe.
- Keep the already merged deferred PUT retry behavior, but share the same retry classifier for both outage-write stages.
- Add explicit `outage PUT candidate` stage context for terminal candidate send failures and per-attempt timeouts.

This follow-up is based on `release` after rustfs/rustfs#7703. The latest G14 validation of #7703 still failed before the deferred PUT phase, because the initial outage PUT probe could return an unlabeled `SlowDownRead`.

## Verification
- `cargo fmt --all --check` passed.
- `cargo check -p e2e_test` passed.
- `git diff --check` passed.

Remaining risk: this is still runner-side narrowing evidence. G14 must be rerun on latest `release` after this merges before the release bundle can consume the result.

## Impact
Test-only change. No production runtime behavior, API, deployment, or configuration impact is expected.

## Additional Notes
N/A
