### PR TITLE
test(heal): remove unused G14 put helper

### DIFF
--- a/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
+++ b/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
@@ -681,10 +681,6 @@ mod tests {
             && operations["activeBySource"]["admin"].as_u64() == Some(1)
     }
 
-    fn is_service_unavailable_put(error: &SdkError<PutObjectError>) -> bool {
-        error.as_service_error().and_then(ProvideErrorMetadata::code) == Some("ServiceUnavailable")
-    }
-
     fn is_retryable_outage_put(error: &SdkError<PutObjectError>) -> bool {
         matches!(
             error.as_service_error().and_then(ProvideErrorMetadata::code),


### PR DESCRIPTION
## Related Issues
rustfs/backlog#2488

## Summary of Changes
- Remove the superseded `ServiceUnavailable`-only G14 PUT helper after rustfs/rustfs#7704 switched outage PUT handling to the shared retry classifier.

## Verification
- `cargo fmt --all --check` passed.
- `cargo check -p e2e_test` passed.
- `git diff --check` passed.

## Impact
Test-only cleanup. No production runtime behavior, API, deployment, or configuration impact is expected.

## Additional Notes
N/A
