### PR TITLE
feat(tftp): add TFTP RRQ support (part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -282,7 +282,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -741,6 +741,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +837,22 @@ name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-tftp"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f24aee9a5a63c41e6720d2ab8e12947d3b9386b2d21f770f890b19b20e0173f0"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "bytes",
+ "futures-lite",
+ "log",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "async-trait"
@@ -1906,7 +1940,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
@@ -3942,7 +3976,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4287,7 +4321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6963,7 +6997,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8049,6 +8083,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "pollster"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8712,7 +8760,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10439,12 +10487,14 @@ version = "1.0.0-rc.6"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
+ "async-tftp",
  "async-trait",
  "axum",
  "base64-simd",
  "bytes",
  "dav-server",
  "futures",
+ "futures-lite",
  "futures-util",
  "hex-simd",
  "hmac 0.13.0",
@@ -11065,7 +11115,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11148,7 +11198,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11949,7 +11999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12100,7 +12150,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12405,10 +12455,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13510,7 +13560,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -367,6 +367,9 @@ rcgen = { version = "0.14.10", default-features = false, features = ["aws_lc_rs"
 russh = { version = "0.63.3" }
 russh-sftp = "3.0.0"
 
+# TFTP
+async-tftp = "0.4.2"
+
 # WebDAV
 dav-server = "0.11.0"
 

--- a/crates/config/src/constants/protocols.rs
+++ b/crates/config/src/constants/protocols.rs
@@ -169,3 +169,59 @@ pub const DEFAULT_SFTP_READ_ONLY: bool = false;
 
 /// Default SSH identification string (no version disclosure).
 pub const DEFAULT_SFTP_BANNER: &str = "SSH-2.0-RustFS";
+
+/// Default TFTP server bind address. The well-known TFTP port is UDP 69,
+/// which needs CAP_NET_BIND_SERVICE (or root) on Linux. The default binds
+/// an unprivileged port instead so enabling the protocol never requires
+/// extra capabilities; operators fronting real PXE clients set
+/// `RUSTFS_TFTP_ADDRESS` to port 69 explicitly.
+pub const DEFAULT_TFTP_ADDRESS: &str = "0.0.0.0:6969";
+
+/// TFTP environment variable names.
+pub const ENV_TFTP_ENABLE: &str = "RUSTFS_TFTP_ENABLE";
+pub const ENV_TFTP_ADDRESS: &str = "RUSTFS_TFTP_ADDRESS";
+/// Access key of the IAM identity every TFTP transfer is authorized as.
+pub const ENV_TFTP_ACCESS_KEY: &str = "RUSTFS_TFTP_ACCESS_KEY";
+pub const ENV_TFTP_SECRET_KEY: &str = "RUSTFS_TFTP_SECRET_KEY";
+/// When set, every request resolves inside this one bucket and the
+/// request filename becomes the object key. When unset, filenames are
+/// addressed as `/<bucket>/<key>`.
+pub const ENV_TFTP_DEFAULT_BUCKET: &str = "RUSTFS_TFTP_DEFAULT_BUCKET";
+/// `ro` (RRQ only), `wo` (WRQ only), or `rw` (both).
+pub const ENV_TFTP_ACCESS_MODE: &str = "RUSTFS_TFTP_ACCESS_MODE";
+pub const ENV_TFTP_MAX_BLOCK_SIZE: &str = "RUSTFS_TFTP_MAX_BLOCK_SIZE";
+pub const ENV_TFTP_MAX_WINDOW_SIZE: &str = "RUSTFS_TFTP_MAX_WINDOW_SIZE";
+pub const ENV_TFTP_MAX_CONCURRENT_TRANSFERS: &str = "RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS";
+pub const ENV_TFTP_BACKEND_OP_TIMEOUT_SECS: &str = "RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS";
+pub const ENV_TFTP_READ_FETCH_BYTES: &str = "RUSTFS_TFTP_READ_FETCH_BYTES";
+/// UDP retransmit attempts after the last good block before giving up on a
+/// transfer. Lower values abort dangling multipart uploads sooner when a
+/// client disappears; raise for lossy PXE/firmware networks.
+pub const ENV_TFTP_MAX_SEND_RETRIES: &str = "RUSTFS_TFTP_MAX_SEND_RETRIES";
+
+/// Default TFTP access mode. TFTP has no authentication on the wire, so
+/// an unset mode grants reads only; enabling writes is an explicit
+/// operator decision.
+pub const DEFAULT_TFTP_ACCESS_MODE: &str = "ro";
+
+/// Default maximum negotiated TFTP block size (RFC 2348 upper bound).
+pub const DEFAULT_TFTP_MAX_BLOCK_SIZE: u16 = 65464;
+
+/// Default maximum negotiated TFTP window size (RFC 7440). Preserves
+/// client-negotiated pipelining unless the operator lowers the ceiling.
+pub const DEFAULT_TFTP_MAX_WINDOW_SIZE: u16 = 65535;
+
+/// Default concurrent TFTP transfers per process.
+pub const DEFAULT_TFTP_MAX_CONCURRENT_TRANSFERS: usize = 64;
+
+/// Default backend operation timeout in seconds.
+pub const DEFAULT_TFTP_BACKEND_OP_TIMEOUT_SECS: u64 = 60;
+
+/// Default read-ahead fetch size for RRQ streaming (4 MiB).
+pub const DEFAULT_TFTP_READ_FETCH_BYTES: u64 = 4 * 1024 * 1024;
+
+/// Default UDP retransmit attempts per TFTP block/window after timeout.
+///
+/// With the server timeout of 3s, five retries give up in ~18s instead of
+/// async-tftp's library default of 100 (~5 minutes).
+pub const DEFAULT_TFTP_MAX_SEND_RETRIES: u32 = 5;

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -108,6 +108,7 @@ swift = [
 ]
 webdav = ["dep:dav-server", "dep:hyper", "dep:hyper-util", "dep:http", "dep:http-body-util", "dep:tokio-rustls", "dep:base64-simd", "dep:rustls", "dep:percent-encoding", "dep:rustfs-tls-runtime", "dep:subtle"]
 sftp = ["dep:russh", "dep:russh-sftp", "dep:uuid", "dep:subtle", "dep:tokio-util", "dep:socket2"]
+tftp = ["dep:async-tftp", "dep:futures-lite", "dep:subtle", "dep:tokio-util"]
 
 [dependencies]
 hotpath.workspace = true
@@ -181,6 +182,10 @@ russh = { workspace = true, optional = true, features = ["serde"] }
 russh-sftp = { workspace = true, optional = true }
 subtle = { workspace = true, optional = true }
 socket2 = { workspace = true, optional = true, features = ["all"] }
+
+# TFTP specific dependencies (optional)
+async-tftp = { workspace = true, optional = true }
+futures-lite = { workspace = true, optional = true }
 
 [dev-dependencies]
 http = { workspace = true }

--- a/crates/protocols/src/common/dummy_storage.rs
+++ b/crates/protocols/src/common/dummy_storage.rs
@@ -185,6 +185,11 @@ struct Inner {
     // mid-await.
     stall_list_objects_v2: bool,
     list_objects_v2_entered: Option<Arc<Notify>>,
+
+    // When stall_head_object is true every head_object invocation
+    // signals head_object_entered and then awaits std::future::pending.
+    stall_head_object: bool,
+    head_object_entered: Option<Arc<Notify>>,
 }
 
 impl Inner {
@@ -222,6 +227,8 @@ impl Inner {
             put_object_entered: None,
             stall_list_objects_v2: false,
             list_objects_v2_entered: None,
+            stall_head_object: false,
+            head_object_entered: None,
         }
     }
 }
@@ -554,6 +561,14 @@ impl DummyBackend {
         inner.list_objects_v2_entered = None;
     }
 
+    /// Configure head_object to stall indefinitely. Each call notifies
+    /// the supplied Notify once, then awaits std::future::pending.
+    pub fn stall_head_object(&self, entered: Arc<Notify>) {
+        let mut inner = self.inner.lock().expect("lock");
+        inner.stall_head_object = true;
+        inner.head_object_entered = Some(entered);
+    }
+
     // Observers. Tests call these after the driver has run to verify the
     // backend received the expected calls.
 
@@ -676,16 +691,27 @@ impl StorageBackend for DummyBackend {
     }
 
     async fn head_object(&self, bucket: &str, key: &str, _credentials: &Credentials) -> Result<HeadObjectOutput, Self::Error> {
-        {
+        let (stall, entered, popped) = {
             let mut inner = self.inner.lock().expect("lock");
             inner.head_object_calls.push(HeadObjectCall {
                 bucket: bucket.to_string(),
                 key: key.to_string(),
             });
-        }
-        match self.inner.lock().expect("lock").head_object.pop_front() {
-            Some(r) => r,
-            None => Err(DummyError::NoSuchKey(format!("{bucket}/{key}"))),
+            let stall = inner.stall_head_object;
+            let entered = inner.head_object_entered.clone();
+            let popped = if stall { None } else { inner.head_object.pop_front() };
+            (stall, entered, popped)
+        };
+        if stall {
+            if let Some(n) = entered {
+                n.notify_one();
+            }
+            std::future::pending::<Result<HeadObjectOutput, Self::Error>>().await
+        } else {
+            match popped {
+                Some(r) => r,
+                None => Err(DummyError::NoSuchKey(format!("{bucket}/{key}"))),
+            }
         }
     }
 

--- a/crates/protocols/src/common/gateway.rs
+++ b/crates/protocols/src/common/gateway.rs
@@ -254,6 +254,7 @@ pub fn is_operation_supported(protocol: super::session::Protocol, action: &S3Act
             S3Action::GetObjectAcl => false,
             S3Action::PutObjectAcl => false,
         },
+        super::session::Protocol::Tftp => matches!(action, S3Action::GetObject | S3Action::HeadObject),
     }
 }
 

--- a/crates/protocols/src/common/session.rs
+++ b/crates/protocols/src/common/session.rs
@@ -26,6 +26,7 @@ pub enum Protocol {
     Swift,
     WebDav,
     Sftp,
+    Tftp,
 }
 
 /// Protocol principal representing an authenticated user
@@ -208,6 +209,7 @@ mod regression_prevention {
                 Protocol::Swift => {}
                 Protocol::WebDav => {}
                 Protocol::Sftp => {}
+                Protocol::Tftp => {}
             }
         }
     }

--- a/crates/protocols/src/lib.rs
+++ b/crates/protocols/src/lib.rs
@@ -29,6 +29,9 @@ pub mod webdav;
 #[cfg(feature = "sftp")]
 pub mod sftp;
 
+#[cfg(feature = "tftp")]
+pub mod tftp;
+
 pub use common::session::Protocol;
 pub use common::{AuthorizationError, ProtocolPrincipal, S3Action, SessionContext, authorize_operation};
 
@@ -43,3 +46,6 @@ pub use webdav::{config::WebDavConfig, server::WebDavServer};
 
 #[cfg(feature = "sftp")]
 pub use sftp::{SftpConfig, SftpInitError, SftpServer};
+
+#[cfg(feature = "tftp")]
+pub use tftp::{TftpConfig, TftpInitError, TftpServer, TftpStorageHandler};

--- a/crates/protocols/src/tftp/config.rs
+++ b/crates/protocols/src/tftp/config.rs
@@ -1,0 +1,117 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! TFTP server configuration.
+
+use super::constants::{
+    BACKEND_OP_TIMEOUT_MAX_SECS, BACKEND_OP_TIMEOUT_MIN_SECS, MAX_BLOCK_SIZE_MAX, MAX_BLOCK_SIZE_MIN,
+    MAX_CONCURRENT_TRANSFERS_MAX, MAX_CONCURRENT_TRANSFERS_MIN, MAX_SEND_RETRIES_MAX, MAX_SEND_RETRIES_MIN, MAX_WINDOW_SIZE_MAX,
+    MAX_WINDOW_SIZE_MIN, READ_FETCH_BYTES_MAX, READ_FETCH_BYTES_MIN,
+};
+use rustfs_config::{
+    DEFAULT_TFTP_ACCESS_MODE, DEFAULT_TFTP_BACKEND_OP_TIMEOUT_SECS, DEFAULT_TFTP_MAX_BLOCK_SIZE,
+    DEFAULT_TFTP_MAX_CONCURRENT_TRANSFERS, DEFAULT_TFTP_MAX_SEND_RETRIES, DEFAULT_TFTP_MAX_WINDOW_SIZE,
+    DEFAULT_TFTP_READ_FETCH_BYTES,
+};
+use std::net::SocketAddr;
+use thiserror::Error;
+
+/// TFTP transfer direction policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TftpAccessMode {
+    ReadOnly,
+    WriteOnly,
+    ReadWrite,
+}
+
+impl TftpAccessMode {
+    pub fn parse(raw: &str) -> Result<Self, TftpInitError> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "ro" | "read-only" | "readonly" => Ok(Self::ReadOnly),
+            "wo" | "write-only" | "writeonly" => Ok(Self::WriteOnly),
+            "rw" | "readwrite" | "read-write" => Ok(Self::ReadWrite),
+            other => Err(TftpInitError::InvalidConfig(format!(
+                "invalid RUSTFS_TFTP_ACCESS_MODE '{other}': expected ro, wo, or rw"
+            ))),
+        }
+    }
+
+    pub fn allows_read(self) -> bool {
+        matches!(self, Self::ReadOnly | Self::ReadWrite)
+    }
+
+    pub fn allows_write(self) -> bool {
+        matches!(self, Self::WriteOnly | Self::ReadWrite)
+    }
+}
+
+/// Runtime configuration for the TFTP server.
+#[derive(Debug, Clone)]
+pub struct TftpConfig {
+    pub bind_addr: SocketAddr,
+    pub default_bucket: Option<String>,
+    pub access_mode: TftpAccessMode,
+    pub max_block_size: u16,
+    pub max_window_size: u16,
+    pub max_concurrent_transfers: usize,
+    pub backend_op_timeout_secs: u64,
+    pub read_fetch_bytes: u64,
+    pub max_send_retries: u32,
+}
+
+/// Errors during TFTP initialization.
+#[derive(Debug, Error)]
+pub enum TftpInitError {
+    #[error("invalid TFTP configuration: {0}")]
+    InvalidConfig(String),
+
+    #[error("TFTP credentials rejected: {0}")]
+    CredentialsRejected(String),
+}
+
+impl TftpConfig {
+    pub fn resolve_max_block_size(raw: Option<u16>) -> u16 {
+        raw.filter(|&v| (MAX_BLOCK_SIZE_MIN..=MAX_BLOCK_SIZE_MAX).contains(&v))
+            .unwrap_or(DEFAULT_TFTP_MAX_BLOCK_SIZE)
+    }
+
+    pub fn resolve_max_window_size(raw: Option<u16>) -> u16 {
+        raw.filter(|&v| (MAX_WINDOW_SIZE_MIN..=MAX_WINDOW_SIZE_MAX).contains(&v))
+            .unwrap_or(DEFAULT_TFTP_MAX_WINDOW_SIZE)
+    }
+
+    pub fn resolve_max_concurrent_transfers(raw: Option<usize>) -> usize {
+        raw.filter(|&v| (MAX_CONCURRENT_TRANSFERS_MIN..=MAX_CONCURRENT_TRANSFERS_MAX).contains(&v))
+            .unwrap_or(DEFAULT_TFTP_MAX_CONCURRENT_TRANSFERS)
+    }
+
+    pub fn resolve_backend_op_timeout_secs(raw: Option<u64>) -> u64 {
+        raw.filter(|&v| (BACKEND_OP_TIMEOUT_MIN_SECS..=BACKEND_OP_TIMEOUT_MAX_SECS).contains(&v))
+            .unwrap_or(DEFAULT_TFTP_BACKEND_OP_TIMEOUT_SECS)
+    }
+
+    pub fn resolve_read_fetch_bytes(raw: Option<u64>) -> u64 {
+        raw.filter(|&v| (READ_FETCH_BYTES_MIN..=READ_FETCH_BYTES_MAX).contains(&v))
+            .unwrap_or(DEFAULT_TFTP_READ_FETCH_BYTES)
+    }
+
+    pub fn resolve_max_send_retries(raw: Option<u32>) -> u32 {
+        raw.filter(|&v| (MAX_SEND_RETRIES_MIN..=MAX_SEND_RETRIES_MAX).contains(&v))
+            .unwrap_or(DEFAULT_TFTP_MAX_SEND_RETRIES)
+    }
+
+    pub fn resolve_access_mode(raw: Option<&str>) -> Result<TftpAccessMode, TftpInitError> {
+        TftpAccessMode::parse(raw.unwrap_or(DEFAULT_TFTP_ACCESS_MODE))
+    }
+}

--- a/crates/protocols/src/tftp/constants.rs
+++ b/crates/protocols/src/tftp/constants.rs
@@ -1,0 +1,51 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! TFTP operational limits.
+
+/// Lower bound for `RUSTFS_TFTP_MAX_BLOCK_SIZE`.
+pub const MAX_BLOCK_SIZE_MIN: u16 = 512;
+
+/// Upper bound for `RUSTFS_TFTP_MAX_BLOCK_SIZE` (RFC 2348).
+pub const MAX_BLOCK_SIZE_MAX: u16 = 65464;
+
+/// Lower bound for `RUSTFS_TFTP_MAX_WINDOW_SIZE` (RFC 7440).
+pub const MAX_WINDOW_SIZE_MIN: u16 = 1;
+
+/// Upper bound for `RUSTFS_TFTP_MAX_WINDOW_SIZE`.
+pub const MAX_WINDOW_SIZE_MAX: u16 = 65535;
+
+/// Lower bound for `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS`.
+pub const MAX_CONCURRENT_TRANSFERS_MIN: usize = 1;
+
+/// Upper bound for `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS`.
+pub const MAX_CONCURRENT_TRANSFERS_MAX: usize = 4096;
+
+/// Lower bound for `RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS`.
+pub const BACKEND_OP_TIMEOUT_MIN_SECS: u64 = 5;
+
+/// Upper bound for `RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS`.
+pub const BACKEND_OP_TIMEOUT_MAX_SECS: u64 = 600;
+
+/// Lower bound for `RUSTFS_TFTP_READ_FETCH_BYTES`.
+pub const READ_FETCH_BYTES_MIN: u64 = 512;
+
+/// Upper bound for `RUSTFS_TFTP_READ_FETCH_BYTES`.
+pub const READ_FETCH_BYTES_MAX: u64 = 64 * 1024 * 1024;
+
+/// Lower bound for `RUSTFS_TFTP_MAX_SEND_RETRIES`.
+pub const MAX_SEND_RETRIES_MIN: u32 = 1;
+
+/// Upper bound for `RUSTFS_TFTP_MAX_SEND_RETRIES`.
+pub const MAX_SEND_RETRIES_MAX: u32 = 100;

--- a/crates/protocols/src/tftp/errors.rs
+++ b/crates/protocols/src/tftp/errors.rs
@@ -1,0 +1,121 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Map backend and authorization failures to TFTP wire error codes.
+
+use async_tftp::packet::Error as TftpPacketError;
+use s3s::{S3Error, S3ErrorCode};
+use std::any::Any;
+use std::fmt::Display;
+use tracing::warn;
+
+const LOG_COMPONENT_PROTOCOLS: &str = "protocols";
+const LOG_SUBSYSTEM_TFTP_ERRORS: &str = "tftp_errors";
+const EVENT_TFTP_ERROR_MAPPING: &str = "tftp_error_mapping";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BackendErrorKind {
+    NotFound,
+    PermissionDenied,
+    Other,
+}
+
+fn classify_s3_code(code: &S3ErrorCode) -> BackendErrorKind {
+    match code {
+        S3ErrorCode::NoSuchKey | S3ErrorCode::NoSuchBucket => BackendErrorKind::NotFound,
+        S3ErrorCode::AccessDenied => BackendErrorKind::PermissionDenied,
+        _ => BackendErrorKind::Other,
+    }
+}
+
+#[cfg(test)]
+fn classify_dummy_error(err: &crate::common::dummy_storage::DummyError) -> BackendErrorKind {
+    match err {
+        crate::common::dummy_storage::DummyError::NoSuchKey(_) | crate::common::dummy_storage::DummyError::NoSuchBucket(_) => {
+            BackendErrorKind::NotFound
+        }
+        crate::common::dummy_storage::DummyError::AccessDenied(_) => BackendErrorKind::PermissionDenied,
+        crate::common::dummy_storage::DummyError::Injected(_) | crate::common::dummy_storage::DummyError::Unconfigured(_) => {
+            BackendErrorKind::Other
+        }
+        crate::common::dummy_storage::DummyError::NoSuchUpload(_) => BackendErrorKind::Other,
+    }
+}
+
+fn classify_backend_error<E: Display + 'static>(err: &E) -> BackendErrorKind {
+    let any = err as &dyn Any;
+    if let Some(err) = any.downcast_ref::<S3Error>() {
+        return classify_s3_code(err.code());
+    }
+
+    #[cfg(test)]
+    if let Some(err) = any.downcast_ref::<crate::common::dummy_storage::DummyError>() {
+        return classify_dummy_error(err);
+    }
+
+    BackendErrorKind::Other
+}
+
+pub fn backend_error_to_tftp<E: Display + 'static>(op: &str, err: E) -> TftpPacketError {
+    let msg = err.to_string();
+    let code = match classify_backend_error(&err) {
+        BackendErrorKind::NotFound => TftpPacketError::FileNotFound,
+        BackendErrorKind::PermissionDenied => TftpPacketError::PermissionDenied,
+        BackendErrorKind::Other => TftpPacketError::UnknownError,
+    };
+    warn!(
+        event = EVENT_TFTP_ERROR_MAPPING,
+        component = LOG_COMPONENT_PROTOCOLS,
+        subsystem = LOG_SUBSYSTEM_TFTP_ERRORS,
+        op = op,
+        err = %msg,
+        mapped = ?code,
+        "tftp error mapping"
+    );
+    code
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::dummy_storage::DummyError;
+
+    #[test]
+    fn no_such_key_maps_to_file_not_found() {
+        let err = backend_error_to_tftp("head_object", S3Error::with_message(S3ErrorCode::NoSuchKey, "missing"));
+        assert!(matches!(err, TftpPacketError::FileNotFound));
+    }
+
+    #[test]
+    fn access_denied_maps_to_permission_denied() {
+        let err = backend_error_to_tftp("head_object", S3Error::with_message(S3ErrorCode::AccessDenied, "denied"));
+        assert!(matches!(err, TftpPacketError::PermissionDenied));
+    }
+
+    #[test]
+    fn unknown_errors_map_to_unknown_error() {
+        struct E(&'static str);
+        impl std::fmt::Display for E {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(self.0)
+            }
+        }
+
+        let err = backend_error_to_tftp("get_object_range", E("something unexpected"));
+        assert!(matches!(err, TftpPacketError::UnknownError));
+
+        let err = backend_error_to_tftp("head_object", DummyError::Injected("backend exploded".into()));
+        assert!(matches!(err, TftpPacketError::UnknownError));
+    }
+}

--- a/crates/protocols/src/tftp/handler.rs
+++ b/crates/protocols/src/tftp/handler.rs
@@ -1,0 +1,272 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! TFTP `Handler` implementation backed by the RustFS storage API.
+
+use super::config::TftpConfig;
+use super::errors::backend_error_to_tftp;
+use super::paths::resolve_object_path;
+use super::reader::ObjectReader;
+use crate::common::client::s3::StorageBackend;
+use crate::common::gateway::{AuthorizationError, S3Action, authorize_operation};
+use crate::common::session::SessionContext;
+use async_tftp::packet::Error as TftpPacketError;
+use async_tftp::server::Handler;
+use futures_lite::io::Sink;
+use rustfs_credentials::Credentials;
+use std::net::SocketAddr;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::time::timeout;
+use tracing::warn;
+
+const LOG_COMPONENT_PROTOCOLS: &str = "protocols";
+const LOG_SUBSYSTEM_TFTP_HANDLER: &str = "tftp_handler";
+const EVENT_TFTP_HANDLER_STATE: &str = "tftp_handler_state";
+
+pub struct TftpStorageHandler<S: StorageBackend + Send + Sync + 'static> {
+    storage: Arc<S>,
+    config: TftpConfig,
+    credentials: Credentials,
+    session_context: SessionContext,
+    transfer_semaphore: Arc<Semaphore>,
+}
+
+impl<S: StorageBackend + Send + Sync + 'static> TftpStorageHandler<S> {
+    pub fn new(storage: S, config: TftpConfig, credentials: Credentials, session_context: SessionContext) -> Self {
+        let permits = config.max_concurrent_transfers;
+        Self {
+            storage: Arc::new(storage),
+            transfer_semaphore: Arc::new(Semaphore::new(permits)),
+            config,
+            credentials,
+            session_context,
+        }
+    }
+
+    fn backend_timeout(&self) -> Duration {
+        Duration::from_secs(self.config.backend_op_timeout_secs)
+    }
+
+    fn try_acquire_permit(&self) -> Result<OwnedSemaphorePermit, TftpPacketError> {
+        self.transfer_semaphore
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| TftpPacketError::DiskFull)
+    }
+
+    fn session_for_client(&self, client: &SocketAddr) -> SessionContext {
+        SessionContext::new(self.session_context.principal.clone(), self.session_context.protocol, client.ip())
+    }
+
+    async fn authorize(&self, client: &SocketAddr, action: &S3Action, bucket: &str, key: &str) -> Result<(), TftpPacketError> {
+        let session = self.session_for_client(client);
+        match authorize_operation(&session, action, bucket, Some(key)).await {
+            Ok(()) => Ok(()),
+            Err(AuthorizationError::AccessDenied) => Err(TftpPacketError::PermissionDenied),
+            Err(AuthorizationError::IamUnavailable) => {
+                warn!(
+                    event = EVENT_TFTP_HANDLER_STATE,
+                    component = LOG_COMPONENT_PROTOCOLS,
+                    subsystem = LOG_SUBSYSTEM_TFTP_HANDLER,
+                    action = action.as_str(),
+                    bucket = %bucket,
+                    key = %key,
+                    result = "iam_unavailable",
+                    "tftp handler state changed"
+                );
+                Err(TftpPacketError::UnknownError)
+            }
+        }
+    }
+}
+
+impl<S: StorageBackend + Send + Sync + 'static> Handler for TftpStorageHandler<S> {
+    type Reader = ObjectReader<S>;
+    type Writer = Sink;
+
+    async fn read_req_open(&mut self, client: &SocketAddr, path: &Path) -> Result<(Self::Reader, Option<u64>), TftpPacketError> {
+        if !self.config.access_mode.allows_read() {
+            return Err(TftpPacketError::PermissionDenied);
+        }
+
+        let permit = self.try_acquire_permit()?;
+        let (bucket, key) = resolve_object_path(path, self.config.default_bucket.as_deref())?;
+        self.authorize(client, &S3Action::GetObject, &bucket, &key).await?;
+
+        let head = timeout(self.backend_timeout(), self.storage.head_object(&bucket, &key, &self.credentials))
+            .await
+            .map_err(|_| TftpPacketError::UnknownError)?
+            .map_err(|e| backend_error_to_tftp("head_object", e))?;
+
+        let object_size = head.content_length.unwrap_or(0).max(0) as u64;
+        let reader = ObjectReader::new(
+            Arc::clone(&self.storage),
+            bucket,
+            key,
+            self.credentials.clone(),
+            object_size,
+            self.config.read_fetch_bytes,
+            self.backend_timeout(),
+            permit,
+        );
+
+        Ok((reader, Some(object_size)))
+    }
+
+    async fn write_req_open(
+        &mut self,
+        _client: &SocketAddr,
+        _path: &Path,
+        _size: Option<u64>,
+    ) -> Result<Self::Writer, TftpPacketError> {
+        if !self.config.access_mode.allows_write() {
+            return Err(TftpPacketError::PermissionDenied);
+        }
+        Err(TftpPacketError::IllegalOperation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::config::TftpAccessMode;
+    use super::super::test_support::{TEST_CLIENT, build_handler, test_config};
+    use crate::common::dummy_storage::DummyBackend;
+    use crate::common::gateway::with_test_auth_override;
+    use async_tftp::packet::Error as TftpPacketError;
+    use async_tftp::server::Handler;
+    use std::path::Path;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::Notify;
+
+    #[tokio::test]
+    async fn read_req_open_success_returns_size_and_reader() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_head_object_ok(128, None);
+
+        let mut handler = build_handler(backend, test_config(TftpAccessMode::ReadOnly, 4, 60, 1024));
+
+        let (reader, size) = with_test_auth_override(|_, _, _| true, handler.read_req_open(&TEST_CLIENT, Path::new("k")))
+            .await
+            .expect("read open must succeed");
+        assert_eq!(size, Some(128));
+        drop(reader);
+    }
+
+    #[tokio::test]
+    async fn read_req_open_wo_mode_returns_permission_denied() {
+        let backend = Arc::new(DummyBackend::new());
+        let mut handler = build_handler(backend, test_config(TftpAccessMode::WriteOnly, 4, 60, 1024));
+
+        let err = match handler.read_req_open(&TEST_CLIENT, Path::new("k")).await {
+            Err(err) => err,
+            Ok(_) => panic!("write-only mode must reject RRQ"),
+        };
+        assert!(matches!(err, TftpPacketError::PermissionDenied));
+    }
+
+    #[tokio::test]
+    async fn read_req_open_head_not_found_maps_file_not_found() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_head_object_not_found();
+
+        let mut handler = build_handler(backend, test_config(TftpAccessMode::ReadOnly, 4, 60, 1024));
+
+        let err = match with_test_auth_override(|_, _, _| true, handler.read_req_open(&TEST_CLIENT, Path::new("k"))).await
+        {
+            Err(err) => err,
+            Ok(_) => panic!("missing object must fail"),
+        };
+        assert!(matches!(err, TftpPacketError::FileNotFound));
+    }
+
+    #[tokio::test]
+    async fn read_req_open_auth_denied() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_head_object_ok(64, None);
+
+        let mut handler = build_handler(backend, test_config(TftpAccessMode::ReadOnly, 4, 60, 1024));
+
+        let err = match with_test_auth_override(|_, _, _| false, handler.read_req_open(&TEST_CLIENT, Path::new("k"))).await
+        {
+            Err(err) => err,
+            Ok(_) => panic!("denied auth must fail"),
+        };
+        assert!(matches!(err, TftpPacketError::PermissionDenied));
+    }
+
+    #[tokio::test]
+    async fn read_req_open_semaphore_full_returns_disk_full() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_head_object_ok(64, None);
+        backend.queue_head_object_ok(64, None);
+
+        let mut handler = build_handler(backend, test_config(TftpAccessMode::ReadOnly, 1, 60, 1024));
+
+        let first = with_test_auth_override(|_, _, _| true, handler.read_req_open(&TEST_CLIENT, Path::new("k")))
+            .await
+            .expect("first open must succeed");
+
+        let err = match with_test_auth_override(|_, _, _| true, handler.read_req_open(&TEST_CLIENT, Path::new("k2"))).await
+        {
+            Err(err) => err,
+            Ok(_) => panic!("second open must fail when semaphore is full"),
+        };
+        assert!(matches!(err, TftpPacketError::DiskFull));
+        drop(first);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn head_object_timeout_returns_unknown_error() {
+        let backend = Arc::new(DummyBackend::new());
+        let entered = Arc::new(Notify::new());
+        backend.stall_head_object(Arc::clone(&entered));
+
+        let mut handler = build_handler(backend, test_config(TftpAccessMode::ReadOnly, 4, 1, 1024));
+
+        let start = std::time::Instant::now();
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(10),
+            with_test_auth_override(|_, _, _| true, handler.read_req_open(&TEST_CLIENT, Path::new("k"))),
+        )
+        .await;
+        let elapsed = start.elapsed();
+
+        let err = match outcome.expect("head timeout must fire before outer guard") {
+            Err(err) => err,
+            Ok(_) => panic!("stalled head must fail"),
+        };
+        assert!(matches!(err, TftpPacketError::UnknownError));
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "head timeout must return quickly, elapsed: {:?}",
+            elapsed,
+        );
+    }
+
+    #[tokio::test]
+    async fn write_req_open_returns_illegal_operation() {
+        let backend = Arc::new(DummyBackend::new());
+        let mut handler = build_handler(backend, test_config(TftpAccessMode::ReadWrite, 4, 60, 1024));
+
+        let err = handler
+            .write_req_open(&TEST_CLIENT, Path::new("k"), None)
+            .await
+            .expect_err("WRQ must be rejected on RRQ branch");
+        assert!(matches!(err, TftpPacketError::IllegalOperation));
+    }
+}

--- a/crates/protocols/src/tftp/mod.rs
+++ b/crates/protocols/src/tftp/mod.rs
@@ -1,0 +1,43 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! TFTP protocol support for RustFS (RFC 1350 RRQ via `async-tftp`).
+//!
+//! RRQ maps to ranged S3 GETs with bounded memory. WRQ upload support
+//! lands in a follow-up change.
+
+mod config;
+mod constants;
+mod errors;
+mod handler;
+mod paths;
+mod reader;
+mod server;
+
+#[cfg(test)]
+mod test_support;
+
+pub use config::{TftpAccessMode, TftpConfig, TftpInitError};
+pub use handler::TftpStorageHandler;
+pub use server::TftpServer;
+
+#[cfg(test)]
+mod tests {
+    use crate::common::session::Protocol;
+
+    #[test]
+    fn protocol_variant_is_named() {
+        let _ = Protocol::Tftp;
+    }
+}

--- a/crates/protocols/src/tftp/paths.rs
+++ b/crates/protocols/src/tftp/paths.rs
@@ -1,0 +1,106 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! TFTP filename to S3 bucket/key resolution with unified validation.
+
+use async_tftp::packet::Error as TftpPacketError;
+use rustfs_utils::path;
+use std::path::Path;
+
+/// Resolve a TFTP filename into `(bucket, object_key)`.
+///
+/// When `default_bucket` is set, the filename becomes the object key under
+/// that bucket. Otherwise the path is parsed as `/<bucket>/<key>`.
+/// Both modes run the same key validation before returning.
+pub fn resolve_object_path(filename: &Path, default_bucket: Option<&str>) -> Result<(String, String), TftpPacketError> {
+    let raw = filename.to_string_lossy();
+    let trimmed = raw.trim_start_matches('/');
+
+    if trimmed.is_empty() {
+        return Err(TftpPacketError::FileNotFound);
+    }
+
+    let (bucket, key) = match default_bucket {
+        Some(bucket) => (bucket.to_string(), trimmed.to_string()),
+        None => {
+            let cleaned = path::clean(&format!("/{trimmed}"));
+            if cleaned == "." || cleaned == ".." || cleaned.starts_with("../") {
+                return Err(TftpPacketError::FileNotFound);
+            }
+            let (bucket, object) = path::path_to_bucket_object(&cleaned);
+            if bucket.is_empty() || object.is_empty() {
+                return Err(TftpPacketError::FileNotFound);
+            }
+            (bucket, object)
+        }
+    };
+
+    validate_object_key(&key)?;
+    Ok((bucket, key))
+}
+
+/// Shared validation for object keys in both bucket-resolution modes.
+fn validate_object_key(key: &str) -> Result<(), TftpPacketError> {
+    if key.contains(['\0', '\r', '\n']) {
+        return Err(TftpPacketError::IllegalOperation);
+    }
+    if key.contains(path::GLOBAL_DIR_SUFFIX) {
+        return Err(TftpPacketError::IllegalOperation);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn default_bucket_uses_filename_as_key() {
+        let (bucket, key) = resolve_object_path(Path::new("pxelinux.0"), Some("pxe")).expect("resolve");
+        assert_eq!(bucket, "pxe");
+        assert_eq!(key, "pxelinux.0");
+    }
+
+    #[test]
+    fn default_bucket_rejects_control_chars() {
+        let err = resolve_object_path(Path::new("bad\0name"), Some("pxe")).expect_err("NUL rejected");
+        assert!(matches!(err, TftpPacketError::IllegalOperation));
+    }
+
+    #[test]
+    fn default_bucket_rejects_xldir_marker() {
+        let err = resolve_object_path(Path::new("foo__XLDIR__"), Some("pxe")).expect_err("marker rejected");
+        assert!(matches!(err, TftpPacketError::IllegalOperation));
+    }
+
+    #[test]
+    fn bucket_key_mode_parses_path() {
+        let (bucket, key) = resolve_object_path(Path::new("/mybucket/boot/vmlinuz"), None).expect("resolve");
+        assert_eq!(bucket, "mybucket");
+        assert_eq!(key, "boot/vmlinuz");
+    }
+
+    #[test]
+    fn bucket_key_mode_rejects_traversal() {
+        let err = resolve_object_path(Path::new("/../secret"), None).expect_err("traversal rejected");
+        assert!(matches!(err, TftpPacketError::FileNotFound));
+    }
+
+    #[test]
+    fn empty_filename_rejected() {
+        let err = resolve_object_path(Path::new(""), Some("pxe")).expect_err("empty rejected");
+        assert!(matches!(err, TftpPacketError::FileNotFound));
+    }
+}

--- a/crates/protocols/src/tftp/reader.rs
+++ b/crates/protocols/src/tftp/reader.rs
@@ -1,0 +1,299 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Streaming `AsyncRead` over ranged S3 GETs with bounded memory.
+
+use crate::common::client::s3::StorageBackend;
+use futures_lite::{AsyncRead, io::Result as AsyncIoResult};
+use futures_util::StreamExt;
+use rustfs_credentials::Credentials;
+use std::io::{Error, ErrorKind};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use tokio::sync::OwnedSemaphorePermit;
+use tokio::time::timeout;
+use tracing::warn;
+
+const LOG_COMPONENT_PROTOCOLS: &str = "protocols";
+const LOG_SUBSYSTEM_TFTP_READER: &str = "tftp_reader";
+const EVENT_TFTP_READ_STATE: &str = "tftp_read_state";
+
+type FetchFuture = Pin<Box<dyn std::future::Future<Output = std::io::Result<Vec<u8>>> + Send>>;
+
+/// Bounded-memory reader for TFTP RRQ transfers.
+pub struct ObjectReader<S: StorageBackend + Send + Sync + 'static> {
+    storage: Arc<S>,
+    bucket: String,
+    key: String,
+    credentials: Credentials,
+    object_size: u64,
+    offset: u64,
+    fetch_bytes: u64,
+    backend_timeout: Duration,
+    buffer: Vec<u8>,
+    buffer_pos: usize,
+    fetch_future: Option<FetchFuture>,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl<S: StorageBackend + Send + Sync + 'static> ObjectReader<S> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        storage: Arc<S>,
+        bucket: String,
+        key: String,
+        credentials: Credentials,
+        object_size: u64,
+        fetch_bytes: u64,
+        backend_timeout: Duration,
+        permit: OwnedSemaphorePermit,
+    ) -> Self {
+        Self {
+            storage,
+            bucket,
+            key,
+            credentials,
+            object_size,
+            offset: 0,
+            fetch_bytes,
+            backend_timeout,
+            buffer: Vec::new(),
+            buffer_pos: 0,
+            fetch_future: None,
+            _permit: permit,
+        }
+    }
+
+    fn start_fetch(&mut self) {
+        if self.offset >= self.object_size {
+            return;
+        }
+        let remaining = self.object_size - self.offset;
+        let fetch_len = remaining.min(self.fetch_bytes);
+        let storage = Arc::clone(&self.storage);
+        let bucket = self.bucket.clone();
+        let key = self.key.clone();
+        let credentials = self.credentials.clone();
+        let offset = self.offset;
+        let backend_timeout = self.backend_timeout;
+
+        self.fetch_future = Some(Box::pin(async move {
+            let fut = storage.get_object_range(&bucket, &key, &credentials, offset, fetch_len);
+            let out = timeout(backend_timeout, fut)
+                .await
+                .map_err(|_| Error::new(ErrorKind::TimedOut, "get_object_range timed out"))?
+                .map_err(Error::other)?;
+
+            let Some(mut body) = out.body else {
+                return Ok(Vec::new());
+            };
+
+            let mut buf = Vec::with_capacity(usize::try_from(fetch_len).unwrap_or(0));
+            loop {
+                let chunk = timeout(backend_timeout, body.next())
+                    .await
+                    .map_err(|_| Error::new(ErrorKind::TimedOut, "get_object stream timed out"))?
+                    .transpose()
+                    .map_err(Error::other)?;
+                let Some(chunk) = chunk else { break };
+                buf.extend_from_slice(&chunk);
+            }
+            Ok(buf)
+        }));
+    }
+}
+
+impl<S: StorageBackend + Send + Sync + 'static> AsyncRead for ObjectReader<S> {
+    fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<AsyncIoResult<usize>> {
+        if self.offset >= self.object_size {
+            return Poll::Ready(Ok(0));
+        }
+
+        if self.buffer_pos >= self.buffer.len() {
+            if self.fetch_future.is_none() {
+                self.start_fetch();
+            }
+
+            if let Some(mut fut) = self.fetch_future.take() {
+                match fut.as_mut().poll(cx) {
+                    Poll::Ready(Ok(data)) => {
+                        self.buffer = data;
+                        self.buffer_pos = 0;
+                        if self.buffer.is_empty() && self.offset < self.object_size {
+                            warn!(
+                                event = EVENT_TFTP_READ_STATE,
+                                component = LOG_COMPONENT_PROTOCOLS,
+                                subsystem = LOG_SUBSYSTEM_TFTP_READER,
+                                bucket = %self.bucket,
+                                key = %self.key,
+                                offset = self.offset,
+                                result = "unexpected_eof",
+                                "tftp read state changed"
+                            );
+                            return Poll::Ready(Err(ErrorKind::UnexpectedEof.into()));
+                        }
+                    }
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                    Poll::Pending => {
+                        self.fetch_future = Some(fut);
+                        return Poll::Pending;
+                    }
+                }
+            }
+        }
+
+        let available = self.buffer.len().saturating_sub(self.buffer_pos);
+        if available == 0 {
+            return Poll::Ready(Ok(0));
+        }
+
+        let to_copy = available.min(buf.len());
+        buf[..to_copy].copy_from_slice(&self.buffer[self.buffer_pos..self.buffer_pos + to_copy]);
+        self.buffer_pos += to_copy;
+        self.offset += to_copy as u64;
+        Poll::Ready(Ok(to_copy))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{build_reader, capture_tracing_at, read_chunk, read_to_end, test_permit};
+    use crate::common::dummy_storage::{DummyBackend, DummyError};
+    use futures_lite::AsyncReadExt;
+    use std::io::ErrorKind;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+    use tracing::Level;
+
+    #[tokio::test]
+    async fn read_returns_full_object() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_get_object_range_bytes(b"hello".to_vec());
+        let mut reader = build_reader(Arc::clone(&backend), 5, 1024, 60, test_permit());
+        let data = read_to_end(&mut reader).await.expect("read must succeed");
+        assert_eq!(data, b"hello");
+    }
+
+    #[tokio::test]
+    async fn read_at_eof_returns_zero_without_extra_backend_call() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_get_object_range_bytes(b"hello".to_vec());
+        let mut reader = build_reader(Arc::clone(&backend), 5, 1024, 60, test_permit());
+        let data = read_to_end(&mut reader).await.expect("first read must succeed");
+        assert_eq!(data, b"hello");
+
+        let mut tail = vec![0_u8; 8];
+        let n = reader.read(&mut tail).await.expect("eof read must succeed");
+        assert_eq!(n, 0);
+    }
+
+    #[tokio::test]
+    async fn read_crosses_fetch_window_triggers_second_backend_call() {
+        let fetch_bytes: u64 = 64;
+        let object_size: u64 = fetch_bytes * 2;
+        let first_window = vec![0xAA_u8; fetch_bytes as usize];
+        let second_window = vec![0xBB_u8; fetch_bytes as usize];
+
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_get_object_range_bytes(first_window);
+        backend.queue_get_object_range_bytes(second_window.clone());
+
+        let mut reader = build_reader(Arc::clone(&backend), object_size, fetch_bytes, 60, test_permit());
+        let data = read_to_end(&mut reader).await.expect("read across windows must succeed");
+        assert_eq!(data.len(), object_size as usize);
+        assert!(data[..fetch_bytes as usize].iter().all(|b| *b == 0xAA));
+        assert!(data[fetch_bytes as usize..].iter().all(|b| *b == 0xBB));
+    }
+
+    #[tokio::test]
+    async fn unexpected_empty_range_returns_unexpected_eof() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_get_object_range_bytes(Vec::new());
+
+        let mut reader = build_reader(backend, 16, 1024, 60, test_permit());
+        let (result, captured) = capture_tracing_at(Level::WARN, read_to_end(&mut reader)).await;
+        let err = result.expect_err("empty range before eof must fail");
+        assert_eq!(err.kind(), ErrorKind::UnexpectedEof);
+        assert!(
+            captured.contains("unexpected_eof"),
+            "empty range must emit unexpected_eof warn, captured: {captured}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_object_range_backend_error_propagates() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_get_object_range_err(DummyError::Injected("backend exploded".into()));
+
+        let mut reader = build_reader(backend, 16, 1024, 60, test_permit());
+        let err = read_to_end(&mut reader).await.expect_err("backend error must propagate");
+        assert_ne!(err.kind(), ErrorKind::UnexpectedEof);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn chunk_stall_times_out_within_deadline() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_get_object_range_stalling_after_chunk(b"prefix".to_vec(), 4096);
+
+        let timeout_secs: u64 = 1;
+        let mut reader = build_reader(Arc::clone(&backend), 4096, 4096, timeout_secs, test_permit());
+
+        let start = Instant::now();
+        let outcome = tokio::time::timeout(Duration::from_secs(10), read_to_end(&mut reader)).await;
+        let elapsed = start.elapsed();
+
+        let inner = outcome.expect("per-chunk deadline must fire before the outer guard");
+        let err = inner.expect_err("stalled body must surface as Err");
+        assert_eq!(err.kind(), ErrorKind::TimedOut);
+        assert!(
+            elapsed < Duration::from_secs(timeout_secs + 4),
+            "stalled body must time out within {} s, elapsed: {:?}",
+            timeout_secs + 4,
+            elapsed,
+        );
+    }
+
+    #[tokio::test]
+    async fn sequential_small_poll_reads_reuse_one_fetch() {
+        let fetch_bytes: u64 = 1024;
+        let payload: Vec<u8> = (0..fetch_bytes).map(|i| i as u8).collect();
+
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_get_object_range_bytes(payload.clone());
+
+        let mut reader = build_reader(Arc::clone(&backend), fetch_bytes, fetch_bytes, 60, test_permit());
+        let mut assembled = Vec::with_capacity(fetch_bytes as usize);
+        for _ in 0..4 {
+            let chunk = read_chunk(&mut reader, 256).await.expect("chunk read must succeed");
+            assert!(!chunk.is_empty(), "chunk must carry bytes");
+            assembled.extend_from_slice(&chunk);
+        }
+        assert_eq!(assembled, payload);
+    }
+
+    #[tokio::test]
+    async fn fetch_len_clamped_to_remaining_bytes() {
+        let object_size: u64 = 100;
+        let payload = vec![0x42_u8; object_size as usize];
+
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_get_object_range_bytes(payload.clone());
+
+        let mut reader = build_reader(Arc::clone(&backend), object_size, 4 * 1024 * 1024, 60, test_permit());
+        let data = read_to_end(&mut reader).await.expect("single fetch must satisfy the object");
+        assert_eq!(data, payload);
+    }
+}

--- a/crates/protocols/src/tftp/server.rs
+++ b/crates/protocols/src/tftp/server.rs
@@ -1,0 +1,110 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! TFTP UDP server lifecycle.
+
+use super::config::{TftpConfig, TftpInitError};
+use super::handler::TftpStorageHandler;
+use crate::common::client::s3::StorageBackend;
+use async_tftp::server::TftpServerBuilder;
+use std::fmt::Debug;
+use std::time::Duration;
+use tokio::sync::broadcast;
+use tracing::{debug, error, info};
+
+const LOG_COMPONENT_PROTOCOLS: &str = "protocols";
+const LOG_SUBSYSTEM_TFTP_SERVER: &str = "tftp_server";
+const EVENT_TFTP_SERVER_STATE: &str = "tftp_server_state";
+
+/// TFTP server entry point.
+pub struct TftpServer<S>
+where
+    S: StorageBackend + Send + Sync + 'static + Debug,
+{
+    config: TftpConfig,
+    handler: TftpStorageHandler<S>,
+}
+
+impl<S> TftpServer<S>
+where
+    S: StorageBackend + Send + Sync + 'static + Debug,
+{
+    pub fn new(config: TftpConfig, handler: TftpStorageHandler<S>) -> Self {
+        Self { config, handler }
+    }
+
+    pub async fn start(self, mut shutdown_rx: broadcast::Receiver<()>) -> Result<(), TftpInitError> {
+        let bind_addr = self.config.bind_addr;
+        let max_block_size = self.config.max_block_size;
+        let max_window_size = self.config.max_window_size;
+        let max_send_retries = self.config.max_send_retries;
+
+        let tftpd = TftpServerBuilder::with_handler(self.handler)
+            .bind(bind_addr)
+            .block_size_limit(max_block_size)
+            .window_size_limit(max_window_size)
+            .timeout(Duration::from_secs(3))
+            .max_send_retries(max_send_retries)
+            .build()
+            .await
+            .map_err(|e| TftpInitError::InvalidConfig(format!("TFTP server build failed: {e}")))?;
+
+        info!(
+            event = EVENT_TFTP_SERVER_STATE,
+            component = LOG_COMPONENT_PROTOCOLS,
+            subsystem = LOG_SUBSYSTEM_TFTP_SERVER,
+            state = "listening",
+            bind_addr = %bind_addr,
+            "tftp server state changed"
+        );
+
+        tokio::select! {
+            result = tftpd.serve() => {
+                match result {
+                    Ok(()) => {
+                        debug!(
+                            event = EVENT_TFTP_SERVER_STATE,
+                            component = LOG_COMPONENT_PROTOCOLS,
+                            subsystem = LOG_SUBSYSTEM_TFTP_SERVER,
+                            state = "stopped",
+                            "tftp server state changed"
+                        );
+                        Ok(())
+                    }
+                    Err(e) => {
+                        error!(
+                            event = EVENT_TFTP_SERVER_STATE,
+                            component = LOG_COMPONENT_PROTOCOLS,
+                            subsystem = LOG_SUBSYSTEM_TFTP_SERVER,
+                            state = "runtime_failed",
+                            error = %e,
+                            "tftp server state changed"
+                        );
+                        Err(TftpInitError::InvalidConfig(format!("TFTP serve failed: {e}")))
+                    }
+                }
+            }
+            _ = shutdown_rx.recv() => {
+                debug!(
+                    event = EVENT_TFTP_SERVER_STATE,
+                    component = LOG_COMPONENT_PROTOCOLS,
+                    subsystem = LOG_SUBSYSTEM_TFTP_SERVER,
+                    state = "shutdown_signal",
+                    "tftp server state changed"
+                );
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/protocols/src/tftp/test_support.rs
+++ b/crates/protocols/src/tftp/test_support.rs
@@ -1,0 +1,141 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared #[cfg(test)] helpers for TFTP unit tests.
+
+#![allow(dead_code)]
+
+use super::config::{TftpAccessMode, TftpConfig};
+use super::handler::TftpStorageHandler;
+use super::reader::ObjectReader;
+use crate::common::dummy_storage::DummyBackend;
+use crate::common::session::{Protocol, test_session};
+use rustfs_config::{
+    DEFAULT_TFTP_MAX_BLOCK_SIZE, DEFAULT_TFTP_MAX_SEND_RETRIES,
+    DEFAULT_TFTP_MAX_WINDOW_SIZE,
+};
+use rustfs_credentials::Credentials;
+use std::io::Write;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::{Arc, Mutex};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tracing::Level;
+use tracing_subscriber::fmt::MakeWriter;
+
+pub(super) const TEST_CLIENT: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 4242);
+
+pub(super) fn test_config(
+    access_mode: TftpAccessMode,
+    max_concurrent_transfers: usize,
+    backend_op_timeout_secs: u64,
+    read_fetch_bytes: u64,
+) -> TftpConfig {
+    TftpConfig {
+        bind_addr: "127.0.0.1:6969".parse().expect("loopback parses"),
+        default_bucket: Some(String::from("b")),
+        access_mode,
+        max_block_size: DEFAULT_TFTP_MAX_BLOCK_SIZE,
+        max_window_size: DEFAULT_TFTP_MAX_WINDOW_SIZE,
+        max_concurrent_transfers,
+        backend_op_timeout_secs,
+        read_fetch_bytes,
+        max_send_retries: DEFAULT_TFTP_MAX_SEND_RETRIES,
+    }
+}
+
+pub(super) fn build_handler(backend: Arc<DummyBackend>, config: TftpConfig) -> TftpStorageHandler<DummyBackend> {
+    let session = test_session(Protocol::Tftp);
+    TftpStorageHandler::new(backend.as_ref().clone(), config, Credentials::default(), session)
+}
+
+pub(super) fn test_permit() -> OwnedSemaphorePermit {
+    Arc::new(Semaphore::new(1))
+        .try_acquire_owned()
+        .expect("test permit available")
+}
+
+pub(super) fn build_reader(
+    backend: Arc<DummyBackend>,
+    object_size: u64,
+    fetch_bytes: u64,
+    backend_timeout_secs: u64,
+    permit: OwnedSemaphorePermit,
+) -> ObjectReader<DummyBackend> {
+    ObjectReader::new(
+        backend,
+        String::from("b"),
+        String::from("k"),
+        Credentials::default(),
+        object_size,
+        fetch_bytes,
+        std::time::Duration::from_secs(backend_timeout_secs),
+        permit,
+    )
+}
+
+pub(super) async fn read_to_end(reader: &mut ObjectReader<DummyBackend>) -> std::io::Result<Vec<u8>> {
+    use futures_lite::AsyncReadExt;
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf).await?;
+    Ok(buf)
+}
+
+pub(super) async fn read_chunk(reader: &mut ObjectReader<DummyBackend>, len: usize) -> std::io::Result<Vec<u8>> {
+    use futures_lite::AsyncReadExt;
+    let mut buf = vec![0_u8; len];
+    let n = reader.read(&mut buf).await?;
+    buf.truncate(n);
+    Ok(buf)
+}
+
+#[derive(Clone)]
+pub(super) struct CapturingWriter(Arc<Mutex<Vec<u8>>>);
+
+impl Write for CapturingWriter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("lock").extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for CapturingWriter {
+    type Writer = CapturingWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+pub(super) async fn capture_tracing_at<F, T>(min_level: Level, fut: F) -> (T, String)
+where
+    F: std::future::Future<Output = T>,
+{
+    let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let writer = CapturingWriter(Arc::clone(&buf));
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(min_level)
+        .with_writer(writer)
+        .with_ansi(false)
+        .with_target(true)
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    let value = fut.await;
+    let captured = String::from_utf8(buf.lock().expect("lock").clone()).expect("utf8");
+    (value, captured)
+}

--- a/docs/operations/tftp.md
+++ b/docs/operations/tftp.md
@@ -1,0 +1,75 @@
+# TFTP (Trivial File Transfer Protocol)
+
+RustFS exposes an optional UDP TFTP sidecar for PXE boot file serving and
+similar read-mostly workflows. The implementation uses the [`async-tftp`](https://crates.io/crates/async-tftp)
+crate and maps RRQ transfers to the S3 storage API.
+
+## Enable
+
+Build with the `tftp` feature and set environment variables at runtime:
+
+```bash
+cargo build --release --bin rustfs --features tftp
+
+export RUSTFS_TFTP_ENABLE=true
+export RUSTFS_TFTP_ADDRESS=0.0.0.0:6969
+export RUSTFS_TFTP_ACCESS_KEY=<service-account-access-key>
+export RUSTFS_TFTP_SECRET_KEY=<service-account-secret-key>
+export RUSTFS_TFTP_DEFAULT_BUCKET=pxe-boot
+export RUSTFS_TFTP_ACCESS_MODE=ro   # ro | wo | rw (WRQ not yet supported)
+```
+
+## Path mapping
+
+| `RUSTFS_TFTP_DEFAULT_BUCKET` | Client RRQ filename | Resolved object |
+| --- | --- | --- |
+| `pxe-boot` | `pxelinux.0` | bucket `pxe-boot`, key `pxelinux.0` |
+| unset | `/mybucket/boot/vmlinuz` | bucket `mybucket`, key `boot/vmlinuz` |
+
+Both modes apply the same key validation (control characters and internal
+`__XLDIR__` markers are rejected).
+
+## Security
+
+TFTP has **no wire authentication**. Restrict access at the network layer
+(PXE VLAN only) and use a dedicated IAM identity with least privilege.
+Temporary STS credentials are rejected at startup.
+
+## Transfer semantics
+
+- **RRQ**: streamed ranged `GetObject` reads with bounded memory.
+- **WRQ**: not supported in this release; clients receive TFTP
+  `Illegal operation`.
+- Concurrent transfers are capped by `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS`.
+- RRQ block size and window size are negotiated with the client; RustFS caps
+  them via `RUSTFS_TFTP_MAX_BLOCK_SIZE` and `RUSTFS_TFTP_MAX_WINDOW_SIZE`.
+
+## Environment reference
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTFS_TFTP_ENABLE` | `false` | Master switch |
+| `RUSTFS_TFTP_ADDRESS` | `0.0.0.0:6969` | UDP bind address |
+| `RUSTFS_TFTP_ACCESS_KEY` | (required) | IAM access key for authorization |
+| `RUSTFS_TFTP_SECRET_KEY` | (required) | Secret for the access key |
+| `RUSTFS_TFTP_DEFAULT_BUCKET` | unset | Lock all requests to one bucket |
+| `RUSTFS_TFTP_ACCESS_MODE` | `ro` | `ro`, `wo`, or `rw` (WRQ pending follow-up) |
+| `RUSTFS_TFTP_MAX_BLOCK_SIZE` | `65464` | RFC 2348 block size ceiling |
+| `RUSTFS_TFTP_MAX_WINDOW_SIZE` | `65535` | RFC 7440 window size ceiling |
+| `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS` | `64` | Concurrent RRQ limit |
+| `RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS` | `60` | S3 call timeout |
+| `RUSTFS_TFTP_READ_FETCH_BYTES` | `4194304` | RRQ read-ahead window (4 MiB) |
+
+Port **69** requires `CAP_NET_BIND_SERVICE` or root on Linux; the default
+uses **6969** so the sidecar can start without extra capabilities.
+
+## Known limitations (stock `async-tftp` 0.4.2)
+
+These are wire-protocol behaviors in `async-tftp`, not RustFS S3 mapping bugs.
+Until upstream fixes are released or the crate is vendored with patches, use:
+
+| Limitation | Practical workaround |
+| --- | --- |
+| `windowsize > 1` can fail with client `got wrong block` after lossy/late ACK | Use `--option "windowsize 1"`; raise `blksize` (up to 65464) for speed |
+| Client TFTP ERROR after OACK may leave the server waiting for ACK#0 | Do not reject OACK; keep `blksize` in `8..=65464` and aligned with `RUSTFS_TFTP_MAX_BLOCK_SIZE` |
+| Out-of-range `blksize` may be silently ignored at parse time | Send only RFC-valid block sizes |

--- a/rustfs/Cargo.toml
+++ b/rustfs/Cargo.toml
@@ -64,10 +64,11 @@ ftps = ["rustfs-protocols/ftps"]
 swift = ["rustfs-protocols/swift"]
 webdav = ["rustfs-protocols/webdav"]
 sftp = ["rustfs-protocols/sftp"]
+tftp = ["rustfs-protocols/tftp"]
 license = []
 io-scheduler-debug = []  # Enable debug information in I/O scheduler
 tracing-chunk-debug = []  # Enable per-chunk tracing in data plane (high noise, for debugging only)
-full = ["metrics-gpu", "ftps", "swift", "webdav", "sftp", "pyroscope", "gcs"]
+full = ["metrics-gpu", "ftps", "swift", "webdav", "sftp", "tftp", "pyroscope", "gcs"]
 e2e-test-hooks = ["rustfs-ecstore/e2e-test-hooks"]
 # Shortens Connect credentials only in debug E2E builds.
 connect-e2e-short-credentials = []

--- a/rustfs/src/config/info.rs
+++ b/rustfs/src/config/info.rs
@@ -636,6 +636,13 @@ fn feature_specs() -> &'static [FeatureSpec] {
             default_enabled: false,
         },
         FeatureSpec {
+            name: "tftp",
+            enabled: cfg!(feature = "tftp"),
+            description: "TFTP protocol support (PXE boot file serving)",
+            dependencies: "rustfs-protocols/tftp",
+            default_enabled: false,
+        },
+        FeatureSpec {
             name: "license",
             enabled: cfg!(feature = "license"),
             description: "License validation",
@@ -660,7 +667,7 @@ fn feature_specs() -> &'static [FeatureSpec] {
             name: "full",
             enabled: cfg!(feature = "full"),
             description: "Full protocol and observability bundle",
-            dependencies: "metrics-gpu + ftps + swift + webdav + sftp + pyroscope",
+            dependencies: "metrics-gpu + ftps + swift + webdav + sftp + tftp + pyroscope",
             default_enabled: false,
         },
         FeatureSpec {

--- a/rustfs/src/init.rs
+++ b/rustfs/src/init.rs
@@ -1372,6 +1372,155 @@ pub async fn init_sftp_system() -> Result<Option<ShutdownHandle>, Box<dyn std::e
     }
 }
 
+/// Start the TFTP server when `RUSTFS_TFTP_ENABLE` is set.
+#[cfg(feature = "tftp")]
+#[instrument(skip_all)]
+pub async fn init_tftp_system() -> Result<Option<ShutdownHandle>, Box<dyn std::error::Error + Send + Sync>> {
+    use crate::protocols::ProtocolStorageClient;
+    use rustfs_config::{
+        DEFAULT_TFTP_ADDRESS, ENV_TFTP_ACCESS_KEY, ENV_TFTP_ACCESS_MODE, ENV_TFTP_ADDRESS, ENV_TFTP_BACKEND_OP_TIMEOUT_SECS,
+        ENV_TFTP_DEFAULT_BUCKET, ENV_TFTP_ENABLE, ENV_TFTP_MAX_BLOCK_SIZE, ENV_TFTP_MAX_CONCURRENT_TRANSFERS,
+        ENV_TFTP_MAX_SEND_RETRIES, ENV_TFTP_MAX_WINDOW_SIZE, ENV_TFTP_READ_FETCH_BYTES, ENV_TFTP_SECRET_KEY,
+    };
+    use rustfs_protocols::common::session::{Protocol, ProtocolPrincipal, SessionContext, is_temporary_credential};
+    use rustfs_protocols::{TftpConfig, TftpServer, TftpStorageHandler};
+    use rustfs_utils::MaskedAccessKey;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::Arc;
+    use subtle::ConstantTimeEq;
+
+    let enabled = rustfs_utils::get_env_bool(ENV_TFTP_ENABLE, false);
+    if !enabled {
+        debug!(
+            target: "rustfs::init",
+            event = EVENT_PROTOCOL_RUNTIME_STATE,
+            component = LOG_COMPONENT_INIT,
+            subsystem = LOG_SUBSYSTEM_PROTOCOL,
+            protocol = "tftp",
+            state = "disabled",
+            "Protocol runtime disabled"
+        );
+        return Ok(None);
+    }
+
+    let addr_str = rustfs_utils::get_env_str(ENV_TFTP_ADDRESS, DEFAULT_TFTP_ADDRESS);
+    let bind_addr =
+        rustfs_utils::net::parse_and_resolve_address(&addr_str).map_err(|e| format!("Invalid TFTP address '{addr_str}': {e}"))?;
+
+    let access_key =
+        rustfs_utils::get_env_opt_str(ENV_TFTP_ACCESS_KEY).ok_or("RUSTFS_TFTP_ACCESS_KEY is required when TFTP is enabled")?;
+    let secret_key =
+        rustfs_utils::get_env_opt_str(ENV_TFTP_SECRET_KEY).ok_or("RUSTFS_TFTP_SECRET_KEY is required when TFTP is enabled")?;
+
+    let iam_sys = rustfs_iam::get().map_err(|e| format!("IAM unavailable for TFTP startup: {e}"))?;
+    let (identity_opt, is_valid) = iam_sys
+        .check_key(&access_key)
+        .await
+        .map_err(|e| format!("TFTP credential lookup failed: {e}"))?;
+    let identity = identity_opt.ok_or_else(|| format!("Unknown TFTP access key: {}", MaskedAccessKey(&access_key)))?;
+    if !is_valid {
+        return Err("TFTP access key is disabled or expired".into());
+    }
+    if is_temporary_credential(&identity.credentials) {
+        return Err("TFTP does not accept temporary STS credentials".into());
+    }
+    let secret_matches: bool = identity.credentials.secret_key.as_bytes().ct_eq(secret_key.as_bytes()).into();
+    if !secret_matches {
+        return Err("RUSTFS_TFTP_SECRET_KEY does not match the configured access key".into());
+    }
+
+    let default_bucket = rustfs_utils::get_env_opt_str(ENV_TFTP_DEFAULT_BUCKET);
+    let access_mode = TftpConfig::resolve_access_mode(rustfs_utils::get_env_opt_str(ENV_TFTP_ACCESS_MODE).as_deref())?;
+    let max_block_size = TftpConfig::resolve_max_block_size(
+        rustfs_utils::get_env_opt_str(ENV_TFTP_MAX_BLOCK_SIZE).and_then(|v| v.parse::<u16>().ok()),
+    );
+    let max_window_size = TftpConfig::resolve_max_window_size(
+        rustfs_utils::get_env_opt_str(ENV_TFTP_MAX_WINDOW_SIZE).and_then(|v| v.parse::<u16>().ok()),
+    );
+    let max_concurrent_transfers = TftpConfig::resolve_max_concurrent_transfers(
+        rustfs_utils::get_env_opt_str(ENV_TFTP_MAX_CONCURRENT_TRANSFERS).and_then(|v| v.parse::<usize>().ok()),
+    );
+    let backend_op_timeout_secs = TftpConfig::resolve_backend_op_timeout_secs(
+        rustfs_utils::get_env_opt_str(ENV_TFTP_BACKEND_OP_TIMEOUT_SECS).and_then(|v| v.parse::<u64>().ok()),
+    );
+    let read_fetch_bytes = TftpConfig::resolve_read_fetch_bytes(
+        rustfs_utils::get_env_opt_str(ENV_TFTP_READ_FETCH_BYTES).and_then(|v| v.parse::<u64>().ok()),
+    );
+    let max_send_retries = TftpConfig::resolve_max_send_retries(
+        rustfs_utils::get_env_opt_str(ENV_TFTP_MAX_SEND_RETRIES).and_then(|v| v.parse::<u32>().ok()),
+    );
+
+    let config = TftpConfig {
+        bind_addr,
+        default_bucket,
+        access_mode,
+        max_block_size,
+        max_window_size,
+        max_concurrent_transfers,
+        backend_op_timeout_secs,
+        read_fetch_bytes,
+        max_send_retries,
+    };
+
+    let principal = ProtocolPrincipal::new(Arc::new(identity));
+    let session_context = SessionContext::new(principal, Protocol::Tftp, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+
+    let fs = crate::storage_api::startup::init::ecfs::FS::new();
+    let storage_client = ProtocolStorageClient::new(fs);
+    let handler = TftpStorageHandler::new(storage_client, config.clone(), session_context.credentials().clone(), session_context);
+    let server = TftpServer::new(config.clone(), handler);
+
+    debug!(
+        target: "rustfs::init",
+        event = EVENT_PROTOCOL_RUNTIME_STATE,
+        component = LOG_COMPONENT_INIT,
+        subsystem = LOG_SUBSYSTEM_PROTOCOL,
+        protocol = "tftp",
+        state = "configured",
+        bind_addr = %config.bind_addr,
+        access_mode = ?config.access_mode,
+        default_bucket = config.default_bucket.as_deref().unwrap_or("-"),
+        "Protocol runtime configured"
+    );
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
+    let task_handle = tokio::spawn(async move {
+        if let Err(e) = server.start(shutdown_rx).await {
+            error!(
+                target: "rustfs::init",
+                event = EVENT_PROTOCOL_SERVER_STATE,
+                component = LOG_COMPONENT_INIT,
+                subsystem = LOG_SUBSYSTEM_PROTOCOL,
+                protocol = "tftp",
+                state = "runtime_failed",
+                error = %e,
+                "Protocol server failed"
+            );
+        }
+        info!(
+            target: "rustfs::init",
+            event = EVENT_PROTOCOL_SERVER_STATE,
+            component = LOG_COMPONENT_INIT,
+            subsystem = LOG_SUBSYSTEM_PROTOCOL,
+            protocol = "tftp",
+            state = "stopped",
+            "Protocol server stopped"
+        );
+    });
+
+    info!(
+        target: "rustfs::init",
+        event = EVENT_PROTOCOL_RUNTIME_STATE,
+        component = LOG_COMPONENT_INIT,
+        subsystem = LOG_SUBSYSTEM_PROTOCOL,
+        protocol = "tftp",
+        state = "started",
+        bind_addr = %config.bind_addr,
+        "Protocol runtime started"
+    );
+    Ok(Some(ShutdownHandle::new(shutdown_tx, task_handle)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/rustfs/src/lib.rs
+++ b/rustfs/src/lib.rs
@@ -95,7 +95,7 @@ pub mod memory_observability;
 pub mod module_switches;
 pub mod on_demand_migration;
 pub mod profiling;
-#[cfg(any(feature = "ftps", feature = "webdav", feature = "sftp"))]
+#[cfg(any(feature = "ftps", feature = "webdav", feature = "sftp", feature = "tftp"))]
 pub mod protocols;
 pub mod runtime_capabilities;
 pub(crate) mod runtime_sources;

--- a/rustfs/src/startup_optional_runtime_sidecars.rs
+++ b/rustfs/src/startup_optional_runtime_sidecars.rs
@@ -45,6 +45,7 @@ enum OptionalRuntimeShutdownStep {
     Ftps,
     Webdav,
     Sftp,
+    Tftp,
 }
 
 impl OptionalRuntimeShutdownStep {
@@ -54,6 +55,7 @@ impl OptionalRuntimeShutdownStep {
             Self::Ftps => "ftps",
             Self::Webdav => "webdav",
             Self::Sftp => "sftp",
+            Self::Tftp => "tftp",
         }
     }
 }
@@ -73,11 +75,20 @@ fn optional_runtime_shutdown_steps(protocols: &ProtocolShutdownSenders) -> Vec<O
     if protocols.sftp.is_some() {
         steps.push(OptionalRuntimeShutdownStep::Sftp);
     }
+    if protocols.tftp.is_some() {
+        steps.push(OptionalRuntimeShutdownStep::Tftp);
+    }
     steps
 }
 
 pub(crate) fn prepare_optional_runtime_shutdowns(optional_runtimes: OptionalRuntimeServices) -> Vec<ShutdownHandle> {
-    let ProtocolShutdownSenders { ftp, ftps, webdav, sftp } = optional_runtimes.protocols;
+    let ProtocolShutdownSenders {
+        ftp,
+        ftps,
+        webdav,
+        sftp,
+        tftp,
+    } = optional_runtimes.protocols;
 
     let mut protocol_shutdowns = Vec::new();
     if let Some(handle) = ftp {
@@ -94,6 +105,10 @@ pub(crate) fn prepare_optional_runtime_shutdowns(optional_runtimes: OptionalRunt
     }
     if let Some(handle) = sftp {
         log_protocol_stopping(OptionalRuntimeShutdownStep::Sftp);
+        protocol_shutdowns.push(handle);
+    }
+    if let Some(handle) = tftp {
+        log_protocol_stopping(OptionalRuntimeShutdownStep::Tftp);
         protocol_shutdowns.push(handle);
     }
 
@@ -147,6 +162,7 @@ mod tests {
             ftps: Some(completed_shutdown_handle()),
             webdav: Some(completed_shutdown_handle()),
             sftp: Some(completed_shutdown_handle()),
+            tftp: Some(completed_shutdown_handle()),
         };
 
         assert_eq!(
@@ -156,6 +172,7 @@ mod tests {
                 OptionalRuntimeShutdownStep::Ftps,
                 OptionalRuntimeShutdownStep::Webdav,
                 OptionalRuntimeShutdownStep::Sftp,
+                OptionalRuntimeShutdownStep::Tftp,
             ]
         );
     }
@@ -168,6 +185,7 @@ mod tests {
             ftps: None,
             webdav: Some(observed_shutdown_handle("webdav", events.clone())),
             sftp: None,
+            tftp: None,
         };
 
         let protocol_shutdowns = prepare_optional_runtime_shutdowns(OptionalRuntimeServices::new(protocols));

--- a/rustfs/src/startup_protocols.rs
+++ b/rustfs/src/startup_protocols.rs
@@ -14,6 +14,8 @@
 
 #[cfg(feature = "sftp")]
 use crate::init::init_sftp_system;
+#[cfg(feature = "tftp")]
+use crate::init::init_tftp_system;
 #[cfg(feature = "webdav")]
 use crate::init::init_webdav_system;
 #[cfg(feature = "ftps")]
@@ -36,6 +38,7 @@ pub(crate) struct ProtocolShutdownSenders {
     pub(crate) ftps: Option<ShutdownHandle>,
     pub(crate) webdav: Option<ShutdownHandle>,
     pub(crate) sftp: Option<ShutdownHandle>,
+    pub(crate) tftp: Option<ShutdownHandle>,
 }
 
 pub(crate) async fn init_protocol_shutdown_senders() -> Result<ProtocolShutdownSenders> {
@@ -44,6 +47,7 @@ pub(crate) async fn init_protocol_shutdown_senders() -> Result<ProtocolShutdownS
         ftps: init_ftps_protocol().await?,
         webdav: init_webdav_protocol().await?,
         sftp: init_sftp_protocol().await?,
+        tftp: init_tftp_protocol().await?,
     })
 }
 
@@ -84,6 +88,16 @@ async fn init_sftp_protocol() -> Result<Option<ShutdownHandle>> {
 
 #[cfg(not(feature = "sftp"))]
 async fn init_sftp_protocol() -> Result<Option<ShutdownHandle>> {
+    Ok(None)
+}
+
+#[cfg(feature = "tftp")]
+async fn init_tftp_protocol() -> Result<Option<ShutdownHandle>> {
+    init_protocol("tftp", init_tftp_system).await
+}
+
+#[cfg(not(feature = "tftp"))]
+async fn init_tftp_protocol() -> Result<Option<ShutdownHandle>> {
     Ok(None)
 }
 

--- a/rustfs/src/startup_services.rs
+++ b/rustfs/src/startup_services.rs
@@ -79,7 +79,6 @@ pub(crate) async fn init_startup_runtime_services(
 ) -> Result<StartupServiceRuntime> {
     init_kms_system(config, store.clone()).await?;
 
-    let optional_runtimes = init_optional_runtime_services().await?;
     let heartbeat_config = HeartbeatConfig::from_env().map_err(std::io::Error::other)?;
     let heartbeat_nodes = heartbeat_config.as_ref().map(|_| endpoint_pools.get_nodes().len());
     let inventory_drives = heartbeat_config
@@ -91,6 +90,9 @@ pub(crate) async fn init_startup_runtime_services(
 
     let buckets = init_bucket_metadata_runtime(store.clone(), ctx.clone()).await?;
     let iam_bootstrap = init_iam_runtime(store.clone(), ctx.clone(), readiness, state_manager, server_ctx).await?;
+
+    // TFTP validates its fixed service-account credentials against IAM at startup.
+    let optional_runtimes = init_optional_runtime_services().await?;
 
     // Audit initialization requires the AppContext (server config + object store)
     // which is published by ensure_startup_after_iam inside init_iam_runtime.


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues

Closes #3241.

## Summary of Changes

Add an optional UDP TFTP sidecar (RRQ read path only) for PXE boot and similar read-mostly workflows. The sidecar uses [`async-tftp`](https://crates.io/crates/async-tftp) **0.4.2** for wire handling and maps RRQ transfers to the existing S3 `StorageBackend` API.

**Behavior**

- **RRQ**: `HeadObject` for size, then streamed ranged `GetObject` reads via `ObjectReader` (`AsyncRead`) with bounded memory (`RUSTFS_TFTP_READ_FETCH_BYTES` per transfer).
- **WRQ**: explicitly rejected with TFTP `Illegal operation` until upload support lands on a follow-up branch.
- **Auth**: fixed IAM service account (`RUSTFS_TFTP_ACCESS_KEY` / `SECRET_KEY`); validated at startup after IAM bootstrap; per-request `GetObject` authorization via `TftpStorageHandler`.
- **Paths**: optional `RUSTFS_TFTP_DEFAULT_BUCKET` or `/<bucket>/<key>` form; unified key validation in `paths.rs`.
- **Concurrency**: process-wide semaphore (`RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS`); excess RRQ opens return TFTP `DiskFull`.

**Code entry points**

| Layer | Path |
| --- | --- |
| Server bind / library knobs | `crates/protocols/src/tftp/server.rs` (`TftpServer::start`) |
| Handler open paths | `crates/protocols/src/tftp/handler.rs` (`TftpStorageHandler`) |
| RRQ streaming | `crates/protocols/src/tftp/reader.rs` (`ObjectReader`) |
| Env clamp bounds | `crates/protocols/src/tftp/constants.rs` |
| Defaults / env names | `crates/config/src/constants/protocols.rs` |

**Parameter map**

| Knob | Where it applies | Meaning |
| --- | --- | --- |
| `RUSTFS_TFTP_MAX_BLOCK_SIZE` | `async-tftp` `block_size_limit` | Ceiling for negotiated RFC 2348 `blksize` (`min(client, limit)`). |
| `RUSTFS_TFTP_MAX_WINDOW_SIZE` | `async-tftp` `window_size_limit` | Ceiling for negotiated RFC 7440 `windowsize`. |
| `RUSTFS_TFTP_MAX_SEND_RETRIES` | `async-tftp` `max_send_retries` | UDP retransmit attempts after timeout before giving up (default 5 ≈ 18s with 3s timeout). |
| `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS` | RustFS `Semaphore` | Max simultaneous RRQ handlers; excess get TFTP `DiskFull`. |
| `RUSTFS_TFTP_READ_FETCH_BYTES` | `ObjectReader` fetch window | Max bytes per ranged GET. |
| `RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS` | every S3 call in reader/handler | Per-call backend deadline. |

RRQ peak memory ≈ one `read_fetch_bytes` buffer per active transfer.

**Startup fix**: optional protocol sidecars (including TFTP) initialize after `init_iam_runtime` so TFTP credential validation does not fail with `IAM unavailable`.

**New dependency**: `async-tftp = "0.4.2"` behind the `tftp` feature (`rustfs-protocols/tftp`, `rustfs --features tftp`).

Documentation: [`docs/operations/tftp.md`](docs/operations/tftp.md).

### RRQ sequence (read)

```mermaid
sequenceDiagram
    autonumber
    participant C as TFTP client
    participant L as async-tftp
    participant H as TftpStorageHandler
    participant R as ObjectReader
    participant S as StorageBackend

    C->>L: RRQ path + opts (blksize, windowsize, tsize, ...)
    L->>H: read_req_open(client, path)
    H->>H: access_mode + try_acquire permit
    H->>H: resolve path → (bucket, key)
    H->>H: authorize GetObject
    H->>S: HeadObject (backend timeout)
    S-->>H: content_length
    H-->>L: ObjectReader + Some(object_size)
    L->>C: OACK (negotiated opts) or DATA (no opts)

    loop until EOF
        L->>R: AsyncRead::poll_read (up to blksize)
        alt buffer empty
            R->>S: GetObject range [offset, offset+fetch_bytes)
            S-->>R: body chunks → buffer
        end
        R-->>L: bytes
        L->>C: DATA block(s) for current window
        C->>L: ACK (last block of window)
    end

    Note over H,R: permit released when ObjectReader drops
```

### Layering

```text
  Client (atftp / firmware)          UDP :6969 (or :69)
           │
           ▼
   ┌───────────────────┐
   │     async-tftp    │  blksize / windowsize / retries / OACK
   │  RRQ tasks        │
   └─────────┬─────────┘
             │ Handler trait
             ▼
   ┌───────────────────┐
   │ TftpStorageHandler│  IAM, path, semaphore
   └─────────┬─────────┘
             │
             ▼
      ObjectReader
      ranged GET
             │
             ▼
        StorageBackend (S3 API)
```

## Verification

Tested commit: `25107cd` (`feat/tftp-sidecar-rrq`).

| Check | Command | Result |
| --- | --- | --- |
| Unit tests | `cargo test -p rustfs-protocols --features tftp --lib tftp` | Passes handler, reader, paths, errors, and config tests |
| Clippy | `cargo clippy -p rustfs-protocols --features tftp -- -D warnings` | Clean |
| Format | `cargo fmt --all --check` | Clean |
| Manual RRQ | `atftp --option "blksize 65464" --option "windowsize 1" -g -r <key> -l /tmp/out 127.0.0.1:6969` against local `rustfs --features tftp` | Object bytes match S3 source; `windowsize 1` workaround for stock 0.4.2 |

**Not run (out of scope for this PR)**

- Full `make pre-pr` / release binary build (requires `protoc` for pulsar dependency in default workspace build).
- E2E TFTP suite in `crates/e2e_test` (not yet added; follow-up).
- `windowsize > 1` end-to-end (known broken on stock `async-tftp` 0.4.2; see Additional Notes).

**Remaining risk**

- Wire-protocol limitations in stock `async-tftp` 0.4.2 (multi-window retransmit, OACK rejection hang) remain until upstream or fork patches are pinned.
- No automated large-object (512 MiB) regression in CI yet.

## Impact

**User-facing**

- New optional TFTP UDP sidecar for RRQ (read) when built with `--features tftp` and `RUSTFS_TFTP_ENABLE=true`.
- Default bind `0.0.0.0:6969` (non-privileged; port 69 requires `CAP_NET_BIND_SERVICE` or root).
- Default access mode `ro`; WRQ returns `Illegal operation`.

**Configuration**

New environment variables (see `docs/operations/tftp.md`):

`RUSTFS_TFTP_ENABLE`, `RUSTFS_TFTP_ADDRESS`, `RUSTFS_TFTP_ACCESS_KEY`, `RUSTFS_TFTP_SECRET_KEY`, `RUSTFS_TFTP_DEFAULT_BUCKET`, `RUSTFS_TFTP_ACCESS_MODE`, `RUSTFS_TFTP_MAX_BLOCK_SIZE`, `RUSTFS_TFTP_MAX_WINDOW_SIZE`, `RUSTFS_TFTP_MAX_SEND_RETRIES`, `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS`, `RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS`, `RUSTFS_TFTP_READ_FETCH_BYTES`.

**Compatibility**

- Feature-gated; no change when `tftp` feature is disabled.
- S3 API and existing HTTP S3 path unchanged.

**Security**

- TFTP has no wire authentication; operators must restrict UDP at the network layer and use a dedicated least-privilege IAM identity. STS credentials rejected at startup.

## Additional Notes

### Known `async-tftp` 0.4.2 issues (not fixed in this PR)

Work tracked against crates.io `async-tftp` **0.4.2**. Three branches are pushed to [ylw510/async-tftp-rs](https://github.com/ylw510/async-tftp-rs):

| Branch | Commit | Remote |
| --- | --- | --- |
| `fix/abort-on-peer-error` | [`c8135e5`](https://github.com/ylw510/async-tftp-rs/commit/c8135e5) | [`ylw510/async-tftp-rs`](https://github.com/ylw510/async-tftp-rs/tree/fix/abort-on-peer-error) |
| `fix/window-retransmit-unacked-suffix` | [`dceebe3`](https://github.com/ylw510/async-tftp-rs/commit/dceebe3) | [`ylw510/async-tftp-rs`](https://github.com/ylw510/async-tftp-rs/tree/fix/window-retransmit-unacked-suffix) |
| `feat/wrq-windowsize` | [`dabfc09`](https://github.com/ylw510/async-tftp-rs/commit/dabfc09) | [`ylw510/async-tftp-rs`](https://github.com/ylw510/async-tftp-rs/tree/feat/wrq-windowsize) |

All three branches fork from [`master`](https://github.com/ylw510/async-tftp-rs/tree/master) independently.

1. **[`fix/abort-on-peer-error`](https://github.com/ylw510/async-tftp-rs/tree/fix/abort-on-peer-error) (`c8135e5`)** — After OACK, client may send TFTP ERROR (e.g. RFC 2347 code 8). Stock `recv_ack` ignored non-ACK packets → server waited forever for ACK#0. Fix: treat `Packet::Error` as `Error::ClientAborted`.

2. **[`fix/window-retransmit-unacked-suffix`](https://github.com/ylw510/async-tftp-rs/tree/fix/window-retransmit-unacked-suffix) (`dceebe3`)** — `windowsize > 1` (e.g. 32) with `atftp` → `got wrong block` on lossy/late ACK. Cause: RRQ `send_window` retransmitted the entire window on timeout. Fix: retransmit only the unacked suffix (RFC 7440 §4).

3. **[`feat/wrq-windowsize`](https://github.com/ylw510/async-tftp-rs/tree/feat/wrq-windowsize) (`dabfc09`)** — Stock 0.4.2 negotiates `windowsize` on RRQ but WRQ still ACKed every DATA block. Fix for future WRQ branch.

**Practical workarounds today** (documented in `docs/operations/tftp.md`):

- Use `blksize 65464` and `windowsize 1` for reliable throughput.
- Keep `blksize` in RFC range `8..=65464`; out-of-range values may be silently dropped at parse time.

### Dependency strategy (follow-up)

**This PR (part 1):** keep crates.io `async-tftp = "0.4.2"` and document current wire-protocol limitations in `docs/operations/tftp.md`. The three [ylw510/async-tftp-rs](https://github.com/ylw510/async-tftp-rs) branches are **not** pinned here.

If those branches are validated as reasonable fixes, follow-up is either:

1. **Upstream path (default)** — Open PRs on [oblique/async-tftp-rs](https://github.com/oblique/async-tftp-rs) (combine or rebase the three branches first). Once upstream merges and publishes a new release, bump RustFS `Cargo.toml` to that version. No org fork required unless upstream is blocked or too slow.

2. **Org fork (only if upstream is blocked or too slow)** — Host a fork under the RustFS org (e.g. `rustfs/async-tftp-rs`), merge the three branches there, and pin RustFS to that git repo until upstream catches up; then switch back to crates.io.

### Follow-up (part 2 — WRQ write path)

- [#7707](https://github.com/rustfs/rustfs/pull/7707) — WRQ upload via `ObjectWriter` (multipart / `PutObject`, commit-on-close, `RUSTFS_TFTP_MAX_TRANSFER_BYTES`). Draft; blocked on this PR.

---
