### PR TITLE
Add consent-bound diagnostic scheduling

### DIFF
--- a/rustfs/src/connect/diagnostics/mod.rs
+++ b/rustfs/src/connect/diagnostics/mod.rs
@@ -1,0 +1,20 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod schedule;
+
+pub use schedule::{
+    DiagnosticCollectionPolicy, DiagnosticReceipt, DiagnosticScheduleError, DiagnosticScheduleRuntime, DiagnosticScheduleStatus,
+    ReceiptOutcome, run_local_environment_once, spawn_environment_schedule,
+};

--- a/rustfs/src/connect/diagnostics/schedule.rs
+++ b/rustfs/src/connect/diagnostics/schedule.rs
@@ -1,0 +1,719 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Consent-bound scheduling for the small set of diagnostic producers compiled into RustFS.
+
+use std::fs;
+use std::future::Future;
+use std::io::{self, Write as _};
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+use tokio::sync::{Mutex, watch};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use crate::connect::InventorySnapshot;
+use crate::connect::environment::{
+    ENVIRONMENT_CAPABILITY, ENVIRONMENT_SCHEMA_VERSION, EnvironmentCollectionRequest, EnvironmentInventory, collect_environment,
+};
+use crate::connect::inventory::InventoryStateStore;
+
+const POLICY_CAPABILITY: &str = "diagnostics.policy.v1";
+const ENVIRONMENT_TOOL_ID: &str = "inventory.environment";
+const MIN_INTERVAL_SECONDS: u64 = 300;
+const MAX_INTERVAL_SECONDS: u64 = 86_400;
+const MAX_RETENTION_DAYS: u16 = 14;
+const MAX_ATTEMPTS: u8 = 3;
+const INITIAL_RETRY: Duration = Duration::from_secs(1);
+const MAX_RETRY: Duration = Duration::from_secs(4);
+const MAX_RESULT_BYTES: usize = 64 * 1024;
+#[cfg(unix)]
+const FILE_MODE: u32 = 0o600;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct DiagnosticCollectionPolicy {
+    policy_name: Option<String>,
+    revision: u64,
+    support_state: SupportState,
+    desired_state: DesiredState,
+    reason_code: Option<ReasonCode>,
+    tool_ids: Vec<String>,
+    interval_seconds: Option<u64>,
+    scope: Scope,
+    retention_days: Option<u16>,
+    consent_reference: Option<String>,
+    consent_expires_at: Option<String>,
+}
+
+impl DiagnosticCollectionPolicy {
+    pub(crate) fn policy_sync_capability() -> &'static str {
+        POLICY_CAPABILITY
+    }
+
+    pub(crate) fn stopped() -> Self {
+        Self {
+            policy_name: None,
+            revision: 0,
+            support_state: SupportState::Unsupported,
+            desired_state: DesiredState::Stopped,
+            reason_code: Some(ReasonCode::PolicyCapabilityUnsupported),
+            tool_ids: Vec::new(),
+            interval_seconds: None,
+            scope: Scope::Cluster,
+            retention_days: None,
+            consent_reference: None,
+            consent_expires_at: None,
+        }
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), DiagnosticScheduleError> {
+        if self.policy_name.as_ref().is_some_and(|value| value.len() > 512)
+            || self.tool_ids.len() > 19
+            || self.tool_ids.iter().any(|value| value.is_empty() || value.len() > 64)
+            || self
+                .consent_reference
+                .as_ref()
+                .is_some_and(|value| value.is_empty() || value.len() > 512)
+        {
+            return Err(DiagnosticScheduleError::Policy);
+        }
+        if self.desired_state == DesiredState::Stopped {
+            return Ok(());
+        }
+        let interval = self.interval_seconds.ok_or(DiagnosticScheduleError::Policy)?;
+        let retention = self.retention_days.ok_or(DiagnosticScheduleError::Policy)?;
+        let expires_at = self.consent_expiry()?;
+        if self.support_state != SupportState::Supported
+            || self.reason_code.is_some()
+            || !(MIN_INTERVAL_SECONDS..=MAX_INTERVAL_SECONDS).contains(&interval)
+            || !(1..=MAX_RETENTION_DAYS).contains(&retention)
+            || self.policy_name.is_none()
+            || self.consent_reference.is_none()
+            || self.tool_ids.is_empty()
+            || expires_at <= Utc::now()
+        {
+            return Err(DiagnosticScheduleError::Policy);
+        }
+        Ok(())
+    }
+
+    fn should_run(&self) -> bool {
+        self.support_state == SupportState::Supported && self.desired_state == DesiredState::Running
+    }
+
+    fn consent_expiry(&self) -> Result<DateTime<Utc>, DiagnosticScheduleError> {
+        self.consent_expires_at
+            .as_deref()
+            .ok_or(DiagnosticScheduleError::Policy)
+            .and_then(parse_time)
+    }
+
+    fn fingerprint(&self) -> Result<String, DiagnosticScheduleError> {
+        let bytes = serde_json::to_vec(self).map_err(|_| DiagnosticScheduleError::Policy)?;
+        Ok(hex_simd::encode_to_string(Sha256::digest(bytes), hex_simd::AsciiCase::Lower))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum SupportState {
+    Supported,
+    Unsupported,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum DesiredState {
+    Running,
+    Stopped,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum ReasonCode {
+    PolicyCapabilityUnsupported,
+    ToolCapabilityUnsupported,
+    Disabled,
+    ConsentInactive,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum Scope {
+    Cluster,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct DiagnosticReceipt {
+    pub receipt_id: String,
+    pub policy_revision: u64,
+    pub tool_id: String,
+    pub interval_started_at: String,
+    pub completed_at: String,
+    pub outcome: ReceiptOutcome,
+    pub attempt_count: u8,
+    pub reason: Option<String>,
+    pub result_sha256: Option<String>,
+    pub result_bytes: Option<usize>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ReceiptOutcome {
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DiagnosticScheduleStatus {
+    Waiting,
+    Running {
+        policy_revision: u64,
+        tool_id: String,
+        attempt: u8,
+    },
+    Receipt(DiagnosticReceipt),
+    Failed {
+        reason: String,
+    },
+    Stopped,
+}
+
+#[derive(Debug, Error)]
+pub enum DiagnosticScheduleError {
+    #[error("connect_diagnostic_policy_invalid")]
+    Policy,
+    #[error("connect_diagnostic_state_io")]
+    StateIo(#[source] io::Error),
+    #[error("connect_diagnostic_state_invalid")]
+    StateInvalid(#[source] serde_json::Error),
+    #[error("connect_diagnostic_state_corrupt")]
+    StateCorrupt,
+    #[error("connect_diagnostic_inventory_unavailable")]
+    InventoryUnavailable,
+    #[error("connect_diagnostic_collection_failed")]
+    CollectionFailed,
+    #[error("connect_diagnostic_result_too_large")]
+    ResultTooLarge,
+    #[error("connect_diagnostic_cancelled")]
+    Cancelled,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct ScheduleState {
+    policy_revision: Option<u64>,
+    policy_fingerprint: Option<String>,
+    next_due_at: Option<String>,
+    active_interval_started_at: Option<String>,
+    last_receipt: Option<DiagnosticReceipt>,
+}
+
+#[derive(Clone)]
+struct StateStore {
+    path: PathBuf,
+    gate: Arc<Mutex<()>>,
+}
+
+impl StateStore {
+    fn new(state_root: &Path) -> Self {
+        Self {
+            path: state_root.join("diagnostics/schedule.json"),
+            gate: Arc::new(Mutex::new(())),
+        }
+    }
+
+    async fn read(&self) -> Result<ScheduleState, DiagnosticScheduleError> {
+        let _guard = self.gate.lock().await;
+        let path = self.path.clone();
+        tokio::task::spawn_blocking(move || read_state(&path))
+            .await
+            .map_err(|error| DiagnosticScheduleError::StateIo(io::Error::other(error)))?
+    }
+
+    async fn write(&self, state: ScheduleState) -> Result<(), DiagnosticScheduleError> {
+        let _guard = self.gate.lock().await;
+        let path = self.path.clone();
+        tokio::task::spawn_blocking(move || write_state(&path, &state))
+            .await
+            .map_err(|error| DiagnosticScheduleError::StateIo(io::Error::other(error)))?
+    }
+}
+
+type RunFuture = Pin<Box<dyn Future<Output = Result<Vec<u8>, DiagnosticScheduleError>> + Send>>;
+type Runner = Arc<dyn Fn(CancellationToken) -> RunFuture + Send + Sync>;
+
+pub struct DiagnosticScheduleRuntime {
+    status: watch::Receiver<DiagnosticScheduleStatus>,
+    task: JoinHandle<()>,
+}
+
+impl DiagnosticScheduleRuntime {
+    pub fn status(&self) -> watch::Receiver<DiagnosticScheduleStatus> {
+        self.status.clone()
+    }
+
+    pub async fn shutdown(self) {
+        let _ = self.task.await;
+    }
+}
+
+pub fn spawn_environment_schedule(
+    state_root: &Path,
+    policies: watch::Receiver<DiagnosticCollectionPolicy>,
+    shutdown: CancellationToken,
+) -> Result<DiagnosticScheduleRuntime, DiagnosticScheduleError> {
+    let inventory_state_root = state_root.to_path_buf();
+    let runner: Runner = Arc::new(move |cancel| {
+        let inventory_state_root = inventory_state_root.clone();
+        Box::pin(async move {
+            let inventory = InventoryStateStore::from_state_root(&inventory_state_root)
+                .map_err(|_| DiagnosticScheduleError::InventoryUnavailable)?;
+            let result = run_environment_with_inventory(&inventory, &cancel).await?;
+            serde_json::to_vec(&result).map_err(|_| DiagnosticScheduleError::CollectionFailed)
+        })
+    });
+    Ok(spawn_schedule(StateStore::new(state_root), policies, shutdown, runner))
+}
+
+/// Run the only diagnostic producer currently compiled into RustFS once.
+pub async fn run_local_environment_once(
+    inventory: &InventorySnapshot,
+    cancel: &CancellationToken,
+) -> Result<EnvironmentInventory, DiagnosticScheduleError> {
+    let request =
+        EnvironmentCollectionRequest::negotiate(ENVIRONMENT_SCHEMA_VERSION, ENVIRONMENT_CAPABILITY, Duration::from_secs(30))
+            .map_err(|_| DiagnosticScheduleError::CollectionFailed)?;
+    collect_environment(inventory, request, cancel)
+        .await
+        .map_err(|error| match error {
+            crate::connect::EnvironmentError::Cancelled => DiagnosticScheduleError::Cancelled,
+            _ => DiagnosticScheduleError::CollectionFailed,
+        })
+}
+
+async fn run_environment_with_inventory(
+    inventory: &InventoryStateStore,
+    cancel: &CancellationToken,
+) -> Result<EnvironmentInventory, DiagnosticScheduleError> {
+    let persisted = inventory
+        .read_latest(Utc::now())
+        .map_err(|_| DiagnosticScheduleError::InventoryUnavailable)?;
+    run_local_environment_once(&persisted.snapshot, cancel).await
+}
+
+fn spawn_schedule(
+    store: StateStore,
+    mut policies: watch::Receiver<DiagnosticCollectionPolicy>,
+    shutdown: CancellationToken,
+    runner: Runner,
+) -> DiagnosticScheduleRuntime {
+    let (status_tx, status_rx) = watch::channel(DiagnosticScheduleStatus::Waiting);
+    let task = tokio::spawn(async move {
+        if let Err(error) = run_collection_schedule(&store, &mut policies, &shutdown, &runner, &status_tx).await {
+            let _ = status_tx.send(DiagnosticScheduleStatus::Failed {
+                reason: error.to_string(),
+            });
+        }
+        let _ = status_tx.send(DiagnosticScheduleStatus::Stopped);
+    });
+    DiagnosticScheduleRuntime { status: status_rx, task }
+}
+
+async fn run_collection_schedule(
+    store: &StateStore,
+    policies: &mut watch::Receiver<DiagnosticCollectionPolicy>,
+    shutdown: &CancellationToken,
+    runner: &Runner,
+    status: &watch::Sender<DiagnosticScheduleStatus>,
+) -> Result<(), DiagnosticScheduleError> {
+    let mut state = store.read().await?;
+    if let Some(started_at) = state.active_interval_started_at.take() {
+        let receipt = receipt(
+            state.policy_revision.unwrap_or_default(),
+            ENVIRONMENT_TOOL_ID,
+            started_at,
+            ReceiptOutcome::Failed,
+            1,
+            Some("producer_restarted_during_collection".to_owned()),
+            None,
+        );
+        state.last_receipt = Some(receipt.clone());
+        store.write(state.clone()).await?;
+        let _ = status.send(DiagnosticScheduleStatus::Receipt(receipt));
+    }
+
+    loop {
+        if shutdown.is_cancelled() {
+            break;
+        }
+        let policy = policies.borrow().clone();
+        if let Err(error) = policy.validate() {
+            if policy.should_run() {
+                return Err(error);
+            }
+        }
+        if !policy.should_run() {
+            state.next_due_at = None;
+            state.active_interval_started_at = None;
+            store.write(state.clone()).await?;
+            let _ = status.send(DiagnosticScheduleStatus::Waiting);
+            if wait_for_policy(policies, shutdown).await {
+                break;
+            }
+            continue;
+        }
+        let fingerprint = policy.fingerprint()?;
+        match state.policy_revision {
+            Some(revision) if revision > policy.revision => {
+                if wait_for_policy(policies, shutdown).await {
+                    break;
+                }
+                continue;
+            }
+            Some(revision) if revision == policy.revision && state.policy_fingerprint.as_deref() != Some(&fingerprint) => {
+                return Err(DiagnosticScheduleError::StateCorrupt);
+            }
+            Some(revision) if revision == policy.revision => {}
+            _ => {
+                state.policy_revision = Some(policy.revision);
+                state.policy_fingerprint = Some(fingerprint);
+                state.next_due_at = Some(now_string());
+                store.write(state.clone()).await?;
+            }
+        }
+        let due = state
+            .next_due_at
+            .as_deref()
+            .ok_or(DiagnosticScheduleError::StateCorrupt)
+            .and_then(parse_time)?;
+        let expiry = policy.consent_expiry()?;
+        if due >= expiry {
+            state.next_due_at = None;
+            store.write(state.clone()).await?;
+            if wait_for_policy(policies, shutdown).await {
+                break;
+            }
+            continue;
+        }
+        let now = Utc::now();
+        if due > now {
+            let wait = (due - now).to_std().map_err(|_| DiagnosticScheduleError::Policy)?;
+            tokio::select! {
+                biased;
+                () = shutdown.cancelled() => break,
+                changed = policies.changed() => if changed.is_err() { break; },
+                () = tokio::time::sleep(wait) => {},
+            }
+            continue;
+        }
+        let tool_id = match policy.tool_ids.as_slice() {
+            [tool_id] if tool_id == ENVIRONMENT_TOOL_ID => tool_id.clone(),
+            _ => return Err(DiagnosticScheduleError::Policy),
+        };
+        let interval_started_at = due.to_rfc3339_opts(SecondsFormat::Secs, true);
+        state.active_interval_started_at = Some(interval_started_at.clone());
+        state.next_due_at = Some(
+            (due + chrono::Duration::seconds(policy.interval_seconds.ok_or(DiagnosticScheduleError::Policy)? as i64))
+                .to_rfc3339_opts(SecondsFormat::Secs, true),
+        );
+        store.write(state.clone()).await?;
+
+        let mut attempt = 1;
+        let mut retry = INITIAL_RETRY;
+        let receipt = loop {
+            let _ = status.send(DiagnosticScheduleStatus::Running {
+                policy_revision: policy.revision,
+                tool_id: tool_id.clone(),
+                attempt,
+            });
+            let cancel = shutdown.child_token();
+            let run = runner(cancel.clone());
+            let result = tokio::select! {
+                biased;
+                () = shutdown.cancelled() => {
+                    cancel.cancel();
+                    Err(DiagnosticScheduleError::Cancelled)
+                }
+                changed = policies.changed() => {
+                    let _ = changed;
+                    cancel.cancel();
+                    Err(DiagnosticScheduleError::Cancelled)
+                }
+                () = tokio::time::sleep_until(tokio::time::Instant::now() + expiry.signed_duration_since(Utc::now()).to_std().unwrap_or_default()) => {
+                    cancel.cancel();
+                    Err(DiagnosticScheduleError::Cancelled)
+                }
+                result = run => result,
+            };
+            match result {
+                Ok(bytes) if bytes.len() <= MAX_RESULT_BYTES => {
+                    break receipt(
+                        policy.revision,
+                        &tool_id,
+                        interval_started_at.clone(),
+                        ReceiptOutcome::Succeeded,
+                        attempt,
+                        None,
+                        Some(&bytes),
+                    );
+                }
+                Ok(_) => {
+                    break receipt(
+                        policy.revision,
+                        &tool_id,
+                        interval_started_at.clone(),
+                        ReceiptOutcome::Failed,
+                        attempt,
+                        Some(DiagnosticScheduleError::ResultTooLarge.to_string()),
+                        None,
+                    );
+                }
+                Err(DiagnosticScheduleError::Cancelled) => {
+                    break receipt(
+                        policy.revision,
+                        &tool_id,
+                        interval_started_at.clone(),
+                        ReceiptOutcome::Cancelled,
+                        attempt,
+                        Some(DiagnosticScheduleError::Cancelled.to_string()),
+                        None,
+                    );
+                }
+                Err(_error) if attempt < MAX_ATTEMPTS => {
+                    tokio::select! {
+                        biased;
+                        () = shutdown.cancelled() => {
+                            break receipt(
+                                policy.revision,
+                                &tool_id,
+                                interval_started_at.clone(),
+                                ReceiptOutcome::Cancelled,
+                                attempt,
+                                Some(DiagnosticScheduleError::Cancelled.to_string()),
+                                None,
+                            );
+                        }
+                        changed = policies.changed() => {
+                            let _ = changed;
+                            break receipt(
+                                policy.revision,
+                                &tool_id,
+                                interval_started_at.clone(),
+                                ReceiptOutcome::Cancelled,
+                                attempt,
+                                Some(DiagnosticScheduleError::Cancelled.to_string()),
+                                None,
+                            );
+                        }
+                        () = tokio::time::sleep(retry) => {}
+                    }
+                    attempt += 1;
+                    retry = retry.saturating_mul(2).min(MAX_RETRY);
+                }
+                Err(error) => {
+                    break receipt(
+                        policy.revision,
+                        &tool_id,
+                        interval_started_at.clone(),
+                        ReceiptOutcome::Failed,
+                        attempt,
+                        Some(error.to_string()),
+                        None,
+                    );
+                }
+            }
+        };
+        state.active_interval_started_at = None;
+        state.last_receipt = Some(receipt.clone());
+        store.write(state.clone()).await?;
+        let _ = status.send(DiagnosticScheduleStatus::Receipt(receipt));
+    }
+    Ok(())
+}
+
+async fn wait_for_policy(policies: &mut watch::Receiver<DiagnosticCollectionPolicy>, shutdown: &CancellationToken) -> bool {
+    tokio::select! {
+        biased;
+        () = shutdown.cancelled() => true,
+        result = policies.changed() => result.is_err(),
+    }
+}
+
+fn receipt(
+    revision: u64,
+    tool_id: &str,
+    interval_started_at: String,
+    outcome: ReceiptOutcome,
+    attempt_count: u8,
+    reason: Option<String>,
+    bytes: Option<&[u8]>,
+) -> DiagnosticReceipt {
+    DiagnosticReceipt {
+        receipt_id: Uuid::new_v4().to_string(),
+        policy_revision: revision,
+        tool_id: tool_id.to_owned(),
+        interval_started_at,
+        completed_at: now_string(),
+        outcome,
+        attempt_count,
+        reason,
+        result_sha256: bytes.map(|value| hex_simd::encode_to_string(Sha256::digest(value), hex_simd::AsciiCase::Lower)),
+        result_bytes: bytes.map(<[u8]>::len),
+    }
+}
+
+fn now_string() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+fn parse_time(value: &str) -> Result<DateTime<Utc>, DiagnosticScheduleError> {
+    if value.len() != 20 || !value.ends_with('Z') {
+        return Err(DiagnosticScheduleError::Policy);
+    }
+    DateTime::parse_from_rfc3339(value)
+        .map(|value| value.with_timezone(&Utc))
+        .map_err(|_| DiagnosticScheduleError::Policy)
+}
+
+fn read_state(path: &Path) -> Result<ScheduleState, DiagnosticScheduleError> {
+    let bytes = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(ScheduleState::default()),
+        Err(error) => return Err(DiagnosticScheduleError::StateIo(error)),
+    };
+    if bytes.len() > MAX_RESULT_BYTES {
+        return Err(DiagnosticScheduleError::StateCorrupt);
+    }
+    serde_json::from_slice(&bytes).map_err(DiagnosticScheduleError::StateInvalid)
+}
+
+fn write_state(path: &Path, state: &ScheduleState) -> Result<(), DiagnosticScheduleError> {
+    let bytes = serde_json::to_vec(state).map_err(DiagnosticScheduleError::StateInvalid)?;
+    let directory = path.parent().ok_or(DiagnosticScheduleError::StateCorrupt)?;
+    fs::create_dir_all(directory).map_err(DiagnosticScheduleError::StateIo)?;
+    let temp = path.with_extension(format!("tmp-{}", Uuid::new_v4()));
+    let mut options = fs::OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(FILE_MODE);
+    }
+    let mut file = options.open(&temp).map_err(DiagnosticScheduleError::StateIo)?;
+    let result = file
+        .write_all(&bytes)
+        .and_then(|()| file.sync_all())
+        .and_then(|()| fs::rename(&temp, path))
+        .map_err(DiagnosticScheduleError::StateIo);
+    if result.is_err() {
+        let _ = fs::remove_file(temp);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn policy(revision: u64, running: bool) -> DiagnosticCollectionPolicy {
+        serde_json::from_value(json!({
+            "policyName": if running { Some("organizations/0198f4b0-1a00-7c10-8d21-2e3f4a5b6c70/clusters/0198f4b0-2b00-7d20-9e31-3f4a5b6c7d81/diagnosticCollectionPreference") } else { None },
+            "revision": revision,
+            "supportState": "SUPPORTED",
+            "desiredState": if running { "RUNNING" } else { "STOPPED" },
+            "reasonCode": if running { None::<&str> } else { Some("DISABLED") },
+            "toolIds": if running { vec!["inventory.environment"] } else { vec![] },
+            "intervalSeconds": if running { Some(300) } else { None },
+            "scope": "CLUSTER",
+            "retentionDays": if running { Some(7) } else { None },
+            "consentReference": if running { Some("organizations/0198f4b0-1a00-7c10-8d21-2e3f4a5b6c70/diagnosticCollectionConsents/0198f4b0-3c00-7e30-8f41-4a5b6c7d8e92") } else { None },
+            "consentExpiresAt": if running { Some("2099-01-01T00:00:00Z") } else { None }
+        }))
+        .expect("policy")
+    }
+
+    async fn wait_running(status: &mut watch::Receiver<DiagnosticScheduleStatus>) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !matches!(&*status.borrow(), DiagnosticScheduleStatus::Running { .. }) {
+                status.changed().await.expect("schedule remains active");
+            }
+        })
+        .await
+        .expect("running");
+    }
+
+    fn blocking_runner() -> Runner {
+        Arc::new(|cancel| {
+            Box::pin(async move {
+                cancel.cancelled().await;
+                Err(DiagnosticScheduleError::Cancelled)
+            })
+        })
+    }
+
+    #[tokio::test]
+    async fn disable_cancels_an_active_run_and_persists_receipt() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (policy_tx, policy_rx) = watch::channel(policy(1, true));
+        let shutdown = CancellationToken::new();
+        let mut runtime = spawn_schedule(StateStore::new(temp.path()), policy_rx, shutdown.clone(), blocking_runner());
+        wait_running(&mut runtime.status).await;
+        policy_tx.send(policy(2, false)).expect("disable");
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let state = StateStore::new(temp.path()).read().await.expect("state");
+                if state
+                    .last_receipt
+                    .is_some_and(|receipt| receipt.outcome == ReceiptOutcome::Cancelled)
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("cancel receipt");
+        let state = StateStore::new(temp.path()).read().await.expect("state");
+        assert_eq!(state.last_receipt.expect("receipt").outcome, ReceiptOutcome::Cancelled);
+        shutdown.cancel();
+        runtime.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_cancels_an_active_run_and_persists_receipt() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (_policy_tx, policy_rx) = watch::channel(policy(3, true));
+        let shutdown = CancellationToken::new();
+        let mut runtime = spawn_schedule(StateStore::new(temp.path()), policy_rx, shutdown.clone(), blocking_runner());
+        wait_running(&mut runtime.status).await;
+        shutdown.cancel();
+        runtime.shutdown().await;
+        let state = StateStore::new(temp.path()).read().await.expect("state");
+        assert_eq!(state.last_receipt.expect("receipt").outcome, ReceiptOutcome::Cancelled);
+    }
+}

--- a/rustfs/src/connect/heartbeat.rs
+++ b/rustfs/src/connect/heartbeat.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 
 use super::config::HeartbeatConfig;
 use super::credential_store::CredentialStoreError;
+use super::diagnostics::DiagnosticCollectionPolicy;
 use super::identity::IdentityError;
 use super::identity_store::StoreError;
 use super::registration::CredentialValidationError;
@@ -82,7 +83,7 @@ pub(crate) struct PendingHeartbeat {
     protocol_version: String,
     request_id: String,
     agent_version: String,
-    capabilities: [String; 1],
+    capabilities: Vec<String>,
     sequence: u64,
     client_time: String,
     coarse_node_summary: CoarseNodeSummary,
@@ -92,7 +93,8 @@ impl PendingHeartbeat {
     fn is_valid(&self) -> bool {
         self.protocol_version == PROTOCOL_VERSION
             && self.agent_version == AGENT_VERSION
-            && self.capabilities[0] == "heartbeat"
+            && (self.capabilities == ["heartbeat"]
+                || self.capabilities == ["heartbeat", DiagnosticCollectionPolicy::policy_sync_capability()])
             && self.sequence <= MAX_SEQUENCE
             && self.coarse_node_summary.is_valid()
             && is_exact_utc_seconds(&self.client_time)
@@ -108,13 +110,26 @@ struct HeartbeatResponse {
     accepted_version: String,
     #[serde(default)]
     capability_hints: Vec<String>,
+    #[serde(default)]
+    diagnostic_collection_policy: Option<DiagnosticCollectionPolicy>,
 }
 
 pub(crate) enum Delivery {
-    Accepted { server_time: String },
-    Retry { retry_after: Option<Duration> },
-    AuthenticationStopped { status: u16, reason: Option<String> },
-    Rejected { status: u16, reason: Option<String> },
+    Accepted {
+        server_time: String,
+        diagnostic_collection_policy: DiagnosticCollectionPolicy,
+    },
+    Retry {
+        retry_after: Option<Duration>,
+    },
+    AuthenticationStopped {
+        status: u16,
+        reason: Option<String>,
+    },
+    Rejected {
+        status: u16,
+        reason: Option<String>,
+    },
 }
 
 pub(crate) struct HeartbeatSender {
@@ -143,8 +158,13 @@ impl HeartbeatSender {
                 {
                     return Err(HeartbeatError::Response);
                 }
+                let policy = accepted
+                    .diagnostic_collection_policy
+                    .unwrap_or_else(DiagnosticCollectionPolicy::stopped);
+                policy.validate().map_err(|_| HeartbeatError::Response)?;
                 Ok(Delivery::Accepted {
                     server_time: accepted.server_time,
+                    diagnostic_collection_policy: policy,
                 })
             }
             TelemetryDelivery::Retry { retry_after } => Ok(Delivery::Retry { retry_after }),
@@ -220,7 +240,10 @@ impl HeartbeatStateStore {
             protocol_version: PROTOCOL_VERSION.to_owned(),
             request_id: Uuid::new_v4().to_string(),
             agent_version: AGENT_VERSION.to_owned(),
-            capabilities: ["heartbeat".to_owned()],
+            capabilities: vec![
+                "heartbeat".to_owned(),
+                DiagnosticCollectionPolicy::policy_sync_capability().to_owned(),
+            ],
             sequence: state.next_sequence,
             client_time: now.to_rfc3339_opts(SecondsFormat::Secs, true),
             coarse_node_summary: summary,

--- a/rustfs/src/connect/mod.rs
+++ b/rustfs/src/connect/mod.rs
@@ -28,6 +28,7 @@
 pub mod client;
 pub mod config;
 pub mod credential_store;
+pub mod diagnostics;
 pub mod environment;
 pub mod heartbeat;
 pub mod identity;
@@ -43,6 +44,10 @@ mod telemetry;
 pub use client::{ClientError, ConnectClient, ConnectConfig};
 pub use config::{HeartbeatConfig, HeartbeatConfigError, HeartbeatSchedule};
 pub use credential_store::{CredentialStore, DeviceCredential};
+pub use diagnostics::{
+    DiagnosticCollectionPolicy, DiagnosticReceipt, DiagnosticScheduleError, DiagnosticScheduleRuntime, DiagnosticScheduleStatus,
+    ReceiptOutcome, run_local_environment_once, spawn_environment_schedule,
+};
 pub use environment::{
     ENVIRONMENT_CAPABILITY, ENVIRONMENT_SCHEMA_VERSION, EnvironmentCollectionRequest, EnvironmentError,
     EnvironmentFilesystemType, EnvironmentInventory, EnvironmentOsFamily, MAX_ENVIRONMENT_DURATION, collect_environment,

--- a/rustfs/src/connect/runtime.rs
+++ b/rustfs/src/connect/runtime.rs
@@ -25,6 +25,9 @@ use tokio_util::sync::CancellationToken;
 
 use super::client::{ClientError, ConnectClient, ConnectConfig, RotationAttempt};
 use super::config::HeartbeatConfig;
+use super::diagnostics::{
+    DiagnosticCollectionPolicy, DiagnosticScheduleRuntime, DiagnosticScheduleStatus, spawn_environment_schedule,
+};
 use super::heartbeat::{CoarseNodeSummary, Delivery, HeartbeatError, HeartbeatSender, HeartbeatStateStore, HeartbeatStatus};
 use super::inventory::{
     InventoryDelivery, InventoryError, InventorySchedule, InventorySender, InventorySnapshot, InventoryStateStore,
@@ -35,6 +38,8 @@ pub struct HeartbeatRuntime {
     shutdown: CancellationToken,
     status: watch::Receiver<HeartbeatStatus>,
     task: Option<JoinHandle<()>>,
+    diagnostic_status: watch::Receiver<DiagnosticScheduleStatus>,
+    diagnostic_task: Option<DiagnosticScheduleRuntime>,
 }
 
 impl HeartbeatRuntime {
@@ -42,10 +47,17 @@ impl HeartbeatRuntime {
         self.status.clone()
     }
 
+    pub fn diagnostic_status(&self) -> watch::Receiver<DiagnosticScheduleStatus> {
+        self.diagnostic_status.clone()
+    }
+
     pub async fn shutdown(mut self) {
         self.shutdown.cancel();
         if let Some(task) = self.task.take() {
             let _ = task.await;
+        }
+        if let Some(task) = self.diagnostic_task.take() {
+            task.shutdown().await;
         }
     }
 }
@@ -122,9 +134,14 @@ where
     let store = HeartbeatStateStore::new(config.state_path.clone());
     let lock = store.try_runtime_lock()?;
     let schedule = config.schedule;
+    let state_root = config.state_root().ok_or(HeartbeatError::StateConflict)?.to_path_buf();
     let shutdown = parent_shutdown.child_token();
     let task_shutdown = shutdown.clone();
     let (status_tx, status_rx) = watch::channel(HeartbeatStatus::Starting);
+    let (policy_tx, policy_rx) = watch::channel(DiagnosticCollectionPolicy::stopped());
+    let diagnostic_task =
+        spawn_environment_schedule(&state_root, policy_rx, shutdown.clone()).map_err(|_| HeartbeatError::StateConflict)?;
+    let diagnostic_status = diagnostic_task.status();
     let task = tokio::spawn(async move {
         let _lock = lock;
         let mut backoff = schedule.initial_backoff;
@@ -178,11 +195,15 @@ where
                 None => break,
             };
             let delay = match delivery {
-                Delivery::Accepted { server_time } => {
+                Delivery::Accepted {
+                    server_time,
+                    diagnostic_collection_policy,
+                } => {
                     if let Err(error) = store.mark_accepted(&pending).await {
                         return failed(&status_tx, error);
                     }
                     backoff = schedule.initial_backoff;
+                    let _ = policy_tx.send(diagnostic_collection_policy);
                     let _ = status_tx.send(HeartbeatStatus::Online { server_time });
                     schedule.cadence.saturating_add(jitter(schedule.jitter))
                 }
@@ -216,6 +237,8 @@ where
         shutdown,
         status: status_rx,
         task: Some(task),
+        diagnostic_status,
+        diagnostic_task: Some(diagnostic_task),
     }))
 }
 
@@ -547,6 +570,7 @@ mod tests {
         let (release_heartbeat, wait_for_release) = tokio::sync::oneshot::channel();
         let (inventory_stopped, stopped) = tokio::sync::oneshot::channel();
         let (_, heartbeat_status) = watch::channel(HeartbeatStatus::Starting);
+        let (_, diagnostic_status) = watch::channel(DiagnosticScheduleStatus::Waiting);
         let (_, inventory_status) = watch::channel(InventoryStatus::Starting);
         let heartbeat_task = tokio::spawn(async move {
             let _ = wait_for_release.await;
@@ -560,6 +584,8 @@ mod tests {
             shutdown: heartbeat_shutdown,
             status: heartbeat_status,
             task: Some(heartbeat_task),
+            diagnostic_status,
+            diagnostic_task: None,
         };
         let inventory = InventoryRuntime {
             shutdown: inventory_shutdown,

--- a/rustfs/tests/connect_diagnostic_schedule.rs
+++ b/rustfs/tests/connect_diagnostic_schedule.rs
@@ -1,0 +1,142 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use rustfs::connect::{
+    DiagnosticCollectionPolicy, DiagnosticScheduleError, DiagnosticScheduleStatus, InventorySnapshot, ReceiptOutcome,
+    run_local_environment_once, spawn_environment_schedule,
+};
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+
+fn policy(revision: u64, desired_state: &str, reason_code: Option<&str>) -> DiagnosticCollectionPolicy {
+    serde_json::from_value(serde_json::json!({
+        "policyName": "organizations/0198f4b0-1a00-7c10-8d21-2e3f4a5b6c70/clusters/0198f4b0-2b00-7d20-9e31-3f4a5b6c7d81/diagnosticCollectionPreference",
+        "revision": revision,
+        "supportState": "SUPPORTED",
+        "desiredState": desired_state,
+        "reasonCode": reason_code,
+        "toolIds": if desired_state == "RUNNING" { vec!["inventory.environment"] } else { vec![] },
+        "intervalSeconds": if desired_state == "RUNNING" { Some(300) } else { None },
+        "scope": "CLUSTER",
+        "retentionDays": if desired_state == "RUNNING" { Some(7) } else { None },
+        "consentReference": if desired_state == "RUNNING" { Some("organizations/0198f4b0-1a00-7c10-8d21-2e3f4a5b6c70/diagnosticCollectionConsents/0198f4b0-3c00-7e30-8f41-4a5b6c7d8e92") } else { None },
+        "consentExpiresAt": if desired_state == "RUNNING" { Some("2099-01-01T00:00:00Z") } else { None }
+    }))
+    .expect("policy")
+}
+
+async fn receipt(status: &mut watch::Receiver<DiagnosticScheduleStatus>) -> rustfs::connect::DiagnosticReceipt {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if let DiagnosticScheduleStatus::Receipt(receipt) = status.borrow().clone() {
+                return receipt;
+            }
+            status.changed().await.expect("schedule remains active");
+        }
+    })
+    .await
+    .expect("receipt timeout")
+}
+
+#[tokio::test]
+async fn local_one_shot_observes_cancellation_before_collecting() {
+    let inventory = InventorySnapshot::current(1, 1, 1_024, 512, []).expect("inventory");
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+
+    assert!(matches!(
+        run_local_environment_once(&inventory, &cancel).await,
+        Err(DiagnosticScheduleError::Cancelled)
+    ));
+}
+
+#[test]
+fn collection_policy_contract_rejects_unknown_fields() {
+    let policy = serde_json::json!({
+        "policyName": null,
+        "revision": 0,
+        "supportState": "SUPPORTED",
+        "desiredState": "STOPPED",
+        "reasonCode": "DISABLED",
+        "toolIds": [],
+        "intervalSeconds": null,
+        "scope": "CLUSTER",
+        "retentionDays": null,
+        "consentReference": null,
+        "consentExpiresAt": null,
+        "unexpected": true
+    });
+
+    assert!(serde_json::from_value::<rustfs::connect::DiagnosticCollectionPolicy>(policy).is_err());
+}
+
+#[tokio::test]
+async fn missing_inventory_has_bounded_retries_and_durable_failure_receipt() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let (_policy_tx, policy_rx) = watch::channel(policy(3, "RUNNING", None));
+    let shutdown = CancellationToken::new();
+    let mut runtime = spawn_environment_schedule(temp.path(), policy_rx, shutdown.clone()).expect("scheduler");
+    let mut status = runtime.status();
+
+    let failed = receipt(&mut status).await;
+    assert_eq!(failed.outcome, ReceiptOutcome::Failed);
+    assert_eq!(failed.attempt_count, 3);
+    let state: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(temp.path().join("diagnostics/schedule.json")).expect("durable state"))
+            .expect("state JSON");
+    assert_eq!(state["lastReceipt"]["receiptId"], failed.receipt_id);
+    shutdown.cancel();
+    runtime.shutdown().await;
+
+    let (_policy_tx, policy_rx) = watch::channel(policy(3, "RUNNING", None));
+    let shutdown = CancellationToken::new();
+    runtime = spawn_environment_schedule(temp.path(), policy_rx, shutdown.clone()).expect("restart scheduler");
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let restarted: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(temp.path().join("diagnostics/schedule.json")).expect("durable state"))
+            .expect("state JSON");
+    assert_eq!(restarted["lastReceipt"]["receiptId"], failed.receipt_id);
+    shutdown.cancel();
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn consent_revoke_cancels_retry_and_persists_receipt() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let (policy_tx, policy_rx) = watch::channel(policy(4, "RUNNING", None));
+    let shutdown = CancellationToken::new();
+    let runtime = spawn_environment_schedule(temp.path(), policy_rx, shutdown.clone()).expect("scheduler");
+    let mut status = runtime.status();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while !matches!(&*status.borrow(), DiagnosticScheduleStatus::Running { .. }) {
+            status.changed().await.expect("schedule remains active");
+        }
+    })
+    .await
+    .expect("first attempt");
+
+    policy_tx
+        .send(policy(5, "STOPPED", Some("CONSENT_INACTIVE")))
+        .expect("revoke policy");
+    let cancelled = receipt(&mut status).await;
+    assert_eq!(cancelled.outcome, ReceiptOutcome::Cancelled);
+    let state: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(temp.path().join("diagnostics/schedule.json")).expect("durable state"))
+            .expect("state JSON");
+    assert_eq!(state["lastReceipt"]["outcome"], "CANCELLED");
+    shutdown.cancel();
+    runtime.shutdown().await;
+}

--- a/rustfs/tests/connect_heartbeat.rs
+++ b/rustfs/tests/connect_heartbeat.rs
@@ -514,7 +514,7 @@ async fn sends_only_l0_fields_and_accepts_additive_response_fields() {
             "sequence"
         ]
     );
-    assert_eq!(request["capabilities"], json!(["heartbeat"]));
+    assert_eq!(request["capabilities"], json!(["heartbeat", "diagnostics.policy.v1"]));
     assert_eq!(request["coarseNodeSummary"], json!({"total": 8, "healthy": 7, "degraded": 1}));
     assert_ne!(request["clientTime"], "2038-01-19T03:14:07Z");
     assert!(request.get("authorization").is_none());


### PR DESCRIPTION
Add consent-bound diagnostic scheduling to the outbound Connect heartbeat runtime. A new policy revision runs the existing bounded environment collector immediately, then persists the next interval so restarts do not duplicate it.

The scheduler enforces 5-minute to 24-hour cadence, 1–14 day retention, consent expiry, 30-second collection and 64 KiB result limits. It records durable success, failure, or cancellation receipts, retries failures at most three times, and cancels active or retrying work when the policy is disabled, revoked, changed, or the runtime shuts down. A public local one-shot entry point uses the same collector and cancellation rules.

Validation: diagnostic scheduler integration 4/4, `cargo check -p rustfs --lib`, `cargo fmt --all -- --check`, and diff check. The broader heartbeat/lib test binaries were stopped during repeated full-crate linking; no test failure was observed.

Connect still reports `TOOL_CAPABILITY_UNSUPPORTED` until it accepts `inventory.environment@1`, and the protocol has no receipt upload endpoint yet. Receipts remain local and durable for this slice.

Refs rustfs/connect#652
