### PR TITLE
ci: tolerate ANSI reset escapes in security verdicts; fix tier product counts

### DIFF
--- a/.github/workflows/rustfs-security-test.yml
+++ b/.github/workflows/rustfs-security-test.yml
@@ -190,15 +190,16 @@ jobs:
 
           # Product gate: failing cases keep the run green — they are reported
           # below and tracked in rustfs/backlog. Only harness/environment
-          # breakdowns turn the workflow red. The suite log lines may carry
-          # ANSI color escapes in front of the verdict tag, so the pattern
-          # allows any number of them before the leading '['.
+          # breakdowns turn the workflow red. The suite log lines carry ANSI
+          # color escapes both before and after the verdict tag
+          # (e.g. "\e[1;31m[FAIL]\e[0m STS-105 ..."), so the pattern allows
+          # any number of escapes on each side of it.
           ESC=$'\033'
-          VERDICTS_TOTAL="$(grep -cE "^(${ESC}\[[0-9;]*m)*\[(PASS|FAIL|UNSUPPORTED)\] [A-Z]" "${LOG_FILE}" 2>/dev/null || true)"
-          VERDICTS_FAIL="$(grep -cE "^(${ESC}\[[0-9;]*m)*\[FAIL\] [A-Z]" "${LOG_FILE}" 2>/dev/null || true)"
+          VERDICTS_TOTAL="$(grep -cE "^(${ESC}\[[0-9;]*m)*\[(PASS|FAIL|UNSUPPORTED)\](${ESC}\[[0-9;]*m)* [A-Z]" "${LOG_FILE}" 2>/dev/null || true)"
+          VERDICTS_FAIL="$(grep -cE "^(${ESC}\[[0-9;]*m)*\[FAIL\](${ESC}\[[0-9;]*m)* [A-Z]" "${LOG_FILE}" 2>/dev/null || true)"
           VERDICTS_TOTAL=$(( ${VERDICTS_TOTAL:-0} + 0 )); VERDICTS_FAIL=$(( ${VERDICTS_FAIL:-0} + 0 ))
           VERDICTS_PASS=$(( VERDICTS_TOTAL - VERDICTS_FAIL ))
-          VERDICTS_SKIPPED="$(grep -cE "^(${ESC}\[[0-9;]*m)*\[SKIP\] [A-Z]" "${LOG_FILE}" 2>/dev/null || true)"
+          VERDICTS_SKIPPED="$(grep -cE "^(${ESC}\[[0-9;]*m)*\[SKIP\](${ESC}\[[0-9;]*m)* [A-Z]" "${LOG_FILE}" 2>/dev/null || true)"
           VERDICTS_SKIPPED=$(( ${VERDICTS_SKIPPED:-0} + 0 ))
           HARNESS_OK=0
           if [ "${TEST_OUTCOME}" = "success" ]; then

--- a/.github/workflows/rustfs-tier-test.yml
+++ b/.github/workflows/rustfs-tier-test.yml
@@ -344,10 +344,20 @@ jobs:
               echo "Structured report generation failed before producing output (exit ${CASE_GATE_RC})."
             } > "${CASE_TABLE}"
           fi
-          CASES_TOTAL="$(grep -cE '^\| [A-Z][A-Z0-9]*-[0-9]+ .*\| (PASS|FAIL|UNSUPPORTED|RUNNING) \|' "${CASE_TABLE}" 2>/dev/null || true)"
-          CASES_FAIL="$(grep -cE '^\| [A-Z][A-Z0-9]*-[0-9]+ .*\| FAIL \|' "${CASE_TABLE}" 2>/dev/null || true)"
-          CASES_TOTAL=$(( ${CASES_TOTAL:-0} + 0 )); CASES_FAIL=$(( ${CASES_FAIL:-0} + 0 ))
-          CASES_PASS=$(( CASES_TOTAL - CASES_FAIL ))
+          # The tier case table carries a "## Case Summary" bullet list
+          # (Total/PASS/FAIL/...); parse the counts from there. Fall back to
+          # the case-ID table rows if the bullets are absent.
+          CASES_FAIL="$(grep -m1 -E '^- FAIL: [0-9]+' "${CASE_TABLE}" 2>/dev/null | grep -oE '[0-9]+' || true)"
+          if [ -n "${CASES_FAIL}" ]; then
+            CASES_PASS="$(grep -m1 -E '^- PASS: [0-9]+' "${CASE_TABLE}" 2>/dev/null | grep -oE '[0-9]+' || true)"
+            CASES_PASS=$(( ${CASES_PASS:-0} + 0 ))
+          else
+            CASES_TOTAL="$(grep -cE '^\| [A-Za-z0-9_.-]+ \| [A-Z][A-Z0-9]*-[0-9]+ .*\| (PASS|FAIL|UNSUPPORTED|RUNNING) \|' "${CASE_TABLE}" 2>/dev/null || true)"
+            CASES_FAIL="$(grep -cE '^\| [A-Za-z0-9_.-]+ \| [A-Z][A-Z0-9]*-[0-9]+ .*\| FAIL \|' "${CASE_TABLE}" 2>/dev/null || true)"
+            CASES_TOTAL=$(( ${CASES_TOTAL:-0} + 0 )); CASES_FAIL=$(( ${CASES_FAIL:-0} + 0 ))
+            CASES_PASS=$(( CASES_TOTAL - CASES_FAIL ))
+          fi
+          CASES_FAIL=$(( ${CASES_FAIL:-0} + 0 ))
           {
             echo "# RustFS tier test report"
             echo ""

--- a/scripts/test_security_workflow.py
+++ b/scripts/test_security_workflow.py
@@ -117,14 +117,16 @@ class SecurityWorkflowTests(WorkflowSteps, unittest.TestCase):
         self.artifacts = self.directory / "rustfs-security-314159-2"
         suite = self.directory / "auto-testing/rustfs-security-test.sh"
         suite.parent.mkdir()
-        ansi = {"ANSI_GREEN": "\033[1;32m", "ANSI_RED": "\033[1;31m", "ANSI_YELLOW": "\033[1;33m"}
+        ansi = {"ANSI_GREEN": "\033[1;32m", "ANSI_RED": "\033[1;31m", "ANSI_YELLOW": "\033[1;33m", "ANSI_RESET": "\033[0m"}
         suite.write_text(
             '#!/usr/bin/env bash\nset -euo pipefail\n'
             'log_dir=$(mktemp -d "$TMPDIR/rustfs-security.XXXXXX")\n'
             # Verdict lines carry ANSI color escapes and are printed to stdout
             # (captured via tee into the artifacts suite.log), exactly like the
-            # real suite output the report step has to grep through.
-            'printf "%s\\n" "${ANSI_GREEN}[PASS] IAM-101 ok" "${ANSI_RED}[FAIL] STS-105 broken" "${ANSI_YELLOW}[SKIP] OIDC-103 skipped" | tee "$log_dir/suite.log"\n'
+            # real suite output the report step has to grep through: a color
+            # tag before the verdict and a reset escape between the tag and
+            # the case id.
+            'printf "%s\\n" "${ANSI_GREEN}[PASS]${ANSI_RESET} IAM-101 ok" "${ANSI_RED}[FAIL]${ANSI_RESET} STS-105 broken" "${ANSI_YELLOW}[SKIP]${ANSI_RESET} OIDC-103 skipped" | tee "$log_dir/suite.log"\n'
             'echo "CURRENT SUITE LOG" >> "$log_dir/suite.log"\n'
             'echo "CURRENT SUITE STDOUT"; echo "CURRENT SUITE STDERR" >&2\n'
             'case "$FAKE_REPORT" in\n'


### PR DESCRIPTION
## Context

Follow-up to #7708, from the first fully-green-semantics overnight pass (all 9 suites dispatched automatically after merge, runs 34703528364..34709372002). Two report-layer defects remain:

### security: verdict greps still counted zero
Real verdict lines are `\e[1;31m[FAIL]\e[0m STS-105 ...` — the ANSI **reset escape sits between the tag and the case id**. The #7708 pattern only tolerated escapes *before* the tag, so `VERDICTS_TOTAL` stayed 0 and the run went red despite completing 45 passed / 6 failed / 3 skipped (the report step itself no longer crashes — it now reaches the final gate line). The pattern now allows escapes on both sides of the tag. The contract-test fixture emits the reset too, so this exact shape is covered.

### tier: Product result showed "0 passed, 0 failed"
`rustfs_tier_report.py` renders rows as `| topology | case | name | status | cleanup |` — topology first — so the case-ID-first table grep matched nothing. The counts are now parsed from the `## Case Summary` bullets the tier report always emits (`- PASS: N` / `- FAIL: N`), with a topology-aware table grep as fallback.

## Validation
- `scripts/test_security_workflow.py`: 21/21 (fixture now carries `\e[0m` after each tag)
- `actionlint`: clean

## Not included
- pool red in the same pass is the **product** failure tracked in rustfs/backlog#2490 (InconsistentDisk after expanding 2→4 pools) — correctly red by design.