### PR TITLE
feat(tftp): add TFTP WRQ support (part 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -282,7 +282,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -741,6 +741,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +837,22 @@ name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-tftp"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f24aee9a5a63c41e6720d2ab8e12947d3b9386b2d21f770f890b19b20e0173f0"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "bytes",
+ "futures-lite",
+ "log",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "async-trait"
@@ -1906,7 +1940,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
@@ -3942,7 +3976,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4287,7 +4321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6963,7 +6997,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8049,6 +8083,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "pollster"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8712,7 +8760,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10439,12 +10487,14 @@ version = "1.0.0-rc.6"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
+ "async-tftp",
  "async-trait",
  "axum",
  "base64-simd",
  "bytes",
  "dav-server",
  "futures",
+ "futures-lite",
  "futures-util",
  "hex-simd",
  "hmac 0.13.0",
@@ -11065,7 +11115,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11148,7 +11198,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11949,7 +11999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12100,7 +12150,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12405,10 +12455,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13510,7 +13560,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -367,6 +367,9 @@ rcgen = { version = "0.14.10", default-features = false, features = ["aws_lc_rs"
 russh = { version = "0.63.3" }
 russh-sftp = "3.0.0"
 
+# TFTP
+async-tftp = "0.4.2"
+
 # WebDAV
 dav-server = "0.11.0"
 

--- a/crates/config/src/constants/protocols.rs
+++ b/crates/config/src/constants/protocols.rs
@@ -169,3 +169,59 @@ pub const DEFAULT_SFTP_READ_ONLY: bool = false;
 
 /// Default SSH identification string (no version disclosure).
 pub const DEFAULT_SFTP_BANNER: &str = "SSH-2.0-RustFS";
+
+/// Default TFTP server bind address. The well-known TFTP port is UDP 69,
+/// which needs CAP_NET_BIND_SERVICE (or root) on Linux. The default binds
+/// an unprivileged port instead so enabling the protocol never requires
+/// extra capabilities; operators fronting real PXE clients set
+/// `RUSTFS_TFTP_ADDRESS` to port 69 explicitly.
+pub const DEFAULT_TFTP_ADDRESS: &str = "0.0.0.0:6969";
+
+/// TFTP environment variable names.
+pub const ENV_TFTP_ENABLE: &str = "RUSTFS_TFTP_ENABLE";
+pub const ENV_TFTP_ADDRESS: &str = "RUSTFS_TFTP_ADDRESS";
+/// Access key of the IAM identity every TFTP transfer is authorized as.
+pub const ENV_TFTP_ACCESS_KEY: &str = "RUSTFS_TFTP_ACCESS_KEY";
+pub const ENV_TFTP_SECRET_KEY: &str = "RUSTFS_TFTP_SECRET_KEY";
+/// When set, every request resolves inside this one bucket and the
+/// request filename becomes the object key. When unset, filenames are
+/// addressed as `/<bucket>/<key>`.
+pub const ENV_TFTP_DEFAULT_BUCKET: &str = "RUSTFS_TFTP_DEFAULT_BUCKET";
+/// `ro` (RRQ only), `wo` (WRQ only), or `rw` (both).
+pub const ENV_TFTP_ACCESS_MODE: &str = "RUSTFS_TFTP_ACCESS_MODE";
+pub const ENV_TFTP_MAX_BLOCK_SIZE: &str = "RUSTFS_TFTP_MAX_BLOCK_SIZE";
+pub const ENV_TFTP_MAX_WINDOW_SIZE: &str = "RUSTFS_TFTP_MAX_WINDOW_SIZE";
+pub const ENV_TFTP_MAX_CONCURRENT_TRANSFERS: &str = "RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS";
+pub const ENV_TFTP_BACKEND_OP_TIMEOUT_SECS: &str = "RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS";
+pub const ENV_TFTP_READ_FETCH_BYTES: &str = "RUSTFS_TFTP_READ_FETCH_BYTES";
+/// UDP retransmit attempts after the last good block before giving up on a
+/// transfer. Lower values abort dangling multipart uploads sooner when a
+/// client disappears; raise for lossy PXE/firmware networks.
+pub const ENV_TFTP_MAX_SEND_RETRIES: &str = "RUSTFS_TFTP_MAX_SEND_RETRIES";
+
+/// Default TFTP access mode. TFTP has no authentication on the wire, so
+/// an unset mode grants reads only; enabling writes is an explicit
+/// operator decision.
+pub const DEFAULT_TFTP_ACCESS_MODE: &str = "ro";
+
+/// Default maximum negotiated TFTP block size (RFC 2348 upper bound).
+pub const DEFAULT_TFTP_MAX_BLOCK_SIZE: u16 = 65464;
+
+/// Default maximum negotiated TFTP window size (RFC 7440). Preserves
+/// client-negotiated pipelining unless the operator lowers the ceiling.
+pub const DEFAULT_TFTP_MAX_WINDOW_SIZE: u16 = 65535;
+
+/// Default concurrent TFTP transfers per process.
+pub const DEFAULT_TFTP_MAX_CONCURRENT_TRANSFERS: usize = 64;
+
+/// Default backend operation timeout in seconds.
+pub const DEFAULT_TFTP_BACKEND_OP_TIMEOUT_SECS: u64 = 60;
+
+/// Default read-ahead fetch size for RRQ streaming (4 MiB).
+pub const DEFAULT_TFTP_READ_FETCH_BYTES: u64 = 4 * 1024 * 1024;
+
+/// Default UDP retransmit attempts per TFTP block/window after timeout.
+///
+/// With the server timeout of 3s, five retries give up in ~18s instead of
+/// async-tftp's library default of 100 (~5 minutes).
+pub const DEFAULT_TFTP_MAX_SEND_RETRIES: u32 = 5;

--- a/crates/config/src/constants/protocols.rs
+++ b/crates/config/src/constants/protocols.rs
@@ -192,6 +192,7 @@ pub const ENV_TFTP_ACCESS_MODE: &str = "RUSTFS_TFTP_ACCESS_MODE";
 pub const ENV_TFTP_MAX_BLOCK_SIZE: &str = "RUSTFS_TFTP_MAX_BLOCK_SIZE";
 pub const ENV_TFTP_MAX_WINDOW_SIZE: &str = "RUSTFS_TFTP_MAX_WINDOW_SIZE";
 pub const ENV_TFTP_MAX_CONCURRENT_TRANSFERS: &str = "RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS";
+pub const ENV_TFTP_MAX_TRANSFER_BYTES: &str = "RUSTFS_TFTP_MAX_TRANSFER_BYTES";
 pub const ENV_TFTP_BACKEND_OP_TIMEOUT_SECS: &str = "RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS";
 pub const ENV_TFTP_READ_FETCH_BYTES: &str = "RUSTFS_TFTP_READ_FETCH_BYTES";
 /// UDP retransmit attempts after the last good block before giving up on a
@@ -214,6 +215,9 @@ pub const DEFAULT_TFTP_MAX_WINDOW_SIZE: u16 = 65535;
 /// Default concurrent TFTP transfers per process.
 pub const DEFAULT_TFTP_MAX_CONCURRENT_TRANSFERS: usize = 64;
 
+/// Default per-transfer byte ceiling (256 MiB).
+pub const DEFAULT_TFTP_MAX_TRANSFER_BYTES: u64 = 256 * 1024 * 1024;
+
 /// Default backend operation timeout in seconds.
 pub const DEFAULT_TFTP_BACKEND_OP_TIMEOUT_SECS: u64 = 60;
 
@@ -223,5 +227,6 @@ pub const DEFAULT_TFTP_READ_FETCH_BYTES: u64 = 4 * 1024 * 1024;
 /// Default UDP retransmit attempts per TFTP block/window after timeout.
 ///
 /// With the server timeout of 3s, five retries give up in ~18s instead of
-/// async-tftp's library default of 100 (~5 minutes).
+/// async-tftp's library default of 100 (~5 minutes), so abandoned WRQ
+/// multipart uploads are aborted promptly.
 pub const DEFAULT_TFTP_MAX_SEND_RETRIES: u32 = 5;

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -108,6 +108,7 @@ swift = [
 ]
 webdav = ["dep:dav-server", "dep:hyper", "dep:hyper-util", "dep:http", "dep:http-body-util", "dep:tokio-rustls", "dep:base64-simd", "dep:rustls", "dep:percent-encoding", "dep:rustfs-tls-runtime", "dep:subtle"]
 sftp = ["dep:russh", "dep:russh-sftp", "dep:uuid", "dep:subtle", "dep:tokio-util", "dep:socket2"]
+tftp = ["dep:async-tftp", "dep:futures-lite", "dep:subtle", "dep:tokio-util"]
 
 [dependencies]
 hotpath.workspace = true
@@ -181,6 +182,10 @@ russh = { workspace = true, optional = true, features = ["serde"] }
 russh-sftp = { workspace = true, optional = true }
 subtle = { workspace = true, optional = true }
 socket2 = { workspace = true, optional = true, features = ["all"] }
+
+# TFTP specific dependencies (optional)
+async-tftp = { workspace = true, optional = true }
+futures-lite = { workspace = true, optional = true }
 
 [dev-dependencies]
 http = { workspace = true }

--- a/crates/protocols/src/common/gateway.rs
+++ b/crates/protocols/src/common/gateway.rs
@@ -254,6 +254,7 @@ pub fn is_operation_supported(protocol: super::session::Protocol, action: &S3Act
             S3Action::GetObjectAcl => false,
             S3Action::PutObjectAcl => false,
         },
+        super::session::Protocol::Tftp => matches!(action, S3Action::GetObject | S3Action::HeadObject),
     }
 }
 

--- a/crates/protocols/src/common/gateway.rs
+++ b/crates/protocols/src/common/gateway.rs
@@ -254,7 +254,16 @@ pub fn is_operation_supported(protocol: super::session::Protocol, action: &S3Act
             S3Action::GetObjectAcl => false,
             S3Action::PutObjectAcl => false,
         },
-        super::session::Protocol::Tftp => matches!(action, S3Action::GetObject | S3Action::HeadObject),
+        super::session::Protocol::Tftp => matches!(
+            action,
+            S3Action::GetObject
+                | S3Action::PutObject
+                | S3Action::HeadObject
+                | S3Action::CreateMultipartUpload
+                | S3Action::UploadPart
+                | S3Action::CompleteMultipartUpload
+                | S3Action::AbortMultipartUpload
+        ),
     }
 }
 

--- a/crates/protocols/src/common/session.rs
+++ b/crates/protocols/src/common/session.rs
@@ -26,6 +26,7 @@ pub enum Protocol {
     Swift,
     WebDav,
     Sftp,
+    Tftp,
 }
 
 /// Protocol principal representing an authenticated user
@@ -208,6 +209,7 @@ mod regression_prevention {
                 Protocol::Swift => {}
                 Protocol::WebDav => {}
                 Protocol::Sftp => {}
+                Protocol::Tftp => {}
             }
         }
     }

--- a/crates/protocols/src/lib.rs
+++ b/crates/protocols/src/lib.rs
@@ -29,6 +29,9 @@ pub mod webdav;
 #[cfg(feature = "sftp")]
 pub mod sftp;
 
+#[cfg(feature = "tftp")]
+pub mod tftp;
+
 pub use common::session::Protocol;
 pub use common::{AuthorizationError, ProtocolPrincipal, S3Action, SessionContext, authorize_operation};
 
@@ -43,3 +46,6 @@ pub use webdav::{config::WebDavConfig, server::WebDavServer};
 
 #[cfg(feature = "sftp")]
 pub use sftp::{SftpConfig, SftpInitError, SftpServer};
+
+#[cfg(feature = "tftp")]
+pub use tftp::{TftpConfig, TftpInitError, TftpServer, TftpStorageHandler};

--- a/crates/protocols/src/tftp/config.rs
+++ b/crates/protocols/src/tftp/config.rs
@@ -1,0 +1,117 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! TFTP server configuration.
+
+use super::constants::{
+    BACKEND_OP_TIMEOUT_MAX_SECS, BACKEND_OP_TIMEOUT_MIN_SECS, MAX_BLOCK_SIZE_MAX, MAX_BLOCK_SIZE_MIN,
+    MAX_CONCURRENT_TRANSFERS_MAX, MAX_CONCURRENT_TRANSFERS_MIN, MAX_SEND_RETRIES_MAX, MAX_SEND_RETRIES_MIN, MAX_WINDOW_SIZE_MAX,
+    MAX_WINDOW_SIZE_MIN, READ_FETCH_BYTES_MAX, READ_FETCH_BYTES_MIN,
+};
+use rustfs_config::{
+    DEFAULT_TFTP_ACCESS_MODE, DEFAULT_TFTP_BACKEND_OP_TIMEOUT_SECS, DEFAULT_TFTP_MAX_BLOCK_SIZE,
+    DEFAULT_TFTP_MAX_CONCURRENT_TRANSFERS, DEFAULT_TFTP_MAX_SEND_RETRIES, DEFAULT_TFTP_MAX_WINDOW_SIZE,
+    DEFAULT_TFTP_READ_FETCH_BYTES,
+};
+use std::net::SocketAddr;
+use thiserror::Error;
+
+/// TFTP transfer direction policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TftpAccessMode {
+    ReadOnly,
+    WriteOnly,
+    ReadWrite,
+}
+
+impl TftpAccessMode {
+    pub fn parse(raw: &str) -> Result<Self, TftpInitError> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "ro" | "read-only" | "readonly" => Ok(Self::ReadOnly),
+            "wo" | "write-only" | "writeonly" => Ok(Self::WriteOnly),
+            "rw" | "readwrite" | "read-write" => Ok(Self::ReadWrite),
+            other => Err(TftpInitError::InvalidConfig(format!(
+                "invalid RUSTFS_TFTP_ACCESS_MODE '{other}': expected ro, wo, or rw"
+            ))),
+        }
+    }
+
+    pub fn allows_read(self) -> bool {
+        matches!(self, Self::ReadOnly | Self::ReadWrite)
+    }
+
+    pub fn allows_write(self) -> bool {
+        matches!(self, Self::WriteOnly | Self::ReadWrite)
+    }
+}
+
+/// Runtime configuration for the TFTP server.
+#[derive(Debug, Clone)]
+pub struct TftpConfig {
+    pub bind_addr: SocketAddr,
+    pub default_bucket: Option<String>,
+    pub access_mode: TftpAccessMode,
+    pub max_block_size: u16,
+    pub max_window_size: u16,
+    pub max_concurrent_transfers: usize,
+    pub backend_op_timeout_secs: u64,
+    pub read_fetch_bytes: u64,
+    pub max_send_retries: u32,
+}
+
+/// Errors during TFTP initialization.
+#[derive(Debug, Error)]
+pub enum TftpInitError {
+    #[error("invalid TFTP configuration: {0}")]
+    InvalidConfig(String),
+
+    #[error("TFTP credentials rejected: {0}")]
+    CredentialsRejected(String),
+}
+
+impl TftpConfig {
+    pub fn resolve_max_block_size(raw: Option<u16>) -> u16 {
+        raw.filter(|&v| (MAX_BLOCK_SIZE_MIN..=MAX_BLOCK_SIZE_MAX).contains(&v))
+            .unwrap_or(DEFAULT_TFTP_MAX_BLOCK_SIZE)
+    }
+
+    pub fn resolve_max_window_size(raw: Option<u16>) -> u16 {
+        raw.filter(|&v| (MAX_WINDOW_SIZE_MIN..=MAX_WINDOW_SIZE_MAX).contains(&v))
+            .unwrap_or(DEFAULT_TFTP_MAX_WINDOW_SIZE)
+    }
+
+    pub fn resolve_max_concurrent_transfers(raw: Option<usize>) -> usize {
+        raw.filter(|&v| (MAX_CONCURRENT_TRANSFERS_MIN..=MAX_CONCURRENT_TRANSFERS_MAX).contains(&v))
+            .unwrap_or(DEFAULT_TFTP_MAX_CONCURRENT_TRANSFERS)
+    }
+
+    pub fn resolve_backend_op_timeout_secs(raw: Option<u64>) -> u64 {
+        raw.filter(|&v| (BACKEND_OP_TIMEOUT_MIN_SECS..=BACKEND_OP_TIMEOUT_MAX_SECS).contains(&v))
+            .unwrap_or(DEFAULT_TFTP_BACKEND_OP_TIMEOUT_SECS)
+    }
+
+    pub fn resolve_read_fetch_bytes(raw: Option<u64>) -> u64 {
+        raw.filter(|&v| (READ_FETCH_BYTES_MIN..=READ_FETCH_BYTES_MAX).contains(&v))
+            .unwrap_or(DEFAULT_TFTP_READ_FETCH_BYTES)
+    }
+
+    pub fn resolve_max_send_retries(raw: Option<u32>) -> u32 {
+        raw.filter(|&v| (MAX_SEND_RETRIES_MIN..=MAX_SEND_RETRIES_MAX).contains(&v))
+            .unwrap_or(DEFAULT_TFTP_MAX_SEND_RETRIES)
+    }
+
+    pub fn resolve_access_mode(raw: Option<&str>) -> Result<TftpAccessMode, TftpInitError> {
+        TftpAccessMode::parse(raw.unwrap_or(DEFAULT_TFTP_ACCESS_MODE))
+    }
+}

--- a/crates/protocols/src/tftp/config.rs
+++ b/crates/protocols/src/tftp/config.rs
@@ -16,13 +16,14 @@
 
 use super::constants::{
     BACKEND_OP_TIMEOUT_MAX_SECS, BACKEND_OP_TIMEOUT_MIN_SECS, MAX_BLOCK_SIZE_MAX, MAX_BLOCK_SIZE_MIN,
-    MAX_CONCURRENT_TRANSFERS_MAX, MAX_CONCURRENT_TRANSFERS_MIN, MAX_SEND_RETRIES_MAX, MAX_SEND_RETRIES_MIN, MAX_WINDOW_SIZE_MAX,
-    MAX_WINDOW_SIZE_MIN, READ_FETCH_BYTES_MAX, READ_FETCH_BYTES_MIN,
+    MAX_CONCURRENT_TRANSFERS_MAX, MAX_CONCURRENT_TRANSFERS_MIN, MAX_SEND_RETRIES_MAX, MAX_SEND_RETRIES_MIN,
+    MAX_TRANSFER_BYTES_MAX, MAX_TRANSFER_BYTES_MIN, MAX_WINDOW_SIZE_MAX, MAX_WINDOW_SIZE_MIN, READ_FETCH_BYTES_MAX,
+    READ_FETCH_BYTES_MIN,
 };
 use rustfs_config::{
     DEFAULT_TFTP_ACCESS_MODE, DEFAULT_TFTP_BACKEND_OP_TIMEOUT_SECS, DEFAULT_TFTP_MAX_BLOCK_SIZE,
-    DEFAULT_TFTP_MAX_CONCURRENT_TRANSFERS, DEFAULT_TFTP_MAX_SEND_RETRIES, DEFAULT_TFTP_MAX_WINDOW_SIZE,
-    DEFAULT_TFTP_READ_FETCH_BYTES,
+    DEFAULT_TFTP_MAX_CONCURRENT_TRANSFERS, DEFAULT_TFTP_MAX_SEND_RETRIES, DEFAULT_TFTP_MAX_TRANSFER_BYTES,
+    DEFAULT_TFTP_MAX_WINDOW_SIZE, DEFAULT_TFTP_READ_FETCH_BYTES,
 };
 use std::net::SocketAddr;
 use thiserror::Error;
@@ -65,6 +66,7 @@ pub struct TftpConfig {
     pub max_block_size: u16,
     pub max_window_size: u16,
     pub max_concurrent_transfers: usize,
+    pub max_transfer_bytes: u64,
     pub backend_op_timeout_secs: u64,
     pub read_fetch_bytes: u64,
     pub max_send_retries: u32,
@@ -94,6 +96,11 @@ impl TftpConfig {
     pub fn resolve_max_concurrent_transfers(raw: Option<usize>) -> usize {
         raw.filter(|&v| (MAX_CONCURRENT_TRANSFERS_MIN..=MAX_CONCURRENT_TRANSFERS_MAX).contains(&v))
             .unwrap_or(DEFAULT_TFTP_MAX_CONCURRENT_TRANSFERS)
+    }
+
+    pub fn resolve_max_transfer_bytes(raw: Option<u64>) -> u64 {
+        raw.filter(|&v| (MAX_TRANSFER_BYTES_MIN..=MAX_TRANSFER_BYTES_MAX).contains(&v))
+            .unwrap_or(DEFAULT_TFTP_MAX_TRANSFER_BYTES)
     }
 
     pub fn resolve_backend_op_timeout_secs(raw: Option<u64>) -> u64 {

--- a/crates/protocols/src/tftp/constants.rs
+++ b/crates/protocols/src/tftp/constants.rs
@@ -1,0 +1,51 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! TFTP operational limits.
+
+/// Lower bound for `RUSTFS_TFTP_MAX_BLOCK_SIZE`.
+pub const MAX_BLOCK_SIZE_MIN: u16 = 512;
+
+/// Upper bound for `RUSTFS_TFTP_MAX_BLOCK_SIZE` (RFC 2348).
+pub const MAX_BLOCK_SIZE_MAX: u16 = 65464;
+
+/// Lower bound for `RUSTFS_TFTP_MAX_WINDOW_SIZE` (RFC 7440).
+pub const MAX_WINDOW_SIZE_MIN: u16 = 1;
+
+/// Upper bound for `RUSTFS_TFTP_MAX_WINDOW_SIZE`.
+pub const MAX_WINDOW_SIZE_MAX: u16 = 65535;
+
+/// Lower bound for `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS`.
+pub const MAX_CONCURRENT_TRANSFERS_MIN: usize = 1;
+
+/// Upper bound for `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS`.
+pub const MAX_CONCURRENT_TRANSFERS_MAX: usize = 4096;
+
+/// Lower bound for `RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS`.
+pub const BACKEND_OP_TIMEOUT_MIN_SECS: u64 = 5;
+
+/// Upper bound for `RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS`.
+pub const BACKEND_OP_TIMEOUT_MAX_SECS: u64 = 600;
+
+/// Lower bound for `RUSTFS_TFTP_READ_FETCH_BYTES`.
+pub const READ_FETCH_BYTES_MIN: u64 = 512;
+
+/// Upper bound for `RUSTFS_TFTP_READ_FETCH_BYTES`.
+pub const READ_FETCH_BYTES_MAX: u64 = 64 * 1024 * 1024;
+
+/// Lower bound for `RUSTFS_TFTP_MAX_SEND_RETRIES`.
+pub const MAX_SEND_RETRIES_MIN: u32 = 1;
+
+/// Upper bound for `RUSTFS_TFTP_MAX_SEND_RETRIES`.
+pub const MAX_SEND_RETRIES_MAX: u32 = 100;

--- a/crates/protocols/src/tftp/constants.rs
+++ b/crates/protocols/src/tftp/constants.rs
@@ -12,7 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! TFTP operational limits.
+//! TFTP operational limits and S3 contract constants.
+
+/// S3 minimum multipart part size (5 MiB).
+pub const S3_MIN_PART_SIZE: u64 = 5 * 1024 * 1024;
+
+/// S3 maximum parts per multipart upload.
+pub const S3_MAX_MULTIPART_PARTS: i32 = 10_000;
 
 /// Lower bound for `RUSTFS_TFTP_MAX_BLOCK_SIZE`.
 pub const MAX_BLOCK_SIZE_MIN: u16 = 512;
@@ -31,6 +37,12 @@ pub const MAX_CONCURRENT_TRANSFERS_MIN: usize = 1;
 
 /// Upper bound for `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS`.
 pub const MAX_CONCURRENT_TRANSFERS_MAX: usize = 4096;
+
+/// Lower bound for `RUSTFS_TFTP_MAX_TRANSFER_BYTES`.
+pub const MAX_TRANSFER_BYTES_MIN: u64 = 512;
+
+/// Upper bound for `RUSTFS_TFTP_MAX_TRANSFER_BYTES` (1 GiB).
+pub const MAX_TRANSFER_BYTES_MAX: u64 = 1024 * 1024 * 1024;
 
 /// Lower bound for `RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS`.
 pub const BACKEND_OP_TIMEOUT_MIN_SECS: u64 = 5;

--- a/crates/protocols/src/tftp/errors.rs
+++ b/crates/protocols/src/tftp/errors.rs
@@ -1,0 +1,67 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Map backend and authorization failures to TFTP wire error codes.
+
+use async_tftp::packet::Error as TftpPacketError;
+use s3s::{S3Error, S3ErrorCode};
+use std::any::Any;
+use std::fmt::Display;
+use tracing::warn;
+
+const LOG_COMPONENT_PROTOCOLS: &str = "protocols";
+const LOG_SUBSYSTEM_TFTP_ERRORS: &str = "tftp_errors";
+const EVENT_TFTP_ERROR_MAPPING: &str = "tftp_error_mapping";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BackendErrorKind {
+    NotFound,
+    PermissionDenied,
+    Other,
+}
+
+fn classify_s3_code(code: &S3ErrorCode) -> BackendErrorKind {
+    match code {
+        S3ErrorCode::NoSuchKey | S3ErrorCode::NoSuchBucket => BackendErrorKind::NotFound,
+        S3ErrorCode::AccessDenied => BackendErrorKind::PermissionDenied,
+        _ => BackendErrorKind::Other,
+    }
+}
+
+fn classify_backend_error<E: Display + 'static>(err: &E) -> BackendErrorKind {
+    let any = err as &dyn Any;
+    if let Some(err) = any.downcast_ref::<S3Error>() {
+        return classify_s3_code(err.code());
+    }
+    BackendErrorKind::Other
+}
+
+pub fn backend_error_to_tftp<E: Display + 'static>(op: &str, err: E) -> TftpPacketError {
+    let msg = err.to_string();
+    let code = match classify_backend_error(&err) {
+        BackendErrorKind::NotFound => TftpPacketError::FileNotFound,
+        BackendErrorKind::PermissionDenied => TftpPacketError::PermissionDenied,
+        BackendErrorKind::Other => TftpPacketError::UnknownError,
+    };
+    warn!(
+        event = EVENT_TFTP_ERROR_MAPPING,
+        component = LOG_COMPONENT_PROTOCOLS,
+        subsystem = LOG_SUBSYSTEM_TFTP_ERRORS,
+        op = op,
+        err = %msg,
+        mapped = ?code,
+        "tftp error mapping"
+    );
+    code
+}

--- a/crates/protocols/src/tftp/errors.rs
+++ b/crates/protocols/src/tftp/errors.rs
@@ -28,6 +28,7 @@ const EVENT_TFTP_ERROR_MAPPING: &str = "tftp_error_mapping";
 enum BackendErrorKind {
     NotFound,
     PermissionDenied,
+    NoSuchUpload,
     Other,
 }
 
@@ -35,6 +36,7 @@ fn classify_s3_code(code: &S3ErrorCode) -> BackendErrorKind {
     match code {
         S3ErrorCode::NoSuchKey | S3ErrorCode::NoSuchBucket => BackendErrorKind::NotFound,
         S3ErrorCode::AccessDenied => BackendErrorKind::PermissionDenied,
+        S3ErrorCode::NoSuchUpload => BackendErrorKind::NoSuchUpload,
         _ => BackendErrorKind::Other,
     }
 }
@@ -47,12 +49,17 @@ fn classify_backend_error<E: Display + 'static>(err: &E) -> BackendErrorKind {
     BackendErrorKind::Other
 }
 
+/// Returns true when AbortMultipartUpload reports an already-missing upload.
+pub fn is_no_such_upload_backend_error<E: Display + 'static>(err: &E) -> bool {
+    classify_backend_error(err) == BackendErrorKind::NoSuchUpload
+}
+
 pub fn backend_error_to_tftp<E: Display + 'static>(op: &str, err: E) -> TftpPacketError {
     let msg = err.to_string();
     let code = match classify_backend_error(&err) {
         BackendErrorKind::NotFound => TftpPacketError::FileNotFound,
         BackendErrorKind::PermissionDenied => TftpPacketError::PermissionDenied,
-        BackendErrorKind::Other => TftpPacketError::UnknownError,
+        BackendErrorKind::NoSuchUpload | BackendErrorKind::Other => TftpPacketError::UnknownError,
     };
     warn!(
         event = EVENT_TFTP_ERROR_MAPPING,

--- a/crates/protocols/src/tftp/handler.rs
+++ b/crates/protocols/src/tftp/handler.rs
@@ -1,0 +1,141 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! TFTP `Handler` implementation backed by the RustFS storage API.
+
+use super::config::TftpConfig;
+use super::errors::backend_error_to_tftp;
+use super::paths::resolve_object_path;
+use super::reader::ObjectReader;
+use crate::common::client::s3::StorageBackend;
+use crate::common::gateway::{AuthorizationError, S3Action, authorize_operation};
+use crate::common::session::SessionContext;
+use async_tftp::packet::Error as TftpPacketError;
+use async_tftp::server::Handler;
+use futures_lite::io::Sink;
+use rustfs_credentials::Credentials;
+use std::net::SocketAddr;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::time::timeout;
+use tracing::warn;
+
+const LOG_COMPONENT_PROTOCOLS: &str = "protocols";
+const LOG_SUBSYSTEM_TFTP_HANDLER: &str = "tftp_handler";
+const EVENT_TFTP_HANDLER_STATE: &str = "tftp_handler_state";
+
+pub struct TftpStorageHandler<S: StorageBackend + Send + Sync + 'static> {
+    storage: Arc<S>,
+    config: TftpConfig,
+    credentials: Credentials,
+    session_context: SessionContext,
+    transfer_semaphore: Arc<Semaphore>,
+}
+
+impl<S: StorageBackend + Send + Sync + 'static> TftpStorageHandler<S> {
+    pub fn new(storage: S, config: TftpConfig, credentials: Credentials, session_context: SessionContext) -> Self {
+        let permits = config.max_concurrent_transfers;
+        Self {
+            storage: Arc::new(storage),
+            transfer_semaphore: Arc::new(Semaphore::new(permits)),
+            config,
+            credentials,
+            session_context,
+        }
+    }
+
+    fn backend_timeout(&self) -> Duration {
+        Duration::from_secs(self.config.backend_op_timeout_secs)
+    }
+
+    fn try_acquire_permit(&self) -> Result<OwnedSemaphorePermit, TftpPacketError> {
+        self.transfer_semaphore
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| TftpPacketError::DiskFull)
+    }
+
+    fn session_for_client(&self, client: &SocketAddr) -> SessionContext {
+        SessionContext::new(self.session_context.principal.clone(), self.session_context.protocol, client.ip())
+    }
+
+    async fn authorize(&self, client: &SocketAddr, action: &S3Action, bucket: &str, key: &str) -> Result<(), TftpPacketError> {
+        let session = self.session_for_client(client);
+        match authorize_operation(&session, action, bucket, Some(key)).await {
+            Ok(()) => Ok(()),
+            Err(AuthorizationError::AccessDenied) => Err(TftpPacketError::PermissionDenied),
+            Err(AuthorizationError::IamUnavailable) => {
+                warn!(
+                    event = EVENT_TFTP_HANDLER_STATE,
+                    component = LOG_COMPONENT_PROTOCOLS,
+                    subsystem = LOG_SUBSYSTEM_TFTP_HANDLER,
+                    action = action.as_str(),
+                    bucket = %bucket,
+                    key = %key,
+                    result = "iam_unavailable",
+                    "tftp handler state changed"
+                );
+                Err(TftpPacketError::UnknownError)
+            }
+        }
+    }
+}
+
+impl<S: StorageBackend + Send + Sync + 'static> Handler for TftpStorageHandler<S> {
+    type Reader = ObjectReader<S>;
+    type Writer = Sink;
+
+    async fn read_req_open(&mut self, client: &SocketAddr, path: &Path) -> Result<(Self::Reader, Option<u64>), TftpPacketError> {
+        if !self.config.access_mode.allows_read() {
+            return Err(TftpPacketError::PermissionDenied);
+        }
+
+        let permit = self.try_acquire_permit()?;
+        let (bucket, key) = resolve_object_path(path, self.config.default_bucket.as_deref())?;
+        self.authorize(client, &S3Action::GetObject, &bucket, &key).await?;
+
+        let head = timeout(self.backend_timeout(), self.storage.head_object(&bucket, &key, &self.credentials))
+            .await
+            .map_err(|_| TftpPacketError::UnknownError)?
+            .map_err(|e| backend_error_to_tftp("head_object", e))?;
+
+        let object_size = head.content_length.unwrap_or(0).max(0) as u64;
+        let reader = ObjectReader::new(
+            Arc::clone(&self.storage),
+            bucket,
+            key,
+            self.credentials.clone(),
+            object_size,
+            self.config.read_fetch_bytes,
+            self.backend_timeout(),
+            permit,
+        );
+
+        Ok((reader, Some(object_size)))
+    }
+
+    async fn write_req_open(
+        &mut self,
+        _client: &SocketAddr,
+        _path: &Path,
+        _size: Option<u64>,
+    ) -> Result<Self::Writer, TftpPacketError> {
+        if !self.config.access_mode.allows_write() {
+            return Err(TftpPacketError::PermissionDenied);
+        }
+        Err(TftpPacketError::IllegalOperation)
+    }
+}

--- a/crates/protocols/src/tftp/handler.rs
+++ b/crates/protocols/src/tftp/handler.rs
@@ -18,12 +18,12 @@ use super::config::TftpConfig;
 use super::errors::backend_error_to_tftp;
 use super::paths::resolve_object_path;
 use super::reader::ObjectReader;
+use super::writer::ObjectWriter;
 use crate::common::client::s3::StorageBackend;
 use crate::common::gateway::{AuthorizationError, S3Action, authorize_operation};
 use crate::common::session::SessionContext;
 use async_tftp::packet::Error as TftpPacketError;
 use async_tftp::server::Handler;
-use futures_lite::io::Sink;
 use rustfs_credentials::Credentials;
 use std::net::SocketAddr;
 use std::path::Path;
@@ -68,6 +68,13 @@ impl<S: StorageBackend + Send + Sync + 'static> TftpStorageHandler<S> {
             .map_err(|_| TftpPacketError::DiskFull)
     }
 
+    fn effective_max_transfer_bytes(&self, advertised: Option<u64>) -> u64 {
+        advertised
+            .filter(|size| *size > 0)
+            .map(|size| size.min(self.config.max_transfer_bytes))
+            .unwrap_or(self.config.max_transfer_bytes)
+    }
+
     fn session_for_client(&self, client: &SocketAddr) -> SessionContext {
         SessionContext::new(self.session_context.principal.clone(), self.session_context.protocol, client.ip())
     }
@@ -96,7 +103,7 @@ impl<S: StorageBackend + Send + Sync + 'static> TftpStorageHandler<S> {
 
 impl<S: StorageBackend + Send + Sync + 'static> Handler for TftpStorageHandler<S> {
     type Reader = ObjectReader<S>;
-    type Writer = Sink;
+    type Writer = ObjectWriter<S>;
 
     async fn read_req_open(&mut self, client: &SocketAddr, path: &Path) -> Result<(Self::Reader, Option<u64>), TftpPacketError> {
         if !self.config.access_mode.allows_read() {
@@ -129,13 +136,30 @@ impl<S: StorageBackend + Send + Sync + 'static> Handler for TftpStorageHandler<S
 
     async fn write_req_open(
         &mut self,
-        _client: &SocketAddr,
-        _path: &Path,
-        _size: Option<u64>,
+        client: &SocketAddr,
+        path: &Path,
+        size: Option<u64>,
     ) -> Result<Self::Writer, TftpPacketError> {
         if !self.config.access_mode.allows_write() {
             return Err(TftpPacketError::PermissionDenied);
         }
-        Err(TftpPacketError::IllegalOperation)
+
+        let permit = self.try_acquire_permit()?;
+        let (bucket, key) = resolve_object_path(path, self.config.default_bucket.as_deref())?;
+        self.authorize(client, &S3Action::PutObject, &bucket, &key).await?;
+
+        let max_bytes = self.effective_max_transfer_bytes(size);
+        let writer = ObjectWriter::new(
+            Arc::clone(&self.storage),
+            bucket,
+            key,
+            self.credentials.clone(),
+            self.config.read_fetch_bytes.max(super::constants::S3_MIN_PART_SIZE),
+            max_bytes,
+            self.backend_timeout(),
+            permit,
+        );
+
+        Ok(writer)
     }
 }

--- a/crates/protocols/src/tftp/mod.rs
+++ b/crates/protocols/src/tftp/mod.rs
@@ -1,0 +1,41 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! TFTP protocol support for RustFS (RFC 1350 RRQ via `async-tftp`).
+//!
+//! RRQ maps to ranged S3 GETs with bounded memory. WRQ upload support
+//! lands in a follow-up change.
+
+mod config;
+mod constants;
+mod errors;
+mod handler;
+mod paths;
+mod reader;
+mod server;
+
+pub use config::{TftpAccessMode, TftpConfig, TftpInitError};
+pub use handler::TftpStorageHandler;
+pub use server::TftpServer;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::session::Protocol;
+
+    #[test]
+    fn protocol_variant_is_named() {
+        let _ = Protocol::Tftp;
+    }
+}

--- a/crates/protocols/src/tftp/mod.rs
+++ b/crates/protocols/src/tftp/mod.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! TFTP protocol support for RustFS (RFC 1350 RRQ via `async-tftp`).
+//! TFTP protocol support for RustFS (RFC 1350 read/write via `async-tftp`).
 //!
-//! RRQ maps to ranged S3 GETs with bounded memory. WRQ upload support
-//! lands in a follow-up change.
+//! RRQ and WRQ map to ranged S3 GETs and multipart/put uploads with
+//! commit-on-close semantics. Failed WRQ transfers abort in-progress
+//! multipart uploads from `Drop` and never commit partial objects.
 
 mod config;
 mod constants;
@@ -24,6 +25,7 @@ mod handler;
 mod paths;
 mod reader;
 mod server;
+mod writer;
 
 pub use config::{TftpAccessMode, TftpConfig, TftpInitError};
 pub use handler::TftpStorageHandler;

--- a/crates/protocols/src/tftp/paths.rs
+++ b/crates/protocols/src/tftp/paths.rs
@@ -1,0 +1,106 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! TFTP filename to S3 bucket/key resolution with unified validation.
+
+use async_tftp::packet::Error as TftpPacketError;
+use rustfs_utils::path;
+use std::path::Path;
+
+/// Resolve a TFTP filename into `(bucket, object_key)`.
+///
+/// When `default_bucket` is set, the filename becomes the object key under
+/// that bucket. Otherwise the path is parsed as `/<bucket>/<key>`.
+/// Both modes run the same key validation before returning.
+pub fn resolve_object_path(filename: &Path, default_bucket: Option<&str>) -> Result<(String, String), TftpPacketError> {
+    let raw = filename.to_string_lossy();
+    let trimmed = raw.trim_start_matches('/');
+
+    if trimmed.is_empty() {
+        return Err(TftpPacketError::FileNotFound);
+    }
+
+    let (bucket, key) = match default_bucket {
+        Some(bucket) => (bucket.to_string(), trimmed.to_string()),
+        None => {
+            let cleaned = path::clean(&format!("/{trimmed}"));
+            if cleaned == "." || cleaned == ".." || cleaned.starts_with("../") {
+                return Err(TftpPacketError::FileNotFound);
+            }
+            let (bucket, object) = path::path_to_bucket_object(&cleaned);
+            if bucket.is_empty() || object.is_empty() {
+                return Err(TftpPacketError::FileNotFound);
+            }
+            (bucket, object)
+        }
+    };
+
+    validate_object_key(&key)?;
+    Ok((bucket, key))
+}
+
+/// Shared validation for object keys in both bucket-resolution modes.
+fn validate_object_key(key: &str) -> Result<(), TftpPacketError> {
+    if key.contains(['\0', '\r', '\n']) {
+        return Err(TftpPacketError::IllegalOperation);
+    }
+    if key.contains(path::GLOBAL_DIR_SUFFIX) {
+        return Err(TftpPacketError::IllegalOperation);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn default_bucket_uses_filename_as_key() {
+        let (bucket, key) = resolve_object_path(Path::new("pxelinux.0"), Some("pxe")).expect("resolve");
+        assert_eq!(bucket, "pxe");
+        assert_eq!(key, "pxelinux.0");
+    }
+
+    #[test]
+    fn default_bucket_rejects_control_chars() {
+        let err = resolve_object_path(Path::new("bad\0name"), Some("pxe")).expect_err("NUL rejected");
+        assert!(matches!(err, TftpPacketError::IllegalOperation));
+    }
+
+    #[test]
+    fn default_bucket_rejects_xldir_marker() {
+        let err = resolve_object_path(Path::new("foo__XLDIR__"), Some("pxe")).expect_err("marker rejected");
+        assert!(matches!(err, TftpPacketError::IllegalOperation));
+    }
+
+    #[test]
+    fn bucket_key_mode_parses_path() {
+        let (bucket, key) = resolve_object_path(Path::new("/mybucket/boot/vmlinuz"), None).expect("resolve");
+        assert_eq!(bucket, "mybucket");
+        assert_eq!(key, "boot/vmlinuz");
+    }
+
+    #[test]
+    fn bucket_key_mode_rejects_traversal() {
+        let err = resolve_object_path(Path::new("/../secret"), None).expect_err("traversal rejected");
+        assert!(matches!(err, TftpPacketError::FileNotFound));
+    }
+
+    #[test]
+    fn empty_filename_rejected() {
+        let err = resolve_object_path(Path::new(""), Some("pxe")).expect_err("empty rejected");
+        assert!(matches!(err, TftpPacketError::FileNotFound));
+    }
+}

--- a/crates/protocols/src/tftp/reader.rs
+++ b/crates/protocols/src/tftp/reader.rs
@@ -1,0 +1,169 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Streaming `AsyncRead` over ranged S3 GETs with bounded memory.
+
+use crate::common::client::s3::StorageBackend;
+use futures_lite::{AsyncRead, io::Result as AsyncIoResult};
+use futures_util::StreamExt;
+use rustfs_credentials::Credentials;
+use std::io::{Error, ErrorKind};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use tokio::sync::OwnedSemaphorePermit;
+use tokio::time::timeout;
+use tracing::warn;
+
+const LOG_COMPONENT_PROTOCOLS: &str = "protocols";
+const LOG_SUBSYSTEM_TFTP_READER: &str = "tftp_reader";
+const EVENT_TFTP_READ_STATE: &str = "tftp_read_state";
+
+type FetchFuture = Pin<Box<dyn std::future::Future<Output = std::io::Result<Vec<u8>>> + Send>>;
+
+/// Bounded-memory reader for TFTP RRQ transfers.
+pub struct ObjectReader<S: StorageBackend + Send + Sync + 'static> {
+    storage: Arc<S>,
+    bucket: String,
+    key: String,
+    credentials: Credentials,
+    object_size: u64,
+    offset: u64,
+    fetch_bytes: u64,
+    backend_timeout: Duration,
+    buffer: Vec<u8>,
+    buffer_pos: usize,
+    fetch_future: Option<FetchFuture>,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl<S: StorageBackend + Send + Sync + 'static> ObjectReader<S> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        storage: Arc<S>,
+        bucket: String,
+        key: String,
+        credentials: Credentials,
+        object_size: u64,
+        fetch_bytes: u64,
+        backend_timeout: Duration,
+        permit: OwnedSemaphorePermit,
+    ) -> Self {
+        Self {
+            storage,
+            bucket,
+            key,
+            credentials,
+            object_size,
+            offset: 0,
+            fetch_bytes,
+            backend_timeout,
+            buffer: Vec::new(),
+            buffer_pos: 0,
+            fetch_future: None,
+            _permit: permit,
+        }
+    }
+
+    fn start_fetch(&mut self) {
+        if self.offset >= self.object_size {
+            return;
+        }
+        let remaining = self.object_size - self.offset;
+        let fetch_len = remaining.min(self.fetch_bytes);
+        let storage = Arc::clone(&self.storage);
+        let bucket = self.bucket.clone();
+        let key = self.key.clone();
+        let credentials = self.credentials.clone();
+        let offset = self.offset;
+        let backend_timeout = self.backend_timeout;
+
+        self.fetch_future = Some(Box::pin(async move {
+            let fut = storage.get_object_range(&bucket, &key, &credentials, offset, fetch_len);
+            let out = timeout(backend_timeout, fut)
+                .await
+                .map_err(|_| Error::new(ErrorKind::TimedOut, "get_object_range timed out"))?
+                .map_err(Error::other)?;
+
+            let Some(mut body) = out.body else {
+                return Ok(Vec::new());
+            };
+
+            let mut buf = Vec::with_capacity(usize::try_from(fetch_len).unwrap_or(0));
+            loop {
+                let chunk = timeout(backend_timeout, body.next())
+                    .await
+                    .map_err(|_| Error::new(ErrorKind::TimedOut, "get_object stream timed out"))?
+                    .transpose()
+                    .map_err(Error::other)?;
+                let Some(chunk) = chunk else { break };
+                buf.extend_from_slice(&chunk);
+            }
+            Ok(buf)
+        }));
+    }
+}
+
+impl<S: StorageBackend + Send + Sync + 'static> AsyncRead for ObjectReader<S> {
+    fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<AsyncIoResult<usize>> {
+        if self.offset >= self.object_size {
+            return Poll::Ready(Ok(0));
+        }
+
+        if self.buffer_pos >= self.buffer.len() {
+            if self.fetch_future.is_none() {
+                self.start_fetch();
+            }
+
+            if let Some(mut fut) = self.fetch_future.take() {
+                match fut.as_mut().poll(cx) {
+                    Poll::Ready(Ok(data)) => {
+                        self.buffer = data;
+                        self.buffer_pos = 0;
+                        if self.buffer.is_empty() && self.offset < self.object_size {
+                            warn!(
+                                event = EVENT_TFTP_READ_STATE,
+                                component = LOG_COMPONENT_PROTOCOLS,
+                                subsystem = LOG_SUBSYSTEM_TFTP_READER,
+                                bucket = %self.bucket,
+                                key = %self.key,
+                                offset = self.offset,
+                                result = "unexpected_eof",
+                                "tftp read state changed"
+                            );
+                            return Poll::Ready(Err(ErrorKind::UnexpectedEof.into()));
+                        }
+                    }
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                    Poll::Pending => {
+                        self.fetch_future = Some(fut);
+                        return Poll::Pending;
+                    }
+                }
+            }
+        }
+
+        let available = self.buffer.len().saturating_sub(self.buffer_pos);
+        if available == 0 {
+            return Poll::Ready(Ok(0));
+        }
+
+        let to_copy = available.min(buf.len());
+        buf[..to_copy].copy_from_slice(&self.buffer[self.buffer_pos..self.buffer_pos + to_copy]);
+        self.buffer_pos += to_copy;
+        self.offset += to_copy as u64;
+        Poll::Ready(Ok(to_copy))
+    }
+}

--- a/crates/protocols/src/tftp/server.rs
+++ b/crates/protocols/src/tftp/server.rs
@@ -1,0 +1,110 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! TFTP UDP server lifecycle.
+
+use super::config::{TftpConfig, TftpInitError};
+use super::handler::TftpStorageHandler;
+use crate::common::client::s3::StorageBackend;
+use async_tftp::server::TftpServerBuilder;
+use std::fmt::Debug;
+use std::time::Duration;
+use tokio::sync::broadcast;
+use tracing::{debug, error, info};
+
+const LOG_COMPONENT_PROTOCOLS: &str = "protocols";
+const LOG_SUBSYSTEM_TFTP_SERVER: &str = "tftp_server";
+const EVENT_TFTP_SERVER_STATE: &str = "tftp_server_state";
+
+/// TFTP server entry point.
+pub struct TftpServer<S>
+where
+    S: StorageBackend + Send + Sync + 'static + Debug,
+{
+    config: TftpConfig,
+    handler: TftpStorageHandler<S>,
+}
+
+impl<S> TftpServer<S>
+where
+    S: StorageBackend + Send + Sync + 'static + Debug,
+{
+    pub fn new(config: TftpConfig, handler: TftpStorageHandler<S>) -> Self {
+        Self { config, handler }
+    }
+
+    pub async fn start(self, mut shutdown_rx: broadcast::Receiver<()>) -> Result<(), TftpInitError> {
+        let bind_addr = self.config.bind_addr;
+        let max_block_size = self.config.max_block_size;
+        let max_window_size = self.config.max_window_size;
+        let max_send_retries = self.config.max_send_retries;
+
+        let tftpd = TftpServerBuilder::with_handler(self.handler)
+            .bind(bind_addr)
+            .block_size_limit(max_block_size)
+            .window_size_limit(max_window_size)
+            .timeout(Duration::from_secs(3))
+            .max_send_retries(max_send_retries)
+            .build()
+            .await
+            .map_err(|e| TftpInitError::InvalidConfig(format!("TFTP server build failed: {e}")))?;
+
+        info!(
+            event = EVENT_TFTP_SERVER_STATE,
+            component = LOG_COMPONENT_PROTOCOLS,
+            subsystem = LOG_SUBSYSTEM_TFTP_SERVER,
+            state = "listening",
+            bind_addr = %bind_addr,
+            "tftp server state changed"
+        );
+
+        tokio::select! {
+            result = tftpd.serve() => {
+                match result {
+                    Ok(()) => {
+                        debug!(
+                            event = EVENT_TFTP_SERVER_STATE,
+                            component = LOG_COMPONENT_PROTOCOLS,
+                            subsystem = LOG_SUBSYSTEM_TFTP_SERVER,
+                            state = "stopped",
+                            "tftp server state changed"
+                        );
+                        Ok(())
+                    }
+                    Err(e) => {
+                        error!(
+                            event = EVENT_TFTP_SERVER_STATE,
+                            component = LOG_COMPONENT_PROTOCOLS,
+                            subsystem = LOG_SUBSYSTEM_TFTP_SERVER,
+                            state = "runtime_failed",
+                            error = %e,
+                            "tftp server state changed"
+                        );
+                        Err(TftpInitError::InvalidConfig(format!("TFTP serve failed: {e}")))
+                    }
+                }
+            }
+            _ = shutdown_rx.recv() => {
+                debug!(
+                    event = EVENT_TFTP_SERVER_STATE,
+                    component = LOG_COMPONENT_PROTOCOLS,
+                    subsystem = LOG_SUBSYSTEM_TFTP_SERVER,
+                    state = "shutdown_signal",
+                    "tftp server state changed"
+                );
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/protocols/src/tftp/writer.rs
+++ b/crates/protocols/src/tftp/writer.rs
@@ -1,0 +1,873 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Streaming `AsyncWrite` with commit-on-close and abort-on-drop semantics.
+
+use super::constants::{S3_MAX_MULTIPART_PARTS, S3_MIN_PART_SIZE};
+use super::errors::is_no_such_upload_backend_error;
+use crate::common::client::s3::StorageBackend;
+use bytes::Bytes;
+use futures_lite::{AsyncWrite, io::Result as AsyncIoResult};
+use futures_util::stream;
+use rustfs_credentials::Credentials;
+use s3s::dto::{
+    AbortMultipartUploadInput, CompleteMultipartUploadInput, CompletedMultipartUpload, CompletedPart as S3CompletedPart,
+    CreateMultipartUploadInput, ETag, PutObjectInput, StreamingBlob, UploadPartInput,
+};
+
+fn etag_to_string(etag: &ETag) -> String {
+    match etag {
+        ETag::Strong(s) | ETag::Weak(s) => s.clone(),
+    }
+}
+use std::io::{Error, ErrorKind, Result};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use tokio::sync::OwnedSemaphorePermit;
+use tokio::time::timeout;
+use tracing::{debug, warn};
+
+const LOG_COMPONENT_PROTOCOLS: &str = "protocols";
+const LOG_SUBSYSTEM_TFTP_WRITER: &str = "tftp_writer";
+const EVENT_TFTP_WRITE_STATE: &str = "tftp_write_state";
+const EVENT_TFTP_ABORT_STATE: &str = "tftp_abort_state";
+
+struct UploadedPart {
+    part_number: i32,
+    e_tag: String,
+}
+
+struct MultipartState {
+    upload_id: String,
+    next_part_number: i32,
+    uploaded_parts: Vec<UploadedPart>,
+}
+
+enum WriterStep {
+    /// CreateMultipartUpload finished; `multipart` is restored before UploadPart runs.
+    UploadCreated {
+        state: MultipartState,
+    },
+    PartFlushed {
+        state: MultipartState,
+        bytes: u64,
+    },
+    Committed,
+}
+
+/// Bounded-memory writer for TFTP WRQ transfers.
+///
+/// `async-tftp` calls `close()` only after a successful WRQ. Failed transfers
+/// drop the writer without closing, so `Drop` aborts in-progress multipart
+/// uploads and never commits partial data.
+pub struct ObjectWriter<S: StorageBackend + Send + Sync + 'static> {
+    storage: Arc<S>,
+    bucket: String,
+    key: String,
+    credentials: Credentials,
+    part_size: u64,
+    max_transfer_bytes: u64,
+    flushed_bytes: u64,
+    buffer: Vec<u8>,
+    multipart: Option<MultipartState>,
+    /// Copy of the live S3 upload_id kept across `multipart.take()` for in-flight
+    /// UploadPart / Complete calls so Drop can still abort.
+    live_upload_id: Option<String>,
+    completed: bool,
+    backend_timeout: Duration,
+    op_future: Option<Pin<Box<dyn std::future::Future<Output = std::io::Result<WriterStep>> + Send>>>,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl<S: StorageBackend + Send + Sync + 'static> ObjectWriter<S> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        storage: Arc<S>,
+        bucket: String,
+        key: String,
+        credentials: Credentials,
+        part_size: u64,
+        max_transfer_bytes: u64,
+        backend_timeout: Duration,
+        permit: OwnedSemaphorePermit,
+    ) -> Self {
+        Self {
+            storage,
+            bucket,
+            key,
+            credentials,
+            part_size: part_size.max(S3_MIN_PART_SIZE),
+            max_transfer_bytes,
+            flushed_bytes: 0,
+            buffer: Vec::new(),
+            multipart: None,
+            live_upload_id: None,
+            completed: false,
+            backend_timeout,
+            op_future: None,
+            _permit: permit,
+        }
+    }
+
+    fn remember_live_upload_id(&mut self, upload_id: &str) {
+        if let Some(id) = non_empty_upload_id(upload_id) {
+            self.live_upload_id = Some(id);
+        }
+    }
+
+    fn preserve_live_upload_id(&mut self) {
+        if let Some(id) = self
+            .multipart
+            .as_ref()
+            .and_then(|state| non_empty_upload_id(&state.upload_id))
+        {
+            self.live_upload_id = Some(id);
+        }
+    }
+
+    fn clear_live_upload_id(&mut self) {
+        self.live_upload_id = None;
+    }
+
+    fn upload_id_for_abort(&mut self) -> Option<String> {
+        self.live_upload_id
+            .take()
+            .or_else(|| self.multipart.take().and_then(|state| non_empty_upload_id(&state.upload_id)))
+    }
+
+    fn total_bytes(&self) -> u64 {
+        self.flushed_bytes.saturating_add(self.buffer.len() as u64)
+    }
+
+    fn check_transfer_limit(&self, additional: usize) -> Result<()> {
+        if self.total_bytes().saturating_add(additional as u64) > self.max_transfer_bytes {
+            return Err(Error::new(ErrorKind::WriteZero, "transfer size limit exceeded"));
+        }
+        Ok(())
+    }
+
+    fn should_use_multipart(&self) -> bool {
+        self.multipart.is_some() || self.total_bytes() > self.part_size
+    }
+
+    fn needs_multipart_create(&self) -> bool {
+        self.multipart
+            .as_ref()
+            .map(|state| state.upload_id.is_empty())
+            .unwrap_or(true)
+    }
+
+    fn poll_op(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        let Some(mut fut) = self.op_future.take() else {
+            return Poll::Ready(Ok(()));
+        };
+        match fut.as_mut().poll(cx) {
+            Poll::Ready(Ok(step)) => {
+                match step {
+                    WriterStep::UploadCreated { state } => {
+                        self.remember_live_upload_id(&state.upload_id);
+                        self.multipart = Some(state);
+                    }
+                    WriterStep::PartFlushed { state, bytes } => {
+                        self.remember_live_upload_id(&state.upload_id);
+                        self.multipart = Some(state);
+                        self.flushed_bytes = self.flushed_bytes.saturating_add(bytes);
+                    }
+                    WriterStep::Committed => {
+                        self.completed = true;
+                        self.clear_live_upload_id();
+                    }
+                }
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Pending => {
+                self.op_future = Some(fut);
+                Poll::Pending
+            }
+        }
+    }
+
+    fn drive_multipart_flush(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        while self.should_use_multipart() && self.buffer.len() >= self.part_size as usize {
+            if self.op_future.is_some() {
+                return match self.poll_op(cx) {
+                    Poll::Ready(Ok(())) => continue,
+                    other => other,
+                };
+            }
+
+            if self.needs_multipart_create() {
+                self.spawn_create_multipart();
+            } else {
+                self.spawn_flush_part();
+            }
+
+            match self.poll_op(cx) {
+                Poll::Ready(Ok(())) => continue,
+                other => return other,
+            }
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn spawn_create_multipart(&mut self) {
+        let storage = Arc::clone(&self.storage);
+        let bucket = self.bucket.clone();
+        let key = self.key.clone();
+        let credentials = self.credentials.clone();
+        let backend_timeout = self.backend_timeout;
+        let state = self.multipart.take().unwrap_or(MultipartState {
+            upload_id: String::new(),
+            next_part_number: 1,
+            uploaded_parts: Vec::new(),
+        });
+
+        self.op_future = Some(Box::pin(async move {
+            let input = CreateMultipartUploadInput::builder()
+                .bucket(bucket.clone())
+                .key(key.clone())
+                .build()
+                .map_err(Error::other)?;
+            let out = timeout(backend_timeout, storage.create_multipart_upload(input, &credentials))
+                .await
+                .map_err(|_| Error::new(ErrorKind::TimedOut, "create_multipart_upload timed out"))?
+                .map_err(Error::other)?;
+            let upload_id = out.upload_id.ok_or_else(|| Error::other("missing upload_id"))?;
+            Ok(WriterStep::UploadCreated {
+                state: MultipartState {
+                    upload_id,
+                    next_part_number: state.next_part_number,
+                    uploaded_parts: state.uploaded_parts,
+                },
+            })
+        }));
+    }
+
+    fn spawn_flush_part(&mut self) {
+        if self.buffer.len() < self.part_size as usize {
+            return;
+        }
+
+        self.preserve_live_upload_id();
+
+        let part_bytes: Vec<u8> = self.buffer.drain(..self.part_size as usize).collect();
+        let part_len = part_bytes.len() as u64;
+        let storage = Arc::clone(&self.storage);
+        let bucket = self.bucket.clone();
+        let key = self.key.clone();
+        let credentials = self.credentials.clone();
+        let backend_timeout = self.backend_timeout;
+        let mut state = self.multipart.take().expect("flush requires multipart state");
+
+        self.op_future = Some(Box::pin(async move {
+            if state.upload_id.is_empty() {
+                return Err(Error::other("upload_part requires upload_id"));
+            }
+
+            if state.next_part_number > S3_MAX_MULTIPART_PARTS {
+                abort_upload(storage.as_ref(), &bucket, &key, &state.upload_id, &credentials, backend_timeout).await;
+                return Err(Error::new(ErrorKind::WriteZero, "multipart part limit exceeded"));
+            }
+
+            let part_number = state.next_part_number;
+            let body_stream = stream::once(async move { Ok::<Bytes, std::io::Error>(Bytes::from(part_bytes)) });
+            let streaming = StreamingBlob::wrap(body_stream);
+            let input = UploadPartInput::builder()
+                .bucket(bucket.clone())
+                .key(key.clone())
+                .upload_id(state.upload_id.clone())
+                .part_number(part_number)
+                .content_length(Some(part_len as i64))
+                .body(Some(streaming))
+                .build()
+                .map_err(Error::other)?;
+
+            let out = match timeout(backend_timeout, storage.upload_part(input, &credentials)).await {
+                Ok(Ok(out)) => out,
+                Ok(Err(e)) => {
+                    abort_upload(storage.as_ref(), &bucket, &key, &state.upload_id, &credentials, backend_timeout).await;
+                    return Err(Error::other(e));
+                }
+                Err(_) => {
+                    abort_upload(storage.as_ref(), &bucket, &key, &state.upload_id, &credentials, backend_timeout).await;
+                    return Err(Error::new(ErrorKind::TimedOut, "upload_part timed out"));
+                }
+            };
+
+            let e_tag = out
+                .e_tag
+                .as_ref()
+                .map(etag_to_string)
+                .ok_or_else(|| Error::other("missing etag"))?;
+            state.uploaded_parts.push(UploadedPart { part_number, e_tag });
+            state.next_part_number += 1;
+            Ok(WriterStep::PartFlushed { state, bytes: part_len })
+        }));
+    }
+
+    fn spawn_commit(&mut self) {
+        self.preserve_live_upload_id();
+
+        let storage = Arc::clone(&self.storage);
+        let bucket = self.bucket.clone();
+        let key = self.key.clone();
+        let credentials = self.credentials.clone();
+        let backend_timeout = self.backend_timeout;
+        let remaining = std::mem::take(&mut self.buffer);
+        let multipart = self.multipart.take();
+
+        self.op_future = Some(Box::pin(async move {
+            if let Some(mut state) = multipart {
+                if !remaining.is_empty() {
+                    if state.next_part_number > S3_MAX_MULTIPART_PARTS {
+                        abort_upload(storage.as_ref(), &bucket, &key, &state.upload_id, &credentials, backend_timeout).await;
+                        return Err(Error::new(ErrorKind::WriteZero, "multipart part limit exceeded"));
+                    }
+                    let part_number = state.next_part_number;
+                    let part_len = remaining.len();
+                    let body_stream = stream::once(async move { Ok::<Bytes, std::io::Error>(Bytes::from(remaining)) });
+                    let streaming = StreamingBlob::wrap(body_stream);
+                    let input = UploadPartInput::builder()
+                        .bucket(bucket.clone())
+                        .key(key.clone())
+                        .upload_id(state.upload_id.clone())
+                        .part_number(part_number)
+                        .content_length(Some(part_len as i64))
+                        .body(Some(streaming))
+                        .build()
+                        .map_err(Error::other)?;
+                    let out = match timeout(backend_timeout, storage.upload_part(input, &credentials)).await {
+                        Ok(Ok(out)) => out,
+                        Ok(Err(e)) => {
+                            abort_upload(storage.as_ref(), &bucket, &key, &state.upload_id, &credentials, backend_timeout).await;
+                            return Err(Error::other(e));
+                        }
+                        Err(_) => {
+                            abort_upload(storage.as_ref(), &bucket, &key, &state.upload_id, &credentials, backend_timeout).await;
+                            return Err(Error::new(ErrorKind::TimedOut, "upload_part timed out"));
+                        }
+                    };
+                    let e_tag = out
+                        .e_tag
+                        .as_ref()
+                        .map(etag_to_string)
+                        .ok_or_else(|| Error::other("missing etag"))?;
+                    state.uploaded_parts.push(UploadedPart { part_number, e_tag });
+                }
+
+                let parts: Vec<S3CompletedPart> = state
+                    .uploaded_parts
+                    .into_iter()
+                    .map(|p| S3CompletedPart {
+                        part_number: Some(p.part_number),
+                        e_tag: Some(ETag::Strong(p.e_tag)),
+                        ..Default::default()
+                    })
+                    .collect();
+                let upload_id = state.upload_id.clone();
+                let input = CompleteMultipartUploadInput::builder()
+                    .bucket(bucket.clone())
+                    .key(key.clone())
+                    .upload_id(upload_id.clone())
+                    .multipart_upload(Some(CompletedMultipartUpload { parts: Some(parts) }))
+                    .build()
+                    .map_err(Error::other)?;
+                match timeout(backend_timeout, storage.complete_multipart_upload(input, &credentials)).await {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(e)) => {
+                        abort_upload(storage.as_ref(), &bucket, &key, &upload_id, &credentials, backend_timeout).await;
+                        return Err(Error::other(e));
+                    }
+                    Err(_) => {
+                        abort_upload(storage.as_ref(), &bucket, &key, &upload_id, &credentials, backend_timeout).await;
+                        return Err(Error::new(ErrorKind::TimedOut, "complete_multipart_upload timed out"));
+                    }
+                }
+            } else {
+                let size = remaining.len() as i64;
+                let body_stream = stream::once(async move { Ok::<Bytes, std::io::Error>(Bytes::from(remaining)) });
+                let streaming = StreamingBlob::wrap(body_stream);
+                let input = PutObjectInput::builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .content_length(Some(size))
+                    .body(Some(streaming))
+                    .build()
+                    .map_err(Error::other)?;
+                timeout(backend_timeout, storage.put_object(input, &credentials))
+                    .await
+                    .map_err(|_| Error::new(ErrorKind::TimedOut, "put_object timed out"))?
+                    .map_err(Error::other)?;
+            }
+            Ok(WriterStep::Committed)
+        }));
+    }
+}
+
+async fn abort_upload<S: StorageBackend + Send + Sync>(
+    storage: &S,
+    bucket: &str,
+    key: &str,
+    upload_id: &str,
+    credentials: &Credentials,
+    backend_timeout: Duration,
+) {
+    let input = match AbortMultipartUploadInput::builder()
+        .bucket(bucket.to_string())
+        .key(key.to_string())
+        .upload_id(upload_id.to_string())
+        .build()
+    {
+        Ok(input) => input,
+        Err(e) => {
+            warn!(
+                event = EVENT_TFTP_ABORT_STATE,
+                component = LOG_COMPONENT_PROTOCOLS,
+                subsystem = LOG_SUBSYSTEM_TFTP_WRITER,
+                bucket = %bucket,
+                key = %key,
+                upload_id = %upload_id,
+                result = "build_failed",
+                error = %e,
+                "tftp abort state changed"
+            );
+            return;
+        }
+    };
+    match timeout(backend_timeout, storage.abort_multipart_upload(input, credentials)).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) if is_no_such_upload_backend_error(&e) => {
+            debug!(
+                event = EVENT_TFTP_ABORT_STATE,
+                component = LOG_COMPONENT_PROTOCOLS,
+                subsystem = LOG_SUBSYSTEM_TFTP_WRITER,
+                bucket = %bucket,
+                key = %key,
+                upload_id = %upload_id,
+                result = "already_aborted",
+                "tftp abort state changed"
+            );
+        }
+        Ok(Err(e)) => {
+            warn!(
+                event = EVENT_TFTP_ABORT_STATE,
+                component = LOG_COMPONENT_PROTOCOLS,
+                subsystem = LOG_SUBSYSTEM_TFTP_WRITER,
+                bucket = %bucket,
+                key = %key,
+                upload_id = %upload_id,
+                result = "failed",
+                error = %e,
+                "tftp abort state changed"
+            );
+        }
+        Err(_) => {
+            warn!(
+                event = EVENT_TFTP_ABORT_STATE,
+                component = LOG_COMPONENT_PROTOCOLS,
+                subsystem = LOG_SUBSYSTEM_TFTP_WRITER,
+                bucket = %bucket,
+                key = %key,
+                upload_id = %upload_id,
+                result = "timed_out",
+                "tftp abort state changed"
+            );
+        }
+    }
+}
+
+fn non_empty_upload_id(upload_id: &str) -> Option<String> {
+    if upload_id.is_empty() {
+        None
+    } else {
+        Some(upload_id.to_owned())
+    }
+}
+
+impl<S: StorageBackend + Send + Sync + 'static> AsyncWrite for ObjectWriter<S> {
+    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<AsyncIoResult<usize>> {
+        if self.completed {
+            return Poll::Ready(Err(ErrorKind::NotConnected.into()));
+        }
+        if self.op_future.is_some() {
+            match self.poll_op(cx) {
+                Poll::Ready(Ok(())) => {}
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+        if let Err(e) = self.check_transfer_limit(buf.len()) {
+            return Poll::Ready(Err(e));
+        }
+
+        self.buffer.extend_from_slice(buf);
+        match self.drive_multipart_flush(cx) {
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(buf.len())),
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<AsyncIoResult<()>> {
+        if self.op_future.is_some() {
+            return match self.poll_op(cx) {
+                Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+                Poll::Pending => Poll::Pending,
+            };
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<AsyncIoResult<()>> {
+        if self.completed {
+            return Poll::Ready(Ok(()));
+        }
+        if self.op_future.is_some() {
+            match self.poll_op(cx) {
+                Poll::Ready(Ok(())) => {}
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        match self.drive_multipart_flush(cx) {
+            Poll::Ready(Ok(())) => {}
+            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+            Poll::Pending => return Poll::Pending,
+        }
+
+        if self.op_future.is_none() {
+            self.spawn_commit();
+        }
+        match self.poll_op(cx) {
+            Poll::Ready(Ok(())) => {
+                debug!(
+                    event = EVENT_TFTP_WRITE_STATE,
+                    component = LOG_COMPONENT_PROTOCOLS,
+                    subsystem = LOG_SUBSYSTEM_TFTP_WRITER,
+                    bucket = %self.bucket,
+                    key = %self.key,
+                    bytes = self.total_bytes(),
+                    result = "committed",
+                    "tftp write state changed"
+                );
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<S: StorageBackend + Send + Sync + 'static> Drop for ObjectWriter<S> {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+        let Some(upload_id) = self.upload_id_for_abort() else {
+            return;
+        };
+        let storage = Arc::clone(&self.storage);
+        let bucket = self.bucket.clone();
+        let key = self.key.clone();
+        let credentials = self.credentials.clone();
+        let backend_timeout = self.backend_timeout;
+
+        if tokio::runtime::Handle::try_current().is_ok() {
+            tokio::spawn(async move {
+                abort_upload(storage.as_ref(), &bucket, &key, &upload_id, &credentials, backend_timeout).await;
+            });
+        } else {
+            warn!(
+                event = EVENT_TFTP_ABORT_STATE,
+                component = LOG_COMPONENT_PROTOCOLS,
+                subsystem = LOG_SUBSYSTEM_TFTP_WRITER,
+                bucket = %bucket,
+                key = %key,
+                upload_id = %upload_id,
+                result = "no_runtime",
+                "tftp abort state changed"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+impl<S: StorageBackend + Send + Sync + 'static> ObjectWriter<S> {
+    fn seed_multipart_for_test(&mut self, upload_id: &str, next_part_number: i32) {
+        self.remember_live_upload_id(upload_id);
+        self.multipart = Some(MultipartState {
+            upload_id: upload_id.to_string(),
+            next_part_number,
+            uploaded_parts: Vec::new(),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::dummy_storage::{AbortCall, DummyBackend, DummyError};
+    use crate::tftp::constants::{S3_MAX_MULTIPART_PARTS, S3_MIN_PART_SIZE};
+    use futures_lite::AsyncWriteExt;
+    use rustfs_credentials::Credentials;
+    use std::io::ErrorKind;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+    const TEST_PART_SIZE: u64 = S3_MIN_PART_SIZE;
+
+    async fn test_permit() -> OwnedSemaphorePermit {
+        Arc::new(Semaphore::new(1)).acquire_owned().await.expect("semaphore permit")
+    }
+
+    async fn build_writer(backend: Arc<DummyBackend>, max_transfer_bytes: u64) -> ObjectWriter<DummyBackend> {
+        ObjectWriter::new(
+            backend,
+            "b".to_string(),
+            "k".to_string(),
+            Credentials::default(),
+            TEST_PART_SIZE,
+            max_transfer_bytes,
+            Duration::from_secs(30),
+            test_permit().await,
+        )
+    }
+
+    async fn drain_drop_abort_tasks() {
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+    }
+
+    fn multipart_payload(extra: usize) -> Vec<u8> {
+        vec![0u8; TEST_PART_SIZE as usize + extra]
+    }
+
+    #[tokio::test]
+    async fn close_small_object_uses_put_object_without_abort() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_put_object_ok();
+        let mut writer = build_writer(backend.clone(), TEST_PART_SIZE * 2).await;
+
+        writer.write_all(b"small-payload").await.expect("write");
+        writer.close().await.expect("close");
+
+        assert_eq!(backend.put_object_calls().len(), 1);
+        assert!(backend.create_multipart_calls().is_empty());
+        assert!(backend.abort_multipart_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn close_multipart_object_completes_without_abort() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_create_multipart_upload_ok("UP-OK");
+        backend.queue_upload_part_ok("etag-full");
+        backend.queue_upload_part_ok("etag-tail");
+        backend.queue_complete_multipart_upload_ok();
+        let mut writer = build_writer(backend.clone(), TEST_PART_SIZE * 4).await;
+
+        writer
+            .write_all(&multipart_payload(512))
+            .await
+            .expect("write multipart payload");
+        writer.close().await.expect("close");
+
+        assert_eq!(backend.create_multipart_calls().len(), 1);
+        assert_eq!(backend.upload_part_calls().len(), 2);
+        assert_eq!(backend.complete_multipart_calls().len(), 1);
+        assert!(backend.put_object_calls().is_empty());
+        assert!(backend.abort_multipart_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn close_complete_multipart_err_aborts_once() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_create_multipart_upload_ok("UP-COMPLETE-ERR");
+        backend.queue_upload_part_ok("etag-full");
+        backend.queue_upload_part_ok("etag-tail");
+        backend.queue_complete_multipart_upload_err(DummyError::Injected("complete failed".into()));
+        let mut writer = build_writer(backend.clone(), TEST_PART_SIZE * 4).await;
+
+        writer.write_all(&multipart_payload(1)).await.expect("write");
+        let err = writer.close().await.expect_err("complete failure must propagate");
+        assert_eq!(err.kind(), ErrorKind::Other);
+
+        let aborts = backend.abort_multipart_calls();
+        assert_eq!(aborts.len(), 1);
+        assert_eq!(aborts[0].upload_id, "UP-COMPLETE-ERR");
+    }
+
+    #[tokio::test]
+    async fn flush_upload_part_err_aborts_without_complete() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_create_multipart_upload_ok("UP-FLUSH-ERR");
+        backend.queue_upload_part_err(DummyError::Injected("flush upload failed".into()));
+        let mut writer = build_writer(backend.clone(), TEST_PART_SIZE * 4).await;
+
+        let err = writer
+            .write_all(&multipart_payload(1))
+            .await
+            .expect_err("flush UploadPart failure must propagate");
+        assert_eq!(err.kind(), ErrorKind::Other);
+
+        let aborts = backend.abort_multipart_calls();
+        assert_eq!(aborts.len(), 1);
+        assert_eq!(aborts[0].upload_id, "UP-FLUSH-ERR");
+        assert!(backend.complete_multipart_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn trailing_upload_part_err_aborts_without_complete() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_create_multipart_upload_ok("UP-TAIL-ERR");
+        backend.queue_upload_part_ok("etag-full");
+        backend.queue_upload_part_err(DummyError::Injected("trailing upload failed".into()));
+        let mut writer = build_writer(backend.clone(), TEST_PART_SIZE * 4).await;
+
+        writer.write_all(&multipart_payload(128)).await.expect("write");
+        let err = writer.close().await.expect_err("trailing UploadPart failure must propagate");
+        assert_eq!(err.kind(), ErrorKind::Other);
+
+        let aborts = backend.abort_multipart_calls();
+        assert_eq!(aborts.len(), 1);
+        assert_eq!(aborts[0].upload_id, "UP-TAIL-ERR");
+        assert!(backend.complete_multipart_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn flush_part_limit_exceeded_aborts_with_write_zero() {
+        let backend = Arc::new(DummyBackend::new());
+        let mut writer = build_writer(backend.clone(), TEST_PART_SIZE * 4).await;
+        writer.seed_multipart_for_test("UP-PART-LIMIT", S3_MAX_MULTIPART_PARTS + 1);
+
+        let err = writer
+            .write_all(&vec![0u8; TEST_PART_SIZE as usize])
+            .await
+            .expect_err("part limit must fail");
+        assert_eq!(err.kind(), ErrorKind::WriteZero);
+
+        let aborts = backend.abort_multipart_calls();
+        assert_eq!(aborts.len(), 1);
+        assert_eq!(aborts[0].upload_id, "UP-PART-LIMIT");
+    }
+
+    #[tokio::test]
+    async fn trailing_part_limit_exceeded_aborts_with_write_zero() {
+        let backend = Arc::new(DummyBackend::new());
+        let mut writer = build_writer(backend.clone(), TEST_PART_SIZE * 4).await;
+        writer.seed_multipart_for_test("UP-TAIL-LIMIT", S3_MAX_MULTIPART_PARTS + 1);
+
+        writer.write_all(b"tail").await.expect("buffer trailing bytes");
+        let err = writer.close().await.expect_err("trailing part limit must fail");
+        assert_eq!(err.kind(), ErrorKind::WriteZero);
+
+        let aborts = backend.abort_multipart_calls();
+        assert_eq!(aborts.len(), 1);
+        assert_eq!(aborts[0].upload_id, "UP-TAIL-LIMIT");
+    }
+
+    #[tokio::test]
+    async fn write_exceeding_max_transfer_bytes_returns_write_zero() {
+        let backend = Arc::new(DummyBackend::new());
+        let mut writer = build_writer(backend.clone(), 128).await;
+
+        let err = writer.write_all(&vec![0u8; 129]).await.expect_err("transfer limit must fail");
+        assert_eq!(err.kind(), ErrorKind::WriteZero);
+        assert!(backend.put_object_calls().is_empty());
+        assert!(backend.abort_multipart_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn drop_incomplete_multipart_aborts_once() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_create_multipart_upload_ok("UP-DROP");
+        backend.queue_upload_part_ok("etag-full");
+        let writer = build_writer(backend.clone(), TEST_PART_SIZE * 4).await;
+        let mut writer = writer;
+        writer.write_all(&multipart_payload(1)).await.expect("write one flushed part");
+
+        drop(writer);
+        drain_drop_abort_tasks().await;
+
+        let aborts = backend.abort_multipart_calls();
+        assert_eq!(aborts.len(), 1);
+        let AbortCall { bucket, key, upload_id } = &aborts[0];
+        assert_eq!(bucket, "b");
+        assert_eq!(key, "k");
+        assert_eq!(upload_id, "UP-DROP");
+    }
+
+    #[tokio::test]
+    async fn drop_put_object_path_does_not_abort() {
+        let backend = Arc::new(DummyBackend::new());
+        let mut writer = build_writer(backend.clone(), TEST_PART_SIZE * 2).await;
+        writer.write_all(b"uncommitted-small").await.expect("write");
+
+        drop(writer);
+        drain_drop_abort_tasks().await;
+
+        assert!(backend.abort_multipart_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn drop_after_successful_close_does_not_abort() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_put_object_ok();
+        let mut writer = build_writer(backend.clone(), TEST_PART_SIZE * 2).await;
+        writer.write_all(b"committed-small").await.expect("write");
+        writer.close().await.expect("close");
+
+        drop(writer);
+        drain_drop_abort_tasks().await;
+
+        assert!(backend.abort_multipart_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn drop_during_in_flight_upload_part_aborts_via_live_upload_id() {
+        let backend = Arc::new(DummyBackend::new());
+        backend.queue_create_multipart_upload_ok("UP-LIVE");
+        let entered = Arc::new(tokio::sync::Notify::new());
+        backend.stall_upload_part(entered.clone());
+
+        let mut writer = build_writer(backend.clone(), TEST_PART_SIZE * 4).await;
+        let payload = multipart_payload(1);
+        let write_fut = writer.write_all(&payload);
+
+        tokio::select! {
+            biased;
+            _ = entered.notified() => {
+                drop(writer);
+            }
+            result = write_fut => {
+                panic!("write must stall inside upload_part, got: {result:?}");
+            }
+        }
+
+        drain_drop_abort_tasks().await;
+
+        let aborts = backend.abort_multipart_calls();
+        assert_eq!(aborts.len(), 1, "Drop during in-flight UploadPart must abort once");
+        assert_eq!(aborts[0].upload_id, "UP-LIVE");
+    }
+}

--- a/docs/operations/tftp-transfer-model.md
+++ b/docs/operations/tftp-transfer-model.md
@@ -1,0 +1,187 @@
+# TFTP transfer model (RRQ)
+
+Code entry points:
+
+| Layer | Path |
+| --- | --- |
+| Server bind / library knobs | `crates/protocols/src/tftp/server.rs` (`TftpServer::start`) |
+| Handler open paths | `crates/protocols/src/tftp/handler.rs` (`TftpStorageHandler`) |
+| RRQ streaming | `crates/protocols/src/tftp/reader.rs` (`ObjectReader`) |
+| Env clamp bounds | `crates/protocols/src/tftp/constants.rs` |
+| Defaults / env names | `crates/config/src/constants/protocols.rs` |
+
+Documentation: [tftp.md](tftp.md).
+
+---
+
+## Parameter map
+
+| Knob | Where it applies | Meaning |
+| --- | --- | --- |
+| `RUSTFS_TFTP_MAX_BLOCK_SIZE` | `async-tftp` `block_size_limit` | Ceiling for negotiated RFC 2348 `blksize` (`min(client, limit)`). |
+| `RUSTFS_TFTP_MAX_WINDOW_SIZE` | `async-tftp` `window_size_limit` | Ceiling for negotiated RFC 7440 `windowsize`. |
+| `RUSTFS_TFTP_MAX_SEND_RETRIES` | `async-tftp` `max_send_retries` | UDP retransmit attempts after timeout before giving up (default 5 ≈ 18s with 3s timeout). |
+| `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS` | RustFS `Semaphore` | Max simultaneous RRQ handlers; excess get TFTP `DiskFull`. |
+| `RUSTFS_TFTP_READ_FETCH_BYTES` | `ObjectReader` fetch window | Max bytes per ranged GET. |
+| `RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS` | every S3 call in reader/handler | Per-call backend deadline. |
+
+RRQ peak memory ≈ one `read_fetch_bytes` buffer per transfer.
+
+---
+
+## RRQ sequence (read)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as TFTP client
+    participant L as async-tftp
+    participant H as TftpStorageHandler
+    participant R as ObjectReader
+    participant S as StorageBackend
+
+    C->>L: RRQ path + opts (blksize, windowsize, tsize, ...)
+    L->>H: read_req_open(client, path)
+    H->>H: access_mode + try_acquire permit
+    H->>H: resolve path → (bucket, key)
+    H->>H: authorize GetObject
+    H->>S: HeadObject (backend timeout)
+    S-->>H: content_length
+    H-->>L: ObjectReader + Some(object_size)
+    L->>C: OACK (negotiated opts) or DATA (no opts)
+
+    loop until EOF
+        L->>R: AsyncRead::poll_read (up to blksize)
+        alt buffer empty
+            R->>S: GetObject range [offset, offset+fetch_bytes)
+            S-->>R: body chunks → buffer
+        end
+        R-->>L: bytes
+        L->>C: DATA block(s) for current window
+        C->>L: ACK (last block of window)
+    end
+
+    Note over H,R: permit released when ObjectReader drops
+```
+
+Notes:
+
+- `async-tftp` drives the UDP window; RustFS only fills bytes on demand.
+- `object_size` from HEAD bounds the reader; unexpected empty range before EOF is an error.
+- Failed open (auth, missing object, no permit) returns a TFTP ERROR via the library; no S3 object body is started.
+- WRQ requests are rejected with TFTP `Illegal operation` until upload support lands.
+
+---
+
+## Layering diagram
+
+```text
+  Client (atftp / firmware)          UDP :6969 (or :69)
+           │
+           ▼
+   ┌───────────────────┐
+   │     async-tftp    │  blksize / windowsize / retries / OACK
+   │  RRQ tasks        │
+   └─────────┬─────────┘
+             │ Handler trait
+             ▼
+   ┌───────────────────┐
+   │ TftpStorageHandler│  IAM, path, semaphore
+   └─────────┬─────────┘
+             │
+             ▼
+      ObjectReader
+      ranged GET
+             │
+             ▼
+        StorageBackend (S3 API)
+```
+
+---
+
+## Known `async-tftp` issues and fork branches
+
+Work tracked against crates.io `async-tftp` **0.4.2**. Three branches are pushed
+to [ylw510/async-tftp-rs](https://github.com/ylw510/async-tftp-rs).
+
+| Branch | Commit | Remote |
+| --- | --- | --- |
+| `fix/abort-on-peer-error` | `c8135e5` | `origin/fix/abort-on-peer-error` |
+| `fix/window-retransmit-unacked-suffix` | `dceebe3` | `origin/fix/window-retransmit-unacked-suffix` |
+| `feat/wrq-windowsize` | `dabfc09` | `origin/feat/wrq-windowsize` |
+
+All three branches fork from `master` independently. Combine or rebase before
+a single release pin.
+
+### 1. `fix/abort-on-peer-error` (commit `c8135e5`)
+
+- **Branch:** [ylw510/async-tftp-rs `fix/abort-on-peer-error`](https://github.com/ylw510/async-tftp-rs/tree/fix/abort-on-peer-error) — after OACK,
+  client may send TFTP ERROR (e.g. RFC 2347 code 8). Stock `recv_ack` ignored
+  non-ACK packets → server waited forever for ACK#0.
+- **Fix:** treat `Packet::Error` as `Error::ClientAborted` on RRQ ACK wait and
+  WRQ DATA wait; do **not** echo another ERROR.
+- **RFCs:** RFC 2347 / 2348 (reject OACK → ERROR 8 terminates); RFC 1350 §7.
+
+### 2. `fix/window-retransmit-unacked-suffix` (commit `dceebe3`)
+
+- **Branch:** [ylw510/async-tftp-rs `fix/window-retransmit-unacked-suffix`](https://github.com/ylw510/async-tftp-rs/tree/fix/window-retransmit-unacked-suffix) —
+  `windowsize > 1` (e.g. 32) with `atftp` → `got wrong block` on lossy/late ACK.
+- **Cause:** RRQ `send_window` retransmitted the **entire** window on timeout.
+- **Fix:** track partial ACK progress; on timeout retransmit only the **unacked
+  suffix** (RFC 7440 §4).
+
+### 3. `feat/wrq-windowsize` (commit `dabfc09`)
+
+- **Branch:** [ylw510/async-tftp-rs `feat/wrq-windowsize`](https://github.com/ylw510/async-tftp-rs/tree/feat/wrq-windowsize) — stock `async-tftp` 0.4.2 negotiates `windowsize` on RRQ but WRQ still
+  ACKed every DATA block (`windowsize` effectively 1 on upload).
+- **Fix:** negotiate `windowsize` in WRQ OACK; receive up to N blocks per window
+  (`recv_window`), ACK once per window; `atftp` WRQ tests in `src/tests/wrq.rs`.
+
+Related residual behavior (not a separate branch): illegal / out-of-range
+`blksize` may be **silently dropped** at parse time (`8..=65464`). That is
+RFC-allowed (“unacknowledged option = never requested”) but can confuse clients
+that print a requested option and then negotiate something else.
+
+---
+
+## Dependency strategy
+
+This PR adds TFTP RRQ support to RustFS. The three fork branches above are
+enhancements to [`async-tftp`](https://crates.io/crates/async-tftp) (the UDP
+wire-protocol dependency). This PR may need to choose one of the following
+approaches for how RustFS takes those fixes:
+
+### (1) Merge into upstream `async-tftp` first (preferred long-term)
+
+1. Open PRs on [oblique/async-tftp-rs](https://github.com/oblique/async-tftp-rs)
+   from the three [ylw510/async-tftp-rs](https://github.com/ylw510/async-tftp-rs)
+   branches (combine or rebase first).
+2. Wait for a crates.io release (or pin a git revision of upstream).
+3. Point RustFS `Cargo.toml` at that version; drop any local `path` override.
+
+Pros: shared fix for all consumers; no vendored fork drift.
+Cons: release latency; RustFS may ship with known limits until the release lands.
+
+### (2) Maintain `async-tftp` under the RustFS org
+
+Host a fork under the official [rustfs](https://github.com/rustfs) GitHub org
+(for example `rustfs/async-tftp-rs`): merge the three
+[ylw510/async-tftp-rs](https://github.com/ylw510/async-tftp-rs) branches there,
+then pin RustFS to that repo via a git dependency in `Cargo.toml`.
+
+Pros: RustFS controls release timing without waiting on oblique/async-tftp-rs;
+wire fixes ship with the TFTP sidecar PR while staying out of the main tree.
+Cons: ongoing merge cost vs upstream oblique/async-tftp-rs; the org repo needs
+its own CI and release tagging.
+
+### (3) Ship with stock 0.4.2 now; upstream merge for a later bump
+
+For this PR, ignore the three fork branches and keep crates.io
+`async-tftp = "0.4.2"`. In parallel, follow (1): open PRs on
+[oblique/async-tftp-rs](https://github.com/oblique/async-tftp-rs) from the
+[ylw510/async-tftp-rs](https://github.com/ylw510/async-tftp-rs) branches.
+Once upstream merges and publishes a new release, bump RustFS `Cargo.toml` to
+that version in a follow-up change.
+
+Until that release lands, known wire-protocol gaps remain; see
+[tftp.md](tftp.md#known-limitations-stock-async-tftp-042).

--- a/docs/operations/tftp-transfer-model.md
+++ b/docs/operations/tftp-transfer-model.md
@@ -1,4 +1,4 @@
-# TFTP transfer model (RRQ)
+# TFTP transfer model (RRQ / WRQ)
 
 Code entry points:
 
@@ -7,6 +7,7 @@ Code entry points:
 | Server bind / library knobs | `crates/protocols/src/tftp/server.rs` (`TftpServer::start`) |
 | Handler open paths | `crates/protocols/src/tftp/handler.rs` (`TftpStorageHandler`) |
 | RRQ streaming | `crates/protocols/src/tftp/reader.rs` (`ObjectReader`) |
+| WRQ streaming | `crates/protocols/src/tftp/writer.rs` (`ObjectWriter`) |
 | Env clamp bounds | `crates/protocols/src/tftp/constants.rs` |
 | Defaults / env names | `crates/config/src/constants/protocols.rs` |
 
@@ -21,11 +22,16 @@ Documentation: [tftp.md](tftp.md).
 | `RUSTFS_TFTP_MAX_BLOCK_SIZE` | `async-tftp` `block_size_limit` | Ceiling for negotiated RFC 2348 `blksize` (`min(client, limit)`). |
 | `RUSTFS_TFTP_MAX_WINDOW_SIZE` | `async-tftp` `window_size_limit` | Ceiling for negotiated RFC 7440 `windowsize`. |
 | `RUSTFS_TFTP_MAX_SEND_RETRIES` | `async-tftp` `max_send_retries` | UDP retransmit attempts after timeout before giving up (default 5 ≈ 18s with 3s timeout). |
-| `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS` | RustFS `Semaphore` | Max simultaneous RRQ handlers; excess get TFTP `DiskFull`. |
-| `RUSTFS_TFTP_READ_FETCH_BYTES` | `ObjectReader` fetch window | Max bytes per ranged GET. |
-| `RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS` | every S3 call in reader/handler | Per-call backend deadline. |
+| `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS` | RustFS `Semaphore` | Max simultaneous RRQ+WRQ handlers; excess get TFTP `DiskFull`. |
+| `RUSTFS_TFTP_MAX_TRANSFER_BYTES` | `ObjectWriter` (+ client `tsize`) | Per-WRQ byte ceiling; effective limit is `min(tsize, config)` when `tsize` is present. |
+| `RUSTFS_TFTP_READ_FETCH_BYTES` | `ObjectReader` fetch window; also WRQ `part_size` floor input | RRQ: max bytes per ranged GET. WRQ: `part_size = max(read_fetch_bytes, S3_MIN_PART_SIZE)`. |
+| `RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS` | every S3 call in reader/writer/handler | Per-call backend deadline. |
+| `S3_MIN_PART_SIZE` / `S3_MAX_MULTIPART_PARTS` | `ObjectWriter` | S3 multipart contract (5 MiB non-final parts; ≤ 10000 parts). |
 
-RRQ peak memory ≈ one `read_fetch_bytes` buffer per transfer.
+Read/write peak memory:
+
+- RRQ peak ≈ one `read_fetch_bytes` buffer per transfer.
+- WRQ peak ≈ one `part_size` buffer per transfer (multipart), plus library UDP window buffers sized by `blksize × windowsize`.
 
 ---
 
@@ -69,7 +75,63 @@ Notes:
 - `async-tftp` drives the UDP window; RustFS only fills bytes on demand.
 - `object_size` from HEAD bounds the reader; unexpected empty range before EOF is an error.
 - Failed open (auth, missing object, no permit) returns a TFTP ERROR via the library; no S3 object body is started.
-- WRQ requests are rejected with TFTP `Illegal operation` until upload support lands.
+
+---
+
+## WRQ sequence (write)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as TFTP client
+    participant L as async-tftp
+    participant H as TftpStorageHandler
+    participant W as ObjectWriter
+    participant S as StorageBackend
+
+    C->>L: WRQ path + opts (incl. optional tsize)
+    L->>H: write_req_open(client, path, size)
+    H->>H: access_mode + try_acquire permit
+    H->>H: resolve path → (bucket, key)
+    H->>H: authorize PutObject
+    H-->>L: ObjectWriter (max_bytes = min(tsize, max_transfer_bytes))
+    L->>C: OACK / ACK#0
+
+    loop until last DATA
+        C->>L: DATA block(s) for window
+        L->>W: AsyncWrite::poll_write
+        W->>W: append buffer; enforce max_transfer_bytes
+        alt buffer >= part_size
+            opt first flush
+                W->>S: CreateMultipartUpload
+            end
+            W->>S: UploadPart
+            S-->>W: ETag
+        end
+        L->>C: ACK last block of window
+    end
+
+    L->>W: AsyncWrite::close (success path only)
+    alt never started multipart (small object)
+        W->>S: PutObject(buffer)
+    else multipart
+        W->>S: UploadPart(remainder) if any
+        W->>S: CompleteMultipartUpload
+    end
+    W-->>L: Ok (completed=true)
+
+    Note over W: Drop without close → AbortMultipartUpload if upload_id exists
+```
+
+Commit vs abort:
+
+| Outcome | What happens |
+| --- | --- |
+| Full WRQ + library `close()` | `PutObject` or `CompleteMultipartUpload`; object is visible. |
+| Timeout, peer ERROR, I/O error, drop without close | No commit. If multipart started, `Drop` spawns `AbortMultipartUpload`. |
+| Over `max_transfer_bytes` or > 10000 parts | Write fails; multipart aborted if started. |
+
+TFTP is UDP: cleanup is **per transfer** (`ObjectWriter` lifetime), not a session teardown like SFTP.
 
 ---
 
@@ -81,7 +143,7 @@ Notes:
            ▼
    ┌───────────────────┐
    │     async-tftp    │  blksize / windowsize / retries / OACK
-   │  RRQ tasks        │
+   │  RRQ/WRQ tasks    │
    └─────────┬─────────┘
              │ Handler trait
              ▼
@@ -89,10 +151,12 @@ Notes:
    │ TftpStorageHandler│  IAM, path, semaphore
    └─────────┬─────────┘
              │
-             ▼
-      ObjectReader
-      ranged GET
-             │
+      ┌──────┴──────┐
+      ▼             ▼
+ ObjectReader   ObjectWriter
+ ranged GET     PutObject / MPU
+      │             │
+      └──────┬──────┘
              ▼
         StorageBackend (S3 API)
 ```
@@ -146,7 +210,7 @@ that print a requested option and then negotiate something else.
 
 ## Dependency strategy
 
-This PR adds TFTP RRQ support to RustFS. The three fork branches above are
+This PR adds TFTP support to RustFS. The three fork branches above are
 enhancements to [`async-tftp`](https://crates.io/crates/async-tftp) (the UDP
 wire-protocol dependency). This PR may need to choose one of the following
 approaches for how RustFS takes those fixes:

--- a/docs/operations/tftp.md
+++ b/docs/operations/tftp.md
@@ -2,9 +2,9 @@
 
 RustFS exposes an optional UDP TFTP sidecar for PXE boot file serving and
 similar read-mostly workflows. The implementation uses the [`async-tftp`](https://crates.io/crates/async-tftp)
-crate and maps RRQ transfers to the S3 storage API.
+crate and maps transfers to the S3 storage API.
 
-For RRQ sequence diagrams, env-knob meaning, and `async-tftp` dependency
+For RRQ/WRQ sequence diagrams, env-knob meaning, and `async-tftp` dependency
 options, see [TFTP transfer model](tftp-transfer-model.md).
 
 ## Enable
@@ -19,12 +19,12 @@ export RUSTFS_TFTP_ADDRESS=0.0.0.0:6969
 export RUSTFS_TFTP_ACCESS_KEY=<service-account-access-key>
 export RUSTFS_TFTP_SECRET_KEY=<service-account-secret-key>
 export RUSTFS_TFTP_DEFAULT_BUCKET=pxe-boot
-export RUSTFS_TFTP_ACCESS_MODE=ro   # ro | wo | rw (WRQ not yet supported)
+export RUSTFS_TFTP_ACCESS_MODE=ro   # ro | wo | rw
 ```
 
 ## Path mapping
 
-| `RUSTFS_TFTP_DEFAULT_BUCKET` | Client RRQ filename | Resolved object |
+| `RUSTFS_TFTP_DEFAULT_BUCKET` | Client RRQ/WRQ filename | Resolved object |
 | --- | --- | --- |
 | `pxe-boot` | `pxelinux.0` | bucket `pxe-boot`, key `pxelinux.0` |
 | unset | `/mybucket/boot/vmlinuz` | bucket `mybucket`, key `boot/vmlinuz` |
@@ -41,11 +41,14 @@ Temporary STS credentials are rejected at startup.
 ## Transfer semantics
 
 - **RRQ**: streamed ranged `GetObject` reads with bounded memory.
-- **WRQ**: not supported in this release; clients receive TFTP
-  `Illegal operation`.
+- **WRQ**: streamed multipart upload; **commit happens only on successful
+  `close()`** after the full transfer completes. Failed or timed-out WRQs
+  abort in-progress multipart uploads and never commit partial objects.
 - Concurrent transfers are capped by `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS`.
-- RRQ block size and window size are negotiated with the client; RustFS caps
-  them via `RUSTFS_TFTP_MAX_BLOCK_SIZE` and `RUSTFS_TFTP_MAX_WINDOW_SIZE`.
+- Per-transfer size is capped by `RUSTFS_TFTP_MAX_TRANSFER_BYTES` and the
+  client-advertised `tsize` option when present.
+- RRQ/WRQ block size and window size are negotiated with the client; RustFS
+  caps them via `RUSTFS_TFTP_MAX_BLOCK_SIZE` and `RUSTFS_TFTP_MAX_WINDOW_SIZE`.
 
 ## Environment reference
 
@@ -56,10 +59,11 @@ Temporary STS credentials are rejected at startup.
 | `RUSTFS_TFTP_ACCESS_KEY` | (required) | IAM access key for authorization |
 | `RUSTFS_TFTP_SECRET_KEY` | (required) | Secret for the access key |
 | `RUSTFS_TFTP_DEFAULT_BUCKET` | unset | Lock all requests to one bucket |
-| `RUSTFS_TFTP_ACCESS_MODE` | `ro` | `ro`, `wo`, or `rw` (WRQ pending follow-up) |
+| `RUSTFS_TFTP_ACCESS_MODE` | `ro` | `ro`, `wo`, or `rw` |
 | `RUSTFS_TFTP_MAX_BLOCK_SIZE` | `65464` | RFC 2348 block size ceiling |
 | `RUSTFS_TFTP_MAX_WINDOW_SIZE` | `65535` | RFC 7440 window size ceiling |
-| `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS` | `64` | Concurrent RRQ limit |
+| `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS` | `64` | Concurrent RRQ/WRQ limit |
+| `RUSTFS_TFTP_MAX_TRANSFER_BYTES` | `268435456` | Per-transfer byte ceiling (256 MiB) |
 | `RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS` | `60` | S3 call timeout |
 | `RUSTFS_TFTP_READ_FETCH_BYTES` | `4194304` | RRQ read-ahead window (4 MiB) |
 
@@ -78,4 +82,4 @@ Until upstream fixes are released or the crate is vendored with patches, use:
 | Out-of-range `blksize` may be silently ignored at parse time | Send only RFC-valid block sizes |
 
 Details, local fix branches, and merge-vs-vendor-vs-document options:
-[tftp-transfer-model.md](tftp-transfer-model.md#known-async-tftp-issues-and-fork-branches).
+[tftp-transfer-model.md](tftp-transfer-model.md#known-async-tftp-issues-and-local-branches).

--- a/docs/operations/tftp.md
+++ b/docs/operations/tftp.md
@@ -1,0 +1,81 @@
+# TFTP (Trivial File Transfer Protocol)
+
+RustFS exposes an optional UDP TFTP sidecar for PXE boot file serving and
+similar read-mostly workflows. The implementation uses the [`async-tftp`](https://crates.io/crates/async-tftp)
+crate and maps RRQ transfers to the S3 storage API.
+
+For RRQ sequence diagrams, env-knob meaning, and `async-tftp` dependency
+options, see [TFTP transfer model](tftp-transfer-model.md).
+
+## Enable
+
+Build with the `tftp` feature and set environment variables at runtime:
+
+```bash
+cargo build --release --bin rustfs --features tftp
+
+export RUSTFS_TFTP_ENABLE=true
+export RUSTFS_TFTP_ADDRESS=0.0.0.0:6969
+export RUSTFS_TFTP_ACCESS_KEY=<service-account-access-key>
+export RUSTFS_TFTP_SECRET_KEY=<service-account-secret-key>
+export RUSTFS_TFTP_DEFAULT_BUCKET=pxe-boot
+export RUSTFS_TFTP_ACCESS_MODE=ro   # ro | wo | rw (WRQ not yet supported)
+```
+
+## Path mapping
+
+| `RUSTFS_TFTP_DEFAULT_BUCKET` | Client RRQ filename | Resolved object |
+| --- | --- | --- |
+| `pxe-boot` | `pxelinux.0` | bucket `pxe-boot`, key `pxelinux.0` |
+| unset | `/mybucket/boot/vmlinuz` | bucket `mybucket`, key `boot/vmlinuz` |
+
+Both modes apply the same key validation (control characters and internal
+`__XLDIR__` markers are rejected).
+
+## Security
+
+TFTP has **no wire authentication**. Restrict access at the network layer
+(PXE VLAN only) and use a dedicated IAM identity with least privilege.
+Temporary STS credentials are rejected at startup.
+
+## Transfer semantics
+
+- **RRQ**: streamed ranged `GetObject` reads with bounded memory.
+- **WRQ**: not supported in this release; clients receive TFTP
+  `Illegal operation`.
+- Concurrent transfers are capped by `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS`.
+- RRQ block size and window size are negotiated with the client; RustFS caps
+  them via `RUSTFS_TFTP_MAX_BLOCK_SIZE` and `RUSTFS_TFTP_MAX_WINDOW_SIZE`.
+
+## Environment reference
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTFS_TFTP_ENABLE` | `false` | Master switch |
+| `RUSTFS_TFTP_ADDRESS` | `0.0.0.0:6969` | UDP bind address |
+| `RUSTFS_TFTP_ACCESS_KEY` | (required) | IAM access key for authorization |
+| `RUSTFS_TFTP_SECRET_KEY` | (required) | Secret for the access key |
+| `RUSTFS_TFTP_DEFAULT_BUCKET` | unset | Lock all requests to one bucket |
+| `RUSTFS_TFTP_ACCESS_MODE` | `ro` | `ro`, `wo`, or `rw` (WRQ pending follow-up) |
+| `RUSTFS_TFTP_MAX_BLOCK_SIZE` | `65464` | RFC 2348 block size ceiling |
+| `RUSTFS_TFTP_MAX_WINDOW_SIZE` | `65535` | RFC 7440 window size ceiling |
+| `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS` | `64` | Concurrent RRQ limit |
+| `RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS` | `60` | S3 call timeout |
+| `RUSTFS_TFTP_READ_FETCH_BYTES` | `4194304` | RRQ read-ahead window (4 MiB) |
+
+Port **69** requires `CAP_NET_BIND_SERVICE` or root on Linux; the default
+uses **6969** so the sidecar can start without extra capabilities.
+
+## Known limitations (stock `async-tftp` 0.4.2)
+
+These are wire-protocol behaviors in `async-tftp`, not RustFS S3 mapping bugs.
+Until upstream fixes are released or the crate is vendored with patches, use:
+
+| Limitation | Practical workaround |
+| --- | --- |
+| `windowsize > 1` can fail with client `got wrong block` after lossy/late ACK | Use `--option "windowsize 1"`; raise `blksize` (up to 65464) for speed |
+| Client TFTP ERROR after OACK may leave the server waiting for ACK#0 | Do not reject OACK; keep `blksize` in `8..=65464` and aligned with `RUSTFS_TFTP_MAX_BLOCK_SIZE` |
+| Out-of-range `blksize` may be silently ignored at parse time | Send only RFC-valid block sizes |
+
+Details, local fix branches, and merge-vs-vendor-vs-document options:
+[tftp-transfer-model.md](tftp-transfer-model.md#known-async-tftp-issues-and-fork-branches).

--- a/rustfs/Cargo.toml
+++ b/rustfs/Cargo.toml
@@ -64,10 +64,11 @@ ftps = ["rustfs-protocols/ftps"]
 swift = ["rustfs-protocols/swift"]
 webdav = ["rustfs-protocols/webdav"]
 sftp = ["rustfs-protocols/sftp"]
+tftp = ["rustfs-protocols/tftp"]
 license = []
 io-scheduler-debug = []  # Enable debug information in I/O scheduler
 tracing-chunk-debug = []  # Enable per-chunk tracing in data plane (high noise, for debugging only)
-full = ["metrics-gpu", "ftps", "swift", "webdav", "sftp", "pyroscope", "gcs"]
+full = ["metrics-gpu", "ftps", "swift", "webdav", "sftp", "tftp", "pyroscope", "gcs"]
 e2e-test-hooks = ["rustfs-ecstore/e2e-test-hooks"]
 # Shortens Connect credentials only in debug E2E builds.
 connect-e2e-short-credentials = []

--- a/rustfs/src/config/info.rs
+++ b/rustfs/src/config/info.rs
@@ -636,6 +636,13 @@ fn feature_specs() -> &'static [FeatureSpec] {
             default_enabled: false,
         },
         FeatureSpec {
+            name: "tftp",
+            enabled: cfg!(feature = "tftp"),
+            description: "TFTP protocol support (PXE boot file serving)",
+            dependencies: "rustfs-protocols/tftp",
+            default_enabled: false,
+        },
+        FeatureSpec {
             name: "license",
             enabled: cfg!(feature = "license"),
             description: "License validation",
@@ -660,7 +667,7 @@ fn feature_specs() -> &'static [FeatureSpec] {
             name: "full",
             enabled: cfg!(feature = "full"),
             description: "Full protocol and observability bundle",
-            dependencies: "metrics-gpu + ftps + swift + webdav + sftp + pyroscope",
+            dependencies: "metrics-gpu + ftps + swift + webdav + sftp + tftp + pyroscope",
             default_enabled: false,
         },
         FeatureSpec {

--- a/rustfs/src/init.rs
+++ b/rustfs/src/init.rs
@@ -1380,7 +1380,8 @@ pub async fn init_tftp_system() -> Result<Option<ShutdownHandle>, Box<dyn std::e
     use rustfs_config::{
         DEFAULT_TFTP_ADDRESS, ENV_TFTP_ACCESS_KEY, ENV_TFTP_ACCESS_MODE, ENV_TFTP_ADDRESS, ENV_TFTP_BACKEND_OP_TIMEOUT_SECS,
         ENV_TFTP_DEFAULT_BUCKET, ENV_TFTP_ENABLE, ENV_TFTP_MAX_BLOCK_SIZE, ENV_TFTP_MAX_CONCURRENT_TRANSFERS,
-        ENV_TFTP_MAX_SEND_RETRIES, ENV_TFTP_MAX_WINDOW_SIZE, ENV_TFTP_READ_FETCH_BYTES, ENV_TFTP_SECRET_KEY,
+        ENV_TFTP_MAX_SEND_RETRIES, ENV_TFTP_MAX_TRANSFER_BYTES, ENV_TFTP_MAX_WINDOW_SIZE, ENV_TFTP_READ_FETCH_BYTES,
+        ENV_TFTP_SECRET_KEY,
     };
     use rustfs_protocols::common::session::{Protocol, ProtocolPrincipal, SessionContext, is_temporary_credential};
     use rustfs_protocols::{TftpConfig, TftpServer, TftpStorageHandler};
@@ -1440,6 +1441,9 @@ pub async fn init_tftp_system() -> Result<Option<ShutdownHandle>, Box<dyn std::e
     let max_concurrent_transfers = TftpConfig::resolve_max_concurrent_transfers(
         rustfs_utils::get_env_opt_str(ENV_TFTP_MAX_CONCURRENT_TRANSFERS).and_then(|v| v.parse::<usize>().ok()),
     );
+    let max_transfer_bytes = TftpConfig::resolve_max_transfer_bytes(
+        rustfs_utils::get_env_opt_str(ENV_TFTP_MAX_TRANSFER_BYTES).and_then(|v| v.parse::<u64>().ok()),
+    );
     let backend_op_timeout_secs = TftpConfig::resolve_backend_op_timeout_secs(
         rustfs_utils::get_env_opt_str(ENV_TFTP_BACKEND_OP_TIMEOUT_SECS).and_then(|v| v.parse::<u64>().ok()),
     );
@@ -1457,6 +1461,7 @@ pub async fn init_tftp_system() -> Result<Option<ShutdownHandle>, Box<dyn std::e
         max_block_size,
         max_window_size,
         max_concurrent_transfers,
+        max_transfer_bytes,
         backend_op_timeout_secs,
         read_fetch_bytes,
         max_send_retries,

--- a/rustfs/src/init.rs
+++ b/rustfs/src/init.rs
@@ -1372,6 +1372,155 @@ pub async fn init_sftp_system() -> Result<Option<ShutdownHandle>, Box<dyn std::e
     }
 }
 
+/// Start the TFTP server when `RUSTFS_TFTP_ENABLE` is set.
+#[cfg(feature = "tftp")]
+#[instrument(skip_all)]
+pub async fn init_tftp_system() -> Result<Option<ShutdownHandle>, Box<dyn std::error::Error + Send + Sync>> {
+    use crate::protocols::ProtocolStorageClient;
+    use rustfs_config::{
+        DEFAULT_TFTP_ADDRESS, ENV_TFTP_ACCESS_KEY, ENV_TFTP_ACCESS_MODE, ENV_TFTP_ADDRESS, ENV_TFTP_BACKEND_OP_TIMEOUT_SECS,
+        ENV_TFTP_DEFAULT_BUCKET, ENV_TFTP_ENABLE, ENV_TFTP_MAX_BLOCK_SIZE, ENV_TFTP_MAX_CONCURRENT_TRANSFERS,
+        ENV_TFTP_MAX_SEND_RETRIES, ENV_TFTP_MAX_WINDOW_SIZE, ENV_TFTP_READ_FETCH_BYTES, ENV_TFTP_SECRET_KEY,
+    };
+    use rustfs_protocols::common::session::{Protocol, ProtocolPrincipal, SessionContext, is_temporary_credential};
+    use rustfs_protocols::{TftpConfig, TftpServer, TftpStorageHandler};
+    use rustfs_utils::MaskedAccessKey;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::Arc;
+    use subtle::ConstantTimeEq;
+
+    let enabled = rustfs_utils::get_env_bool(ENV_TFTP_ENABLE, false);
+    if !enabled {
+        debug!(
+            target: "rustfs::init",
+            event = EVENT_PROTOCOL_RUNTIME_STATE,
+            component = LOG_COMPONENT_INIT,
+            subsystem = LOG_SUBSYSTEM_PROTOCOL,
+            protocol = "tftp",
+            state = "disabled",
+            "Protocol runtime disabled"
+        );
+        return Ok(None);
+    }
+
+    let addr_str = rustfs_utils::get_env_str(ENV_TFTP_ADDRESS, DEFAULT_TFTP_ADDRESS);
+    let bind_addr =
+        rustfs_utils::net::parse_and_resolve_address(&addr_str).map_err(|e| format!("Invalid TFTP address '{addr_str}': {e}"))?;
+
+    let access_key =
+        rustfs_utils::get_env_opt_str(ENV_TFTP_ACCESS_KEY).ok_or("RUSTFS_TFTP_ACCESS_KEY is required when TFTP is enabled")?;
+    let secret_key =
+        rustfs_utils::get_env_opt_str(ENV_TFTP_SECRET_KEY).ok_or("RUSTFS_TFTP_SECRET_KEY is required when TFTP is enabled")?;
+
+    let iam_sys = rustfs_iam::get().map_err(|e| format!("IAM unavailable for TFTP startup: {e}"))?;
+    let (identity_opt, is_valid) = iam_sys
+        .check_key(&access_key)
+        .await
+        .map_err(|e| format!("TFTP credential lookup failed: {e}"))?;
+    let identity = identity_opt.ok_or_else(|| format!("Unknown TFTP access key: {}", MaskedAccessKey(&access_key)))?;
+    if !is_valid {
+        return Err("TFTP access key is disabled or expired".into());
+    }
+    if is_temporary_credential(&identity.credentials) {
+        return Err("TFTP does not accept temporary STS credentials".into());
+    }
+    let secret_matches: bool = identity.credentials.secret_key.as_bytes().ct_eq(secret_key.as_bytes()).into();
+    if !secret_matches {
+        return Err("RUSTFS_TFTP_SECRET_KEY does not match the configured access key".into());
+    }
+
+    let default_bucket = rustfs_utils::get_env_opt_str(ENV_TFTP_DEFAULT_BUCKET);
+    let access_mode = TftpConfig::resolve_access_mode(rustfs_utils::get_env_opt_str(ENV_TFTP_ACCESS_MODE).as_deref())?;
+    let max_block_size = TftpConfig::resolve_max_block_size(
+        rustfs_utils::get_env_opt_str(ENV_TFTP_MAX_BLOCK_SIZE).and_then(|v| v.parse::<u16>().ok()),
+    );
+    let max_window_size = TftpConfig::resolve_max_window_size(
+        rustfs_utils::get_env_opt_str(ENV_TFTP_MAX_WINDOW_SIZE).and_then(|v| v.parse::<u16>().ok()),
+    );
+    let max_concurrent_transfers = TftpConfig::resolve_max_concurrent_transfers(
+        rustfs_utils::get_env_opt_str(ENV_TFTP_MAX_CONCURRENT_TRANSFERS).and_then(|v| v.parse::<usize>().ok()),
+    );
+    let backend_op_timeout_secs = TftpConfig::resolve_backend_op_timeout_secs(
+        rustfs_utils::get_env_opt_str(ENV_TFTP_BACKEND_OP_TIMEOUT_SECS).and_then(|v| v.parse::<u64>().ok()),
+    );
+    let read_fetch_bytes = TftpConfig::resolve_read_fetch_bytes(
+        rustfs_utils::get_env_opt_str(ENV_TFTP_READ_FETCH_BYTES).and_then(|v| v.parse::<u64>().ok()),
+    );
+    let max_send_retries = TftpConfig::resolve_max_send_retries(
+        rustfs_utils::get_env_opt_str(ENV_TFTP_MAX_SEND_RETRIES).and_then(|v| v.parse::<u32>().ok()),
+    );
+
+    let config = TftpConfig {
+        bind_addr,
+        default_bucket,
+        access_mode,
+        max_block_size,
+        max_window_size,
+        max_concurrent_transfers,
+        backend_op_timeout_secs,
+        read_fetch_bytes,
+        max_send_retries,
+    };
+
+    let principal = ProtocolPrincipal::new(Arc::new(identity));
+    let session_context = SessionContext::new(principal, Protocol::Tftp, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+
+    let fs = crate::storage_api::startup::init::ecfs::FS::new();
+    let storage_client = ProtocolStorageClient::new(fs);
+    let handler = TftpStorageHandler::new(storage_client, config.clone(), session_context.credentials().clone(), session_context);
+    let server = TftpServer::new(config.clone(), handler);
+
+    debug!(
+        target: "rustfs::init",
+        event = EVENT_PROTOCOL_RUNTIME_STATE,
+        component = LOG_COMPONENT_INIT,
+        subsystem = LOG_SUBSYSTEM_PROTOCOL,
+        protocol = "tftp",
+        state = "configured",
+        bind_addr = %config.bind_addr,
+        access_mode = ?config.access_mode,
+        default_bucket = config.default_bucket.as_deref().unwrap_or("-"),
+        "Protocol runtime configured"
+    );
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
+    let task_handle = tokio::spawn(async move {
+        if let Err(e) = server.start(shutdown_rx).await {
+            error!(
+                target: "rustfs::init",
+                event = EVENT_PROTOCOL_SERVER_STATE,
+                component = LOG_COMPONENT_INIT,
+                subsystem = LOG_SUBSYSTEM_PROTOCOL,
+                protocol = "tftp",
+                state = "runtime_failed",
+                error = %e,
+                "Protocol server failed"
+            );
+        }
+        info!(
+            target: "rustfs::init",
+            event = EVENT_PROTOCOL_SERVER_STATE,
+            component = LOG_COMPONENT_INIT,
+            subsystem = LOG_SUBSYSTEM_PROTOCOL,
+            protocol = "tftp",
+            state = "stopped",
+            "Protocol server stopped"
+        );
+    });
+
+    info!(
+        target: "rustfs::init",
+        event = EVENT_PROTOCOL_RUNTIME_STATE,
+        component = LOG_COMPONENT_INIT,
+        subsystem = LOG_SUBSYSTEM_PROTOCOL,
+        protocol = "tftp",
+        state = "started",
+        bind_addr = %config.bind_addr,
+        "Protocol runtime started"
+    );
+    Ok(Some(ShutdownHandle::new(shutdown_tx, task_handle)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/rustfs/src/lib.rs
+++ b/rustfs/src/lib.rs
@@ -95,7 +95,7 @@ pub mod memory_observability;
 pub mod module_switches;
 pub mod on_demand_migration;
 pub mod profiling;
-#[cfg(any(feature = "ftps", feature = "webdav", feature = "sftp"))]
+#[cfg(any(feature = "ftps", feature = "webdav", feature = "sftp", feature = "tftp"))]
 pub mod protocols;
 pub mod runtime_capabilities;
 pub(crate) mod runtime_sources;

--- a/rustfs/src/startup_optional_runtime_sidecars.rs
+++ b/rustfs/src/startup_optional_runtime_sidecars.rs
@@ -45,6 +45,7 @@ enum OptionalRuntimeShutdownStep {
     Ftps,
     Webdav,
     Sftp,
+    Tftp,
 }
 
 impl OptionalRuntimeShutdownStep {
@@ -54,6 +55,7 @@ impl OptionalRuntimeShutdownStep {
             Self::Ftps => "ftps",
             Self::Webdav => "webdav",
             Self::Sftp => "sftp",
+            Self::Tftp => "tftp",
         }
     }
 }
@@ -73,11 +75,20 @@ fn optional_runtime_shutdown_steps(protocols: &ProtocolShutdownSenders) -> Vec<O
     if protocols.sftp.is_some() {
         steps.push(OptionalRuntimeShutdownStep::Sftp);
     }
+    if protocols.tftp.is_some() {
+        steps.push(OptionalRuntimeShutdownStep::Tftp);
+    }
     steps
 }
 
 pub(crate) fn prepare_optional_runtime_shutdowns(optional_runtimes: OptionalRuntimeServices) -> Vec<ShutdownHandle> {
-    let ProtocolShutdownSenders { ftp, ftps, webdav, sftp } = optional_runtimes.protocols;
+    let ProtocolShutdownSenders {
+        ftp,
+        ftps,
+        webdav,
+        sftp,
+        tftp,
+    } = optional_runtimes.protocols;
 
     let mut protocol_shutdowns = Vec::new();
     if let Some(handle) = ftp {
@@ -94,6 +105,10 @@ pub(crate) fn prepare_optional_runtime_shutdowns(optional_runtimes: OptionalRunt
     }
     if let Some(handle) = sftp {
         log_protocol_stopping(OptionalRuntimeShutdownStep::Sftp);
+        protocol_shutdowns.push(handle);
+    }
+    if let Some(handle) = tftp {
+        log_protocol_stopping(OptionalRuntimeShutdownStep::Tftp);
         protocol_shutdowns.push(handle);
     }
 
@@ -147,6 +162,7 @@ mod tests {
             ftps: Some(completed_shutdown_handle()),
             webdav: Some(completed_shutdown_handle()),
             sftp: Some(completed_shutdown_handle()),
+            tftp: Some(completed_shutdown_handle()),
         };
 
         assert_eq!(
@@ -156,6 +172,7 @@ mod tests {
                 OptionalRuntimeShutdownStep::Ftps,
                 OptionalRuntimeShutdownStep::Webdav,
                 OptionalRuntimeShutdownStep::Sftp,
+                OptionalRuntimeShutdownStep::Tftp,
             ]
         );
     }
@@ -168,6 +185,7 @@ mod tests {
             ftps: None,
             webdav: Some(observed_shutdown_handle("webdav", events.clone())),
             sftp: None,
+            tftp: None,
         };
 
         let protocol_shutdowns = prepare_optional_runtime_shutdowns(OptionalRuntimeServices::new(protocols));

--- a/rustfs/src/startup_protocols.rs
+++ b/rustfs/src/startup_protocols.rs
@@ -14,6 +14,8 @@
 
 #[cfg(feature = "sftp")]
 use crate::init::init_sftp_system;
+#[cfg(feature = "tftp")]
+use crate::init::init_tftp_system;
 #[cfg(feature = "webdav")]
 use crate::init::init_webdav_system;
 #[cfg(feature = "ftps")]
@@ -36,6 +38,7 @@ pub(crate) struct ProtocolShutdownSenders {
     pub(crate) ftps: Option<ShutdownHandle>,
     pub(crate) webdav: Option<ShutdownHandle>,
     pub(crate) sftp: Option<ShutdownHandle>,
+    pub(crate) tftp: Option<ShutdownHandle>,
 }
 
 pub(crate) async fn init_protocol_shutdown_senders() -> Result<ProtocolShutdownSenders> {
@@ -44,6 +47,7 @@ pub(crate) async fn init_protocol_shutdown_senders() -> Result<ProtocolShutdownS
         ftps: init_ftps_protocol().await?,
         webdav: init_webdav_protocol().await?,
         sftp: init_sftp_protocol().await?,
+        tftp: init_tftp_protocol().await?,
     })
 }
 
@@ -84,6 +88,16 @@ async fn init_sftp_protocol() -> Result<Option<ShutdownHandle>> {
 
 #[cfg(not(feature = "sftp"))]
 async fn init_sftp_protocol() -> Result<Option<ShutdownHandle>> {
+    Ok(None)
+}
+
+#[cfg(feature = "tftp")]
+async fn init_tftp_protocol() -> Result<Option<ShutdownHandle>> {
+    init_protocol("tftp", init_tftp_system).await
+}
+
+#[cfg(not(feature = "tftp"))]
+async fn init_tftp_protocol() -> Result<Option<ShutdownHandle>> {
     Ok(None)
 }
 

--- a/rustfs/src/startup_services.rs
+++ b/rustfs/src/startup_services.rs
@@ -79,7 +79,6 @@ pub(crate) async fn init_startup_runtime_services(
 ) -> Result<StartupServiceRuntime> {
     init_kms_system(config, store.clone()).await?;
 
-    let optional_runtimes = init_optional_runtime_services().await?;
     let heartbeat_config = HeartbeatConfig::from_env().map_err(std::io::Error::other)?;
     let heartbeat_nodes = heartbeat_config.as_ref().map(|_| endpoint_pools.get_nodes().len());
     let inventory_drives = heartbeat_config
@@ -91,6 +90,9 @@ pub(crate) async fn init_startup_runtime_services(
 
     let buckets = init_bucket_metadata_runtime(store.clone(), ctx.clone()).await?;
     let iam_bootstrap = init_iam_runtime(store.clone(), ctx.clone(), readiness, state_manager, server_ctx).await?;
+
+    // TFTP validates its fixed service-account credentials against IAM at startup.
+    let optional_runtimes = init_optional_runtime_services().await?;
 
     // Audit initialization requires the AppContext (server config + object store)
     // which is published by ensure_startup_after_iam inside init_iam_runtime.


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues

Part 2 of #3241. Depends on part 1 RRQ sidecar (`feat/tftp-sidecar-rrq`).

## Summary of Changes

Add TFTP **WRQ (upload) path** (part 2) on top of the RRQ sidecar. Wire handling
still uses [`async-tftp`](https://crates.io/crates/async-tftp) **0.4.2**; uploads
map to S3 `PutObject` or multipart upload via `ObjectWriter` (`AsyncWrite`).

**Behavior**

- **WRQ**: `write_req_open` authorizes `PutObject`, then `ObjectWriter` buffers
  incoming DATA blocks. Commit happens only on successful library `close()` after
  the full transfer; `Drop` without close aborts in-progress multipart uploads.
- **Size limits**: per-transfer ceiling is `min(client tsize, RUSTFS_TFTP_MAX_TRANSFER_BYTES)`
  when `tsize > 0`; otherwise config default. Exceeding the limit fails the write.
- **Multipart**: `part_size = max(RUSTFS_TFTP_READ_FETCH_BYTES, S3_MIN_PART_SIZE)`
  (5 MiB floor). Small objects use single `PutObject`; larger objects use
  `CreateMultipartUpload` / `UploadPart` / `CompleteMultipartUpload`.
- **Auth**: same fixed IAM service account as RRQ; per-request `PutObject`
  authorization in `write_req_open`.
- **Paths / concurrency**: same path rules and semaphore as RRQ; excess WRQ opens
  return TFTP `DiskFull`.
- **Access mode**: `wo` / `rw` allow WRQ; `ro` returns TFTP `Permission denied`.

**Code entry points**

| Layer | Path |
| --- | --- |
| Server bind / library knobs | `crates/protocols/src/tftp/server.rs` (`TftpServer::start`) |
| Handler open path | `crates/protocols/src/tftp/handler.rs` (`write_req_open`) |
| WRQ streaming | `crates/protocols/src/tftp/writer.rs` (`ObjectWriter`) |
| Env clamp bounds | `crates/protocols/src/tftp/constants.rs` |
| Defaults / env names | `crates/config/src/constants/protocols.rs` |

**Parameter map**

| Knob | Where it applies | Meaning |
| --- | --- | --- |
| `RUSTFS_TFTP_MAX_BLOCK_SIZE` | `async-tftp` `block_size_limit` | Ceiling for negotiated RFC 2348 `blksize` (`min(client, limit)`). |
| `RUSTFS_TFTP_MAX_WINDOW_SIZE` | `async-tftp` `window_size_limit` | Ceiling for negotiated RFC 7440 `windowsize`; stock 0.4.2 WRQ ACKs every block until `feat/wrq-windowsize` is pinned. |
| `RUSTFS_TFTP_MAX_SEND_RETRIES` | `async-tftp` `max_send_retries` | UDP retransmit attempts after timeout (default 5 ≈ 18s with 3s library timeout). |
| UDP timeout (3s) | `async-tftp` `timeout` in `TftpServer::start` | Hardcoded in `server.rs` (not env-configurable). |
| `RUSTFS_TFTP_MAX_CONCURRENT_TRANSFERS` | RustFS `Semaphore` | Max simultaneous RRQ+WRQ handlers; excess get TFTP `DiskFull`. |
| `RUSTFS_TFTP_MAX_TRANSFER_BYTES` | `ObjectWriter` (+ client `tsize`) | Per-WRQ byte ceiling; effective limit is `min(tsize, config)` when `tsize > 0`. |
| `RUSTFS_TFTP_READ_FETCH_BYTES` | WRQ `part_size` floor | `part_size = max(read_fetch_bytes, S3_MIN_PART_SIZE)`. |
| `RUSTFS_TFTP_BACKEND_OP_TIMEOUT_SECS` | every S3 call in writer/handler | Per-call backend deadline. |
| `S3_MIN_PART_SIZE` / `S3_MAX_MULTIPART_PARTS` | `ObjectWriter` | S3 multipart contract (5 MiB non-final parts; ≤ 10000 parts). |

WRQ peak memory ≈ one `part_size` buffer per transfer, plus library UDP buffers sized
by negotiated `blksize` (and `windowsize` when fork-patched).

**New / changed surface**

- `ObjectWriter`: commit-on-close, abort-on-drop for multipart.
- `RUSTFS_TFTP_MAX_TRANSFER_BYTES` env (default 256 MiB).
- `handler::write_req_open` replaces part 1 stub (`Illegal operation`).

Documentation: [`docs/operations/tftp.md`](docs/operations/tftp.md).

### WRQ sequence (write)

Stock `async-tftp` 0.4.2 receives one DATA block per ACK on WRQ. Diagram matches
intended behavior once `feat/wrq-windowsize` is pinned; until then treat each loop
iteration as `windowsize = 1`.

```mermaid
sequenceDiagram
    autonumber
    participant C as TFTP client
    participant L as async-tftp
    participant H as TftpStorageHandler
    participant W as ObjectWriter
    participant S as StorageBackend

    C->>L: WRQ path and opts
    L->>H: write_req_open(client, path, size)
    H->>H: access_mode and permit
    H->>H: resolve path to bucket and key
    H->>H: authorize PutObject
    H-->>L: ObjectWriter
    L->>C: OACK or ACK 0

    loop each DATA window
        C->>L: DATA blocks
        L->>W: poll_write
        W->>W: append and enforce max bytes
        opt buffer reaches part_size
            W->>S: CreateMultipartUpload on first flush
            W->>S: UploadPart
            S-->>W: ETag
        end
        L->>C: ACK last block
    end

    L->>W: close on success
    alt small object
        W->>S: PutObject
    else multipart
        W->>S: UploadPart remainder
        W->>S: CompleteMultipartUpload
    end
    W-->>L: Ok

    Note over W: Drop without close aborts MPU
```

### Commit vs abort

| Outcome | What happens |
| --- | --- |
| Full WRQ + library `close()` | `PutObject` or `CompleteMultipartUpload`; object is visible. |
| Timeout, peer ERROR, I/O error, drop without close | No commit. If multipart started, `Drop` spawns `AbortMultipartUpload`. |
| Over `max_transfer_bytes` or > 10000 parts | Write fails; multipart aborted if started. |

### Layering

```text
  Client (atftp / firmware)          UDP :6969 (or :69)
           │
           ▼
   ┌───────────────────┐
   │     async-tftp    │  blksize / windowsize / retries / OACK
   │  WRQ task         │
   └─────────┬─────────┘
             │ Handler::write_req_open
             ▼
   ┌───────────────────┐
   │ TftpStorageHandler│  IAM, path, semaphore, max_bytes
   └─────────┬─────────┘
             │
             ▼
      ObjectWriter
      buffer → UploadPart / PutObject
             │
             ▼
        StorageBackend (S3 API)
```

## Verification

Tested branch: `feat/tftp-sidecar-wrq` (based on `feat/tftp-sidecar-rrq`).

| Check | Command | Result |
| --- | --- | --- |
| Unit tests | `cargo test -p rustfs-protocols --features tftp --lib tftp::writer tftp::handler` | Writer commit/abort, size limit, multipart path |
| Clippy | `cargo clippy -p rustfs-protocols --features tftp -- -D warnings` | Clean |
| Format | `cargo fmt --all --check` | Clean |
| Manual WRQ | `atftp --option "blksize 65464" --option "windowsize 1" -p -l /tmp/in.bin -r <key> 127.0.0.1:6969` against `rustfs --features tftp` with `RUSTFS_TFTP_ACCESS_MODE=wo` | Uploaded object bytes match source via S3 GET |

**Not run:** full `make pre-pr` (needs `protoc` for default workspace build); TFTP
WRQ E2E in CI (follow-up).

**Remaining risk:** no automated large-object WRQ regression; manual WRQ used
`windowsize 1` only. Stock 0.4.2 WRQ throughput is block-at-a-time — see Additional Notes.

## Impact

**User-facing**

- TFTP sidecar gains WRQ (upload) when `RUSTFS_TFTP_ACCESS_MODE` is `wo` or `rw`.
- Objects commit only after a complete successful transfer; partial uploads are
  not visible.
- Default per-transfer ceiling 256 MiB (`RUSTFS_TFTP_MAX_TRANSFER_BYTES`).

**Configuration**

New/changed environment variable:

- `RUSTFS_TFTP_MAX_TRANSFER_BYTES` (default `268435456` / 256 MiB)

Existing TFTP env vars from part 1 apply; `RUSTFS_TFTP_READ_FETCH_BYTES` also sets
WRQ multipart part-size floor.

**Compatibility**

- Builds on part 1 `tftp` feature; no change when feature disabled.
- RRQ behavior unchanged.
- S3 API and HTTP S3 path unchanged.

**Security**

- Same wire-trust model as RRQ: no TFTP authentication; restrict UDP at network
  layer; dedicated least-privilege IAM identity with `PutObject` on target prefix.

## Additional Notes

### Known `async-tftp` 0.4.2 issues (WRQ-relevant)

Fork branches at [ylw510/async-tftp-rs](https://github.com/ylw510/async-tftp-rs):

| Branch | Commit |
| --- | --- |
| `fix/abort-on-peer-error` | [`c8135e5`](https://github.com/ylw510/async-tftp-rs/commit/c8135e5) |
| `feat/wrq-windowsize` | [`dabfc09`](https://github.com/ylw510/async-tftp-rs/commit/dabfc09) |

1. **`fix/abort-on-peer-error`** — client TFTP ERROR during WRQ DATA wait leaves
   stock server hanging. Fix: treat `Packet::Error` as `Error::ClientAborted`.
2. **`feat/wrq-windowsize`** — stock WRQ ACKs every DATA block despite negotiated
   `windowsize`. Fix: `recv_window`, ACK once per window.

**Practical workaround:** use `windowsize 1` on upload until fork is pinned.

### Dependency strategy

**Part 2 default:** ship on crates.io `async-tftp = "0.4.2"` with documented WRQ
`windowsize` limit. Pin `fix/abort-on-peer-error` and/or `feat/wrq-windowsize` in a
follow-up once validated; prefer upstream merge on
[oblique/async-tftp-rs](https://github.com/oblique/async-tftp-rs).

---
