### PR TITLE
Add bounded top diagnostic captures

### DIFF
--- a/rustfs/src/config/cli.rs
+++ b/rustfs/src/config/cli.rs
@@ -135,6 +135,74 @@ pub enum ConnectCommands {
     Logs(ConnectLogsOpts),
     /// Record, forward, or replay consent-bound telemetry
     Telemetry(ConnectTelemetryOpts),
+    /// Capture a consent-bound local top snapshot
+    Top(ConnectTopOpts),
+}
+
+#[derive(Args, Clone)]
+pub struct ConnectTopOpts {
+    #[command(subcommand)]
+    pub command: ConnectTopCommands,
+}
+
+#[derive(Subcommand, Clone)]
+pub enum ConnectTopCommands {
+    /// Capture API activity when an approved typed source is available
+    Api(ConnectTopCaptureOpts),
+    /// Capture process disk I/O on supported platforms
+    Disk(ConnectTopCaptureOpts),
+    /// Capture lock activity when an approved typed source is available
+    Locks(ConnectTopCaptureOpts),
+    /// Capture internode network traffic
+    Net(ConnectTopCaptureOpts),
+    /// Capture RPC activity when an approved typed source is available
+    Rpc(ConnectTopCaptureOpts),
+}
+
+#[derive(Args, Clone)]
+pub struct ConnectTopCaptureOpts {
+    /// Directory containing an enrolled Connect device identity
+    #[arg(long = "state-dir")]
+    pub state_dir: PathBuf,
+    /// New local archive path; an existing file is never replaced
+    #[arg(long)]
+    pub output: PathBuf,
+    /// Organization resource name bound to the export
+    #[arg(long, value_parser = NonEmptyStringValueParser::new())]
+    pub organization: String,
+    /// Cluster resource name bound to the export
+    #[arg(long, value_parser = NonEmptyStringValueParser::new())]
+    pub cluster: String,
+    /// Cluster-device resource name bound to the export
+    #[arg(long, value_parser = NonEmptyStringValueParser::new())]
+    pub device: String,
+    /// UUIDv7 diagnostic run identifier issued by Connect
+    #[arg(long = "run-uid", value_parser = NonEmptyStringValueParser::new())]
+    pub run_uid: String,
+    /// UUIDv7 artifact identifier issued by Connect
+    #[arg(long = "artifact-uid", value_parser = NonEmptyStringValueParser::new())]
+    pub artifact_uid: String,
+    /// UUIDv7 consent identifier issued by Connect
+    #[arg(long = "consent-uid", value_parser = NonEmptyStringValueParser::new())]
+    pub consent_uid: String,
+    /// Consent policy revision bound to this capture
+    #[arg(long = "policy-revision")]
+    pub policy_revision: u64,
+    /// Consent expiry as UTC Unix seconds
+    #[arg(long = "consent-expires-at")]
+    pub consent_expires_at_unix: i64,
+    /// Diagnostic run expiry as UTC Unix seconds
+    #[arg(long = "run-expires-at")]
+    pub run_expires_at_unix: i64,
+    /// Monotonic sampling window in milliseconds
+    #[arg(long = "window-millis", default_value_t = 1_000)]
+    pub window_millis: u64,
+    /// Signed export validity in seconds
+    #[arg(long = "export-validity-seconds", default_value_t = 300)]
+    pub export_validity_seconds: u64,
+    /// Confirm this explicit local L3 diagnostic operation
+    #[arg(long = "acknowledge-l3", required = true, action = clap::ArgAction::SetTrue)]
+    pub acknowledge_l3: bool,
 }
 
 #[derive(Args, Clone)]
@@ -890,6 +958,8 @@ pub enum CommandResult {
     ConnectLogs(ConnectLogsOpts),
     /// Consent-bound local Connect telemetry operation
     ConnectTelemetry(ConnectTelemetryCommands),
+    /// Consent-bound local Connect top operation
+    ConnectTop(ConnectTopCommands),
 }
 
 /// Create default ServerOpts from environment variables

--- a/rustfs/src/config/mod.rs
+++ b/rustfs/src/config/mod.rs
@@ -59,6 +59,7 @@ pub use cli::{
     ConnectTelemetryArtifactOpts, ConnectTelemetryCommands, ConnectTelemetryOtlpOpts, ConnectTelemetryRecordOpts,
     ConnectTelemetryReplayOpts,
 };
+pub use cli::{ConnectTopCaptureOpts, ConnectTopCommands};
 pub use cli::{DiagnoseFormat, DiagnoseOpts};
 pub use cli::{InspectBucketMetaOpts, InspectCommands, InspectOpts};
 pub use cli::{TlsCommands, TlsInspectOpts, TlsOpts};

--- a/rustfs/src/config/opt.rs
+++ b/rustfs/src/config/opt.rs
@@ -149,6 +149,7 @@ impl Opt {
                 ConnectCommands::Profile(opts) => Ok(CommandResult::ConnectProfile(opts)),
                 ConnectCommands::Logs(opts) => Ok(CommandResult::ConnectLogs(opts)),
                 ConnectCommands::Telemetry(opts) => Ok(CommandResult::ConnectTelemetry(opts.command)),
+                ConnectCommands::Top(opts) => Ok(CommandResult::ConnectTop(opts.command)),
             },
             Some(Commands::Server(opts)) => Self::server_command_result(Self::from_server_opts(*opts)),
             None => {

--- a/rustfs/src/connect/diagnostics/mod.rs
+++ b/rustfs/src/connect/diagnostics/mod.rs
@@ -18,6 +18,11 @@ mod profile_cpu;
 mod profile_memory;
 mod profile_threads;
 mod schedule;
+mod top_api;
+mod top_disk;
+mod top_locks;
+mod top_net;
+mod top_rpc;
 mod trace_analysis;
 mod trace_otlp;
 mod trace_record;
@@ -45,6 +50,15 @@ pub use schedule::{
     DiagnosticCollectionPolicy, DiagnosticReceipt, DiagnosticScheduleError, DiagnosticScheduleRuntime, DiagnosticScheduleStatus,
     ReceiptOutcome, run_local_environment_once, spawn_environment_schedule,
 };
+pub use top_api::{
+    LocalTopConsent, MAX_TOP_DURATION, MAX_TOP_EXPORT_VALIDITY, SavedTopExport, SignedTopExport, TOP_CLASSIFICATION,
+    TOP_SCHEMA_VERSION, TopApiData, TopApiOperation, TopCaptureError, TopCaptureLimits, TopCaptureRequest, TopCaptureScope,
+    TopCoverage, TopOutcome, TopProvenance, TopReasonCode, TopResult, capture_top_api, save_signed_top_export, sign_top_export,
+};
+pub use top_disk::{DiskCounterSnapshot, TopDiskData, capture_top_disk, evaluate_disk_window};
+pub use top_locks::{TopLocksData, capture_top_locks};
+pub use top_net::{NetworkCounterSnapshot, TopNetData, capture_top_net, evaluate_network_window};
+pub use top_rpc::{TopRpcData, capture_top_rpc};
 pub use trace_analysis::{OperationSummary, TraceAnalysis, TraceAnalysisError, analyze_trace};
 pub use trace_otlp::{
     LocalOtlpHeaders, MAX_OTLP_BODY_BYTES, OtlpBatch, OtlpForwardError, OtlpReceipt, export_trace_otlp, export_trace_otlp_result,

--- a/rustfs/src/connect/diagnostics/top_api.rs
+++ b/rustfs/src/connect/diagnostics/top_api.rs
@@ -1,0 +1,856 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared bounded result/export contract and the `top.api` producer.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{Cursor, Write as _};
+use std::path::Path;
+use std::time::Duration;
+
+use base64_simd::URL_SAFE_NO_PAD;
+use p256::ecdsa::{Signature, SigningKey, signature::Signer as _};
+use p256::pkcs8::DecodePrivateKey as _;
+use rand::{TryRng as _, rngs::SysRng};
+use serde::Serialize;
+use sha2::{Digest as _, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+use tokio::sync::{Semaphore, SemaphorePermit};
+use tokio_util::sync::CancellationToken;
+use uuid::{Uuid, Variant, Version};
+use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
+
+use crate::connect::identity::DeviceIdentity;
+
+pub const TOP_SCHEMA_VERSION: u8 = 1;
+pub const TOP_CLASSIFICATION: &str = "L3";
+pub const MAX_TOP_DURATION: Duration = Duration::from_secs(30);
+pub const MAX_TOP_RESULT_BYTES: usize = 262_144;
+pub const MAX_TOP_WORKING_MEMORY_BYTES: u64 = 67_108_864;
+pub const MAX_TOP_RECORDS: u16 = 1_024;
+pub const MAX_TOP_CPU_MILLIS: u64 = 5_000;
+pub const MAX_TOP_TEMPORARY_BYTES: u64 = 2_097_152;
+pub const MAX_TOP_TRAFFIC_BYTES: u64 = 1_048_576;
+pub const MAX_TOP_BANDWIDTH_BYTES_PER_SECOND: u64 = 1_048_576;
+pub const MAX_TOP_OPERATIONS: u16 = 1_024;
+pub const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+
+const ENVELOPE_FORMAT: &str = "rustfs.connect.diagnosticEnvelope/1";
+const PROTOCOL_VERSION: &str = "v1";
+const SIGNATURE_ALGORITHM: &str = "ES256";
+const SIGNATURE_DOMAIN: &[u8] = b"rustfs-diagnostic-envelope-v1";
+const MAX_ENVELOPE_BYTES: usize = 16_384;
+const MAX_ARCHIVE_BYTES: usize = 524_288;
+const MAX_DECOMPRESSED_BYTES: usize = 278_528;
+pub const MAX_TOP_EXPORT_VALIDITY: Duration = Duration::from_secs(2_592_000);
+const TOP_CAPTURE_WORKING_SET_BYTES: u64 = 1_048_576;
+const ENVELOPE_PATH: &str = "envelope.json";
+const SIGNATURE_PATH: &str = "envelope.sig";
+const RESULT_PATH: &str = "result.json";
+const OUTPUT_MODE: u32 = 0o600;
+static TOP_CAPTURE: Semaphore = Semaphore::const_new(1);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LocalTopConsent {
+    pub uid: String,
+    pub tool_id: String,
+    pub classification: String,
+    pub active: bool,
+    pub expires_at_unix: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TopCaptureScope {
+    pub organization_name: String,
+    pub cluster_name: String,
+    pub device_name: String,
+    pub run_uid: String,
+    pub artifact_uid: String,
+    pub policy_revision: u64,
+    pub run_expires_at_unix: i64,
+    pub executable_sha256: String,
+    pub build_features: Vec<String>,
+    pub consent: LocalTopConsent,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TopCaptureLimits {
+    pub max_duration_millis: u64,
+    pub max_result_bytes: usize,
+    pub max_working_memory_bytes: u64,
+    pub max_records: u16,
+    pub max_concurrency: u8,
+    pub max_cpu_millis: u64,
+    pub max_temporary_bytes: u64,
+    pub max_traffic_bytes: u64,
+    pub max_bandwidth_bytes_per_second: u64,
+    pub max_operations: u16,
+}
+
+impl Default for TopCaptureLimits {
+    fn default() -> Self {
+        Self {
+            max_duration_millis: MAX_TOP_DURATION.as_millis() as u64,
+            max_result_bytes: MAX_TOP_RESULT_BYTES,
+            max_working_memory_bytes: MAX_TOP_WORKING_MEMORY_BYTES,
+            max_records: MAX_TOP_RECORDS,
+            max_concurrency: 1,
+            max_cpu_millis: MAX_TOP_CPU_MILLIS,
+            max_temporary_bytes: MAX_TOP_TEMPORARY_BYTES,
+            max_traffic_bytes: MAX_TOP_TRAFFIC_BYTES,
+            max_bandwidth_bytes_per_second: MAX_TOP_BANDWIDTH_BYTES_PER_SECOND,
+            max_operations: MAX_TOP_OPERATIONS,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TopCaptureRequest {
+    pub scope: TopCaptureScope,
+    pub limits: TopCaptureLimits,
+    pub window: Duration,
+    pub export_validity: Duration,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TopOutcome {
+    Succeeded,
+    Partial,
+    Failed,
+    Unsupported,
+    Cancelled,
+}
+
+impl TopOutcome {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Succeeded => "SUCCEEDED",
+            Self::Partial => "PARTIAL",
+            Self::Failed => "FAILED",
+            Self::Unsupported => "UNSUPPORTED",
+            Self::Cancelled => "CANCELLED",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TopReasonCode {
+    Complete,
+    LimitExceeded,
+    SourceUnavailable,
+    UnsupportedTool,
+    UnsupportedPlatform,
+    Cancelled,
+    CounterReset,
+    CollectionFailed,
+}
+
+impl TopReasonCode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Complete => "COMPLETE",
+            Self::LimitExceeded => "LIMIT_EXCEEDED",
+            Self::SourceUnavailable => "SOURCE_UNAVAILABLE",
+            Self::UnsupportedTool => "UNSUPPORTED_TOOL",
+            Self::UnsupportedPlatform => "UNSUPPORTED_PLATFORM",
+            Self::Cancelled => "CANCELLED",
+            Self::CounterReset => "COUNTER_RESET",
+            Self::CollectionFailed => "COLLECTION_FAILED",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TopProvenance {
+    repository: &'static str,
+    source_commit: String,
+    executable_sha256: String,
+    rustfs_version: &'static str,
+    os_family: &'static str,
+    architecture: &'static str,
+    build_features: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TopCoverage {
+    pub requested_units: u32,
+    pub completed_units: u32,
+    pub unit: &'static str,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TopResult<T: Serialize> {
+    pub schema_version: u8,
+    pub run_uid: String,
+    pub tool_id: &'static str,
+    pub capability: String,
+    pub outcome: TopOutcome,
+    pub reason_code: TopReasonCode,
+    pub duration_millis: u64,
+    pub provenance: TopProvenance,
+    pub coverage: TopCoverage,
+    pub data: Option<T>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TopApiOperation {
+    GetObject,
+    PutObject,
+    HeadObject,
+    ListObjects,
+    InternalRpc,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TopApiData {
+    pub operation: TopApiOperation,
+    pub request_count: u64,
+    pub error_count: u64,
+    pub window_millis: u64,
+    pub total_duration_micros: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SignedTopExport {
+    pub artifact_uid: String,
+    pub archive_bytes: Vec<u8>,
+    pub archive_sha256: String,
+    pub envelope_json: Vec<u8>,
+    pub envelope_signature: Vec<u8>,
+    pub result_json: Vec<u8>,
+    pub result_sha256: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SavedTopExport {
+    pub artifact_uid: String,
+    pub archive_size_bytes: u64,
+    pub archive_sha256: String,
+}
+
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum TopCaptureError {
+    #[error("connect_top_consent_required")]
+    ConsentRequired,
+    #[error("connect_top_consent_expired")]
+    ConsentExpired,
+    #[error("connect_top_consent_scope_invalid")]
+    ConsentScope,
+    #[error("connect_top_scope_invalid")]
+    Scope,
+    #[error("connect_top_provenance_invalid")]
+    Provenance,
+    #[error("connect_top_limits_invalid")]
+    Limits,
+    #[error("connect_top_run_expired")]
+    Expired,
+    #[error("connect_top_result_invalid")]
+    Result,
+    #[error("connect_top_cancelled")]
+    Cancelled,
+    #[error("connect_top_result_too_large")]
+    ResultTooLarge,
+    #[error("connect_top_serialization_failed")]
+    Serialization,
+    #[error("connect_top_signing_failed")]
+    Signing,
+    #[error("connect_top_random_failed")]
+    Random,
+    #[error("connect_top_export_exists")]
+    AlreadyExists,
+    #[error("connect_top_io_failed: {0:?}")]
+    Io(std::io::ErrorKind),
+    #[error("connect_top_export_durability_failed_after_commit: {0:?}")]
+    DurabilityAfterCommit(std::io::ErrorKind),
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DiagnosticEnvelope<'a> {
+    format_version: &'static str,
+    protocol_version: &'static str,
+    organization_name: &'a str,
+    cluster_name: &'a str,
+    device_name: &'a str,
+    run_uid: &'a str,
+    artifact_uid: &'a str,
+    tool_id: &'static str,
+    schema_version: u8,
+    classification: &'static str,
+    consent_uid: &'a str,
+    policy_revision: u64,
+    produced_at: String,
+    expires_at: String,
+    nonce: String,
+    device_key_id: String,
+    payload: DiagnosticPayload,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DiagnosticPayload {
+    path: &'static str,
+    media_type: &'static str,
+    size_bytes: usize,
+    sha256: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DiagnosticSignature {
+    algorithm: &'static str,
+    key_id: String,
+    value: String,
+}
+
+pub async fn capture_top_api(
+    request: &TopCaptureRequest,
+    _operation: TopApiOperation,
+    cancel: &CancellationToken,
+) -> Result<TopResult<TopApiData>, TopCaptureError> {
+    request.validate_capture("top.api")?;
+    if cancel.is_cancelled() {
+        return request.cancelled("top.api");
+    }
+
+    // RustFS has exact bounded S3 operation/outcome counters, but no snapshot of
+    // total request duration for the same operation/window. The v1 shape makes
+    // that field mandatory, so publishing the available counters would invent a
+    // duration or mix unrelated histograms.
+    request.unsupported("top.api", TopReasonCode::UnsupportedTool)
+}
+
+pub fn sign_top_export<T: Serialize>(
+    request: &TopCaptureRequest,
+    result: &TopResult<T>,
+    identity: &DeviceIdentity,
+    cancel: &CancellationToken,
+) -> Result<SignedTopExport, TopCaptureError> {
+    if !matches!(result.tool_id, "top.api" | "top.disk" | "top.locks" | "top.net" | "top.rpc") {
+        return Err(TopCaptureError::Result);
+    }
+    request.validate_scope(result.tool_id)?;
+    if cancel.is_cancelled() {
+        return Err(TopCaptureError::Cancelled);
+    }
+    if result.schema_version != TOP_SCHEMA_VERSION
+        || result.run_uid != request.scope.run_uid
+        || result.capability != format!("{}@{TOP_SCHEMA_VERSION}", result.tool_id)
+        || result.provenance != provenance(&request.scope)?
+        || !valid_export_outcome(result)
+    {
+        return Err(TopCaptureError::Result);
+    }
+
+    let data =
+        serde_json::to_value(result.data.as_ref().ok_or(TopCaptureError::Result)?).map_err(|_| TopCaptureError::Serialization)?;
+    if !data.is_object() {
+        return Err(TopCaptureError::Result);
+    }
+
+    let result_json = serde_json::to_vec(result).map_err(|_| TopCaptureError::Serialization)?;
+    if result_json.len() > request.limits.max_result_bytes || result_json.len() > MAX_TOP_RESULT_BYTES {
+        return Err(TopCaptureError::ResultTooLarge);
+    }
+    let result_sha256 = hex_lower(&Sha256::digest(&result_json));
+    let now = OffsetDateTime::now_utc();
+    let export_validity = time::Duration::try_from(request.export_validity).map_err(|_| TopCaptureError::Expired)?;
+    let requested_expiry = now
+        .checked_add(export_validity)
+        .ok_or(TopCaptureError::Expired)?
+        .unix_timestamp();
+    let expires_at_unix = requested_expiry
+        .min(request.scope.run_expires_at_unix)
+        .min(request.scope.consent.expires_at_unix);
+    if expires_at_unix <= now.unix_timestamp() {
+        return Err(TopCaptureError::Expired);
+    }
+
+    let mut nonce = [0u8; 32];
+    SysRng.try_fill_bytes(&mut nonce).map_err(|_| TopCaptureError::Random)?;
+    let device_key_id = hex_lower(&Sha256::digest(identity.public_key_der()));
+    let envelope = DiagnosticEnvelope {
+        format_version: ENVELOPE_FORMAT,
+        protocol_version: PROTOCOL_VERSION,
+        organization_name: &request.scope.organization_name,
+        cluster_name: &request.scope.cluster_name,
+        device_name: &request.scope.device_name,
+        run_uid: &request.scope.run_uid,
+        artifact_uid: &request.scope.artifact_uid,
+        tool_id: result.tool_id,
+        schema_version: TOP_SCHEMA_VERSION,
+        classification: TOP_CLASSIFICATION,
+        consent_uid: &request.scope.consent.uid,
+        policy_revision: request.scope.policy_revision,
+        produced_at: now.format(&Rfc3339).map_err(|_| TopCaptureError::Serialization)?,
+        expires_at: OffsetDateTime::from_unix_timestamp(expires_at_unix)
+            .map_err(|_| TopCaptureError::Expired)?
+            .format(&Rfc3339)
+            .map_err(|_| TopCaptureError::Serialization)?,
+        nonce: URL_SAFE_NO_PAD.encode_to_string(nonce),
+        device_key_id: device_key_id.clone(),
+        payload: DiagnosticPayload {
+            path: "result.json",
+            media_type: "application/json",
+            size_bytes: result_json.len(),
+            sha256: result_sha256.clone(),
+        },
+    };
+    let envelope_json = serde_json::to_vec(&envelope).map_err(|_| TopCaptureError::Serialization)?;
+    if envelope_json.len() > MAX_ENVELOPE_BYTES {
+        return Err(TopCaptureError::ResultTooLarge);
+    }
+    if cancel.is_cancelled() {
+        return Err(TopCaptureError::Cancelled);
+    }
+
+    let key = identity.to_pkcs8_der().map_err(|_| TopCaptureError::Signing)?;
+    let signing_key = SigningKey::from_pkcs8_der(key.as_slice()).map_err(|_| TopCaptureError::Signing)?;
+    let mut input = Vec::with_capacity(SIGNATURE_DOMAIN.len() + 1 + envelope_json.len());
+    input.extend_from_slice(SIGNATURE_DOMAIN);
+    input.push(0);
+    input.extend_from_slice(&envelope_json);
+    let signature: Signature = signing_key.sign(&input);
+    let signature = signature.normalize_s();
+    let envelope_signature = serde_json::to_vec(&DiagnosticSignature {
+        algorithm: SIGNATURE_ALGORITHM,
+        key_id: device_key_id,
+        value: URL_SAFE_NO_PAD.encode_to_string(signature.to_bytes()),
+    })
+    .map_err(|_| TopCaptureError::Serialization)?;
+    let decompressed_size = envelope_json
+        .len()
+        .checked_add(envelope_signature.len())
+        .and_then(|size| size.checked_add(result_json.len()))
+        .ok_or(TopCaptureError::ResultTooLarge)?;
+    if decompressed_size > MAX_DECOMPRESSED_BYTES {
+        return Err(TopCaptureError::ResultTooLarge);
+    }
+    if cancel.is_cancelled() {
+        return Err(TopCaptureError::Cancelled);
+    }
+    let archive_bytes = archive(&envelope_json, &envelope_signature, &result_json)?;
+    if archive_bytes.len() > MAX_ARCHIVE_BYTES {
+        return Err(TopCaptureError::ResultTooLarge);
+    }
+    let archive_sha256 = hex_lower(&Sha256::digest(&archive_bytes));
+
+    Ok(SignedTopExport {
+        artifact_uid: request.scope.artifact_uid.clone(),
+        archive_bytes,
+        archive_sha256,
+        envelope_json,
+        envelope_signature,
+        result_json,
+        result_sha256,
+    })
+}
+
+fn valid_export_outcome<T: Serialize>(result: &TopResult<T>) -> bool {
+    if result.duration_millis == 0
+        || result.duration_millis > MAX_TOP_DURATION.as_millis() as u64
+        || result.coverage.unit != "WINDOW"
+    {
+        return false;
+    }
+    match result.outcome {
+        TopOutcome::Succeeded => {
+            result.reason_code == TopReasonCode::Complete
+                && result.data.is_some()
+                && result.coverage.requested_units == 1
+                && result.coverage.completed_units == 1
+        }
+        TopOutcome::Partial => {
+            matches!(
+                result.reason_code,
+                TopReasonCode::LimitExceeded | TopReasonCode::SourceUnavailable | TopReasonCode::CounterReset
+            ) && result.data.is_some()
+                && result.coverage.completed_units > 0
+                && result.coverage.completed_units < result.coverage.requested_units
+                && result.coverage.requested_units <= 1_048_576
+        }
+        TopOutcome::Failed | TopOutcome::Unsupported | TopOutcome::Cancelled => false,
+    }
+}
+
+pub fn save_signed_top_export(
+    output: &Path,
+    export: &SignedTopExport,
+    cancel: &CancellationToken,
+) -> Result<SavedTopExport, TopCaptureError> {
+    if cancel.is_cancelled() {
+        return Err(TopCaptureError::Cancelled);
+    }
+    if !is_uuid_v7(&export.artifact_uid) {
+        return Err(TopCaptureError::Scope);
+    }
+    if export.archive_bytes.is_empty()
+        || export.archive_bytes.len() > MAX_ARCHIVE_BYTES
+        || hex_lower(&Sha256::digest(&export.archive_bytes)) != export.archive_sha256
+    {
+        return Err(TopCaptureError::Result);
+    }
+    let parent = output
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let filename = output.file_name().ok_or(TopCaptureError::Scope)?.to_string_lossy();
+    let temporary = parent.join(format!(".{filename}.{}.partial", export.artifact_uid));
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(OUTPUT_MODE);
+    }
+    let mut file = options.open(&temporary).map_err(map_create_error)?;
+    let result = (|| {
+        file.write_all(&export.archive_bytes).map_err(io_error)?;
+        if cancel.is_cancelled() {
+            return Err(TopCaptureError::Cancelled);
+        }
+        file.sync_all().map_err(io_error)?;
+        if cancel.is_cancelled() {
+            return Err(TopCaptureError::Cancelled);
+        }
+        fs::hard_link(&temporary, output).map_err(map_publish_error)?;
+        if let Err(error) = fs::remove_file(&temporary) {
+            return Err(TopCaptureError::DurabilityAfterCommit(error.kind()));
+        }
+        #[cfg(unix)]
+        if let Err(error) = File::open(parent).and_then(|directory| directory.sync_all()) {
+            return Err(TopCaptureError::DurabilityAfterCommit(error.kind()));
+        }
+        Ok(SavedTopExport {
+            artifact_uid: export.artifact_uid.clone(),
+            archive_size_bytes: export.archive_bytes.len() as u64,
+            archive_sha256: export.archive_sha256.clone(),
+        })
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+impl TopCaptureRequest {
+    pub(crate) fn validate_capture(&self, tool_id: &'static str) -> Result<(), TopCaptureError> {
+        self.validate_scope(tool_id)?;
+        if self.window.is_zero()
+            || self.window > MAX_TOP_DURATION
+            || self.window.as_millis() > u128::from(self.limits.max_duration_millis)
+        {
+            return Err(TopCaptureError::Limits);
+        }
+        let remaining = self
+            .scope
+            .run_expires_at_unix
+            .min(self.scope.consent.expires_at_unix)
+            .checked_sub(unix_now()?)
+            .ok_or(TopCaptureError::Expired)?;
+        if remaining <= 0 || self.window.as_secs_f64().ceil() as i64 > remaining {
+            return Err(TopCaptureError::Expired);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_scope(&self, tool_id: &'static str) -> Result<(), TopCaptureError> {
+        let now = unix_now()?;
+        validate_resource_scope(&self.scope)?;
+        validate_limits(self.limits)?;
+        validate_provenance(&self.scope)?;
+        if !self.scope.consent.active {
+            return Err(TopCaptureError::ConsentRequired);
+        }
+        if self.scope.consent.classification != TOP_CLASSIFICATION || self.scope.consent.tool_id != tool_id {
+            return Err(TopCaptureError::ConsentScope);
+        }
+        if self.scope.consent.expires_at_unix <= now {
+            return Err(TopCaptureError::ConsentExpired);
+        }
+        if self.scope.run_expires_at_unix <= now {
+            return Err(TopCaptureError::Expired);
+        }
+        if self.export_validity.is_zero() || self.export_validity > MAX_TOP_EXPORT_VALIDITY {
+            return Err(TopCaptureError::Limits);
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn acquire(&self, cancel: &CancellationToken) -> Result<Option<SemaphorePermit<'static>>, TopCaptureError> {
+        tokio::select! {
+            permit = TOP_CAPTURE.acquire() => Ok(Some(permit.map_err(|_| TopCaptureError::Limits)?)),
+            () = cancel.cancelled() => Ok(None),
+        }
+    }
+
+    pub(crate) async fn wait_window(&self, tool_id: &'static str, cancel: &CancellationToken) -> Result<bool, TopCaptureError> {
+        tokio::select! {
+            () = tokio::time::sleep(self.window) => {
+                self.validate_scope(tool_id)?;
+                Ok(true)
+            }
+            () = cancel.cancelled() => Ok(false),
+        }
+    }
+
+    pub(crate) fn succeeded<T: Serialize>(
+        &self,
+        tool_id: &'static str,
+        duration_millis: u64,
+        data: T,
+    ) -> Result<TopResult<T>, TopCaptureError> {
+        let result = TopResult {
+            schema_version: TOP_SCHEMA_VERSION,
+            run_uid: self.scope.run_uid.clone(),
+            tool_id,
+            capability: format!("{tool_id}@{TOP_SCHEMA_VERSION}"),
+            outcome: TopOutcome::Succeeded,
+            reason_code: TopReasonCode::Complete,
+            duration_millis,
+            provenance: provenance(&self.scope)?,
+            coverage: TopCoverage {
+                requested_units: 1,
+                completed_units: 1,
+                unit: "WINDOW",
+            },
+            data: Some(data),
+        };
+        self.bound_result(result)
+    }
+
+    pub(crate) fn failed<T: Serialize>(
+        &self,
+        tool_id: &'static str,
+        duration_millis: u64,
+        reason_code: TopReasonCode,
+    ) -> Result<TopResult<T>, TopCaptureError> {
+        self.terminal(tool_id, duration_millis, TopOutcome::Failed, reason_code)
+    }
+
+    pub(crate) fn unsupported<T: Serialize>(
+        &self,
+        tool_id: &'static str,
+        reason_code: TopReasonCode,
+    ) -> Result<TopResult<T>, TopCaptureError> {
+        self.terminal(tool_id, 0, TopOutcome::Unsupported, reason_code)
+    }
+
+    pub(crate) fn cancelled<T: Serialize>(&self, tool_id: &'static str) -> Result<TopResult<T>, TopCaptureError> {
+        self.terminal(tool_id, 0, TopOutcome::Cancelled, TopReasonCode::Cancelled)
+    }
+
+    fn terminal<T: Serialize>(
+        &self,
+        tool_id: &'static str,
+        duration_millis: u64,
+        outcome: TopOutcome,
+        reason_code: TopReasonCode,
+    ) -> Result<TopResult<T>, TopCaptureError> {
+        let result = TopResult {
+            schema_version: TOP_SCHEMA_VERSION,
+            run_uid: self.scope.run_uid.clone(),
+            tool_id,
+            capability: format!("{tool_id}@{TOP_SCHEMA_VERSION}"),
+            outcome,
+            reason_code,
+            duration_millis,
+            provenance: provenance(&self.scope)?,
+            coverage: TopCoverage {
+                requested_units: 1,
+                completed_units: 0,
+                unit: "WINDOW",
+            },
+            data: None,
+        };
+        self.bound_result(result)
+    }
+
+    fn bound_result<T: Serialize>(&self, result: TopResult<T>) -> Result<TopResult<T>, TopCaptureError> {
+        let size = serde_json::to_vec(&result).map_err(|_| TopCaptureError::Serialization)?.len();
+        if size > self.limits.max_result_bytes || size > MAX_TOP_RESULT_BYTES {
+            return Err(TopCaptureError::ResultTooLarge);
+        }
+        Ok(result)
+    }
+}
+
+fn validate_resource_scope(scope: &TopCaptureScope) -> Result<(), TopCaptureError> {
+    let organization_uid = scope
+        .organization_name
+        .strip_prefix("organizations/")
+        .filter(|tail| !tail.contains('/'))
+        .ok_or(TopCaptureError::Scope)?;
+    let cluster_prefix = format!("{}/clusters/", scope.organization_name);
+    let cluster_uid = scope
+        .cluster_name
+        .strip_prefix(&cluster_prefix)
+        .filter(|tail| !tail.contains('/'))
+        .ok_or(TopCaptureError::Scope)?;
+    let device_prefix = format!("{}/clusterDevices/", scope.cluster_name);
+    let device_uid = scope
+        .device_name
+        .strip_prefix(&device_prefix)
+        .filter(|tail| !tail.contains('/'))
+        .ok_or(TopCaptureError::Scope)?;
+    if scope.policy_revision == 0
+        || ![
+            organization_uid,
+            cluster_uid,
+            device_uid,
+            scope.run_uid.as_str(),
+            scope.artifact_uid.as_str(),
+            scope.consent.uid.as_str(),
+        ]
+        .into_iter()
+        .all(is_uuid_v7)
+    {
+        return Err(TopCaptureError::Scope);
+    }
+    Ok(())
+}
+
+fn validate_limits(limits: TopCaptureLimits) -> Result<(), TopCaptureError> {
+    if limits.max_duration_millis == 0
+        || limits.max_duration_millis > MAX_TOP_DURATION.as_millis() as u64
+        || limits.max_result_bytes == 0
+        || limits.max_result_bytes > MAX_TOP_RESULT_BYTES
+        || limits.max_working_memory_bytes < TOP_CAPTURE_WORKING_SET_BYTES
+        || limits.max_working_memory_bytes > MAX_TOP_WORKING_MEMORY_BYTES
+        || limits.max_records == 0
+        || limits.max_records > MAX_TOP_RECORDS
+        || limits.max_concurrency != 1
+        || limits.max_cpu_millis == 0
+        || limits.max_cpu_millis > MAX_TOP_CPU_MILLIS
+        || limits.max_temporary_bytes > MAX_TOP_TEMPORARY_BYTES
+        || limits.max_traffic_bytes > MAX_TOP_TRAFFIC_BYTES
+        || limits.max_bandwidth_bytes_per_second > MAX_TOP_BANDWIDTH_BYTES_PER_SECOND
+        || limits.max_operations == 0
+        || limits.max_operations > MAX_TOP_OPERATIONS
+    {
+        return Err(TopCaptureError::Limits);
+    }
+    Ok(())
+}
+
+fn validate_provenance(scope: &TopCaptureScope) -> Result<(), TopCaptureError> {
+    if !lower_hex(&scope.executable_sha256, 64)
+        || scope.build_features.len() > 64
+        || scope.build_features.iter().any(|feature| {
+            feature.is_empty()
+                || feature.len() > 64
+                || !feature.as_bytes()[0].is_ascii_lowercase()
+                || !feature
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_' || byte == b'-')
+        })
+    {
+        return Err(TopCaptureError::Provenance);
+    }
+    let commit = crate::version::build::COMMIT_HASH;
+    if !lower_hex(commit, 40) {
+        return Err(TopCaptureError::Provenance);
+    }
+    Ok(())
+}
+
+fn provenance(scope: &TopCaptureScope) -> Result<TopProvenance, TopCaptureError> {
+    validate_provenance(scope)?;
+    let mut build_features = scope.build_features.clone();
+    build_features.sort();
+    build_features.dedup();
+    Ok(TopProvenance {
+        repository: "rustfs/rustfs",
+        source_commit: crate::version::build::COMMIT_HASH.to_owned(),
+        executable_sha256: scope.executable_sha256.clone(),
+        rustfs_version: env!("CARGO_PKG_VERSION"),
+        os_family: match std::env::consts::OS {
+            "linux" => "LINUX",
+            "macos" => "DARWIN",
+            "windows" => "WINDOWS",
+            "freebsd" => "FREEBSD",
+            _ => "OTHER",
+        },
+        architecture: match std::env::consts::ARCH {
+            "x86_64" => "x86_64",
+            "aarch64" => "aarch64",
+            _ => "other",
+        },
+        build_features,
+    })
+}
+
+fn archive(envelope: &[u8], signature: &[u8], result: &[u8]) -> Result<Vec<u8>, TopCaptureError> {
+    let cursor = Cursor::new(Vec::with_capacity(envelope.len() + signature.len() + result.len() + 512));
+    let mut writer = ZipWriter::new(cursor);
+    let options = SimpleFileOptions::DEFAULT
+        .compression_method(CompressionMethod::Stored)
+        .unix_permissions(OUTPUT_MODE);
+    for (name, bytes) in [(ENVELOPE_PATH, envelope), (SIGNATURE_PATH, signature), (RESULT_PATH, result)] {
+        writer.start_file(name, options).map_err(|_| TopCaptureError::Serialization)?;
+        writer.write_all(bytes).map_err(io_error)?;
+    }
+    writer
+        .finish()
+        .map(|cursor| cursor.into_inner())
+        .map_err(|_| TopCaptureError::Serialization)
+}
+
+fn map_create_error(error: std::io::Error) -> TopCaptureError {
+    if error.kind() == std::io::ErrorKind::AlreadyExists {
+        TopCaptureError::AlreadyExists
+    } else {
+        io_error(error)
+    }
+}
+
+fn map_publish_error(error: std::io::Error) -> TopCaptureError {
+    if error.kind() == std::io::ErrorKind::AlreadyExists {
+        TopCaptureError::AlreadyExists
+    } else {
+        io_error(error)
+    }
+}
+
+fn io_error(error: std::io::Error) -> TopCaptureError {
+    TopCaptureError::Io(error.kind())
+}
+
+fn unix_now() -> Result<i64, TopCaptureError> {
+    Ok(OffsetDateTime::now_utc().unix_timestamp())
+}
+
+fn is_uuid_v7(value: &str) -> bool {
+    Uuid::parse_str(value).is_ok_and(|uuid| {
+        uuid.get_version() == Some(Version::SortRand) && uuid.get_variant() == Variant::RFC4122 && uuid.to_string() == value
+    })
+}
+
+fn lower_hex(value: &str, len: usize) -> bool {
+    value.len() == len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    hex_simd::encode_to_string(bytes, hex_simd::AsciiCase::Lower)
+}

--- a/rustfs/src/connect/diagnostics/top_disk.rs
+++ b/rustfs/src/connect/diagnostics/top_disk.rs
@@ -1,0 +1,129 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Bounded process disk-I/O window backed by RustFS's existing process sampler.
+
+use serde::Serialize;
+#[cfg(target_os = "linux")]
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+
+use super::top_api::{MAX_SAFE_INTEGER, TopCaptureError, TopCaptureRequest, TopReasonCode, TopResult};
+
+const TOOL_ID: &str = "top.disk";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DiskCounterSnapshot {
+    pub read_bytes: u64,
+    pub write_bytes: u64,
+    pub io_count: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TopDiskData {
+    pub resource_alias: &'static str,
+    pub read_bytes: u64,
+    pub write_bytes: u64,
+    pub io_count: u64,
+    pub window_millis: u64,
+}
+
+pub async fn capture_top_disk(
+    request: &TopCaptureRequest,
+    cancel: &CancellationToken,
+) -> Result<TopResult<TopDiskData>, TopCaptureError> {
+    request.validate_capture(TOOL_ID)?;
+    if cancel.is_cancelled() {
+        return request.cancelled(TOOL_ID);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    return request.unsupported(TOOL_ID, TopReasonCode::UnsupportedPlatform);
+
+    #[cfg(target_os = "linux")]
+    {
+        let Some(_permit) = request.acquire(cancel).await? else {
+            return request.cancelled(TOOL_ID);
+        };
+        let mut sampler = rustfs_io_metrics::ProcessSampler::new();
+        let before = process_snapshot(&mut sampler)?;
+        let started = Instant::now();
+        if !request.wait_window(TOOL_ID, cancel).await? {
+            return request.cancelled(TOOL_ID);
+        }
+        let after = process_snapshot(&mut sampler)?;
+        evaluate_disk_window(request, before, after, elapsed_millis(started.elapsed()))
+    }
+}
+
+pub fn evaluate_disk_window(
+    request: &TopCaptureRequest,
+    before: DiskCounterSnapshot,
+    after: DiskCounterSnapshot,
+    window_millis: u64,
+) -> Result<TopResult<TopDiskData>, TopCaptureError> {
+    request.validate_scope(TOOL_ID)?;
+    if window_millis == 0 || window_millis > request.limits.max_duration_millis {
+        return Err(TopCaptureError::Limits);
+    }
+    let Some(read_bytes) = after.read_bytes.checked_sub(before.read_bytes) else {
+        return request.failed(TOOL_ID, window_millis, TopReasonCode::CollectionFailed);
+    };
+    let Some(write_bytes) = after.write_bytes.checked_sub(before.write_bytes) else {
+        return request.failed(TOOL_ID, window_millis, TopReasonCode::CollectionFailed);
+    };
+    let Some(io_count) = after.io_count.checked_sub(before.io_count) else {
+        return request.failed(TOOL_ID, window_millis, TopReasonCode::CollectionFailed);
+    };
+    if [read_bytes, write_bytes, io_count]
+        .into_iter()
+        .any(|value| value > MAX_SAFE_INTEGER)
+    {
+        return request.failed(TOOL_ID, window_millis, TopReasonCode::CollectionFailed);
+    }
+
+    request.succeeded(
+        TOOL_ID,
+        window_millis,
+        TopDiskData {
+            // The v1 contract excludes disk paths. This alias denotes the
+            // RustFS process-wide disk counter source for this one run.
+            resource_alias: "resource-1",
+            read_bytes,
+            write_bytes,
+            io_count,
+            window_millis,
+        },
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn process_snapshot(sampler: &mut rustfs_io_metrics::ProcessSampler) -> Result<DiskCounterSnapshot, TopCaptureError> {
+    let (_, snapshot) = sampler.snapshot_resource_and_system();
+    let io_count = snapshot
+        .syscall_read_total
+        .checked_add(snapshot.syscall_write_total)
+        .ok_or(TopCaptureError::Result)?;
+    Ok(DiskCounterSnapshot {
+        read_bytes: snapshot.io_read_bytes,
+        write_bytes: snapshot.io_write_bytes,
+        io_count,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn elapsed_millis(duration: std::time::Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX).max(1)
+}

--- a/rustfs/src/connect/diagnostics/top_locks.rs
+++ b/rustfs/src/connect/diagnostics/top_locks.rs
@@ -1,0 +1,46 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Honest `top.locks` capability result.
+
+use serde::Serialize;
+use tokio_util::sync::CancellationToken;
+
+use super::top_api::{TopCaptureError, TopCaptureRequest, TopReasonCode, TopResult};
+
+const TOOL_ID: &str = "top.locks";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TopLocksData {
+    pub held_count: u64,
+    pub waiting_count: u64,
+    pub truncated: bool,
+}
+
+pub async fn capture_top_locks(
+    request: &TopCaptureRequest,
+    cancel: &CancellationToken,
+) -> Result<TopResult<TopLocksData>, TopCaptureError> {
+    request.validate_capture(TOOL_ID)?;
+    if cancel.is_cancelled() {
+        return request.cancelled(TOOL_ID);
+    }
+
+    // `GlobalLockManager` exposes exact held-lock entries, but the current
+    // public adapter does not expose the live waiter total required by v1.
+    // Reading holder resource names only to discard them would widen L3
+    // collection without making the result valid.
+    request.unsupported(TOOL_ID, TopReasonCode::UnsupportedTool)
+}

--- a/rustfs/src/connect/diagnostics/top_net.rs
+++ b/rustfs/src/connect/diagnostics/top_net.rs
@@ -1,0 +1,104 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Bounded internode-network window backed by RustFS's monotonic counters.
+
+use serde::Serialize;
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+
+use super::top_api::{MAX_SAFE_INTEGER, TopCaptureError, TopCaptureRequest, TopReasonCode, TopResult};
+
+const TOOL_ID: &str = "top.net";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NetworkCounterSnapshot {
+    pub received_bytes: u64,
+    pub sent_bytes: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TopNetData {
+    pub received_bytes: u64,
+    pub sent_bytes: u64,
+    pub window_millis: u64,
+}
+
+pub async fn capture_top_net(
+    request: &TopCaptureRequest,
+    cancel: &CancellationToken,
+) -> Result<TopResult<TopNetData>, TopCaptureError> {
+    request.validate_capture(TOOL_ID)?;
+    if cancel.is_cancelled() {
+        return request.cancelled(TOOL_ID);
+    }
+    let Some(_permit) = request.acquire(cancel).await? else {
+        return request.cancelled(TOOL_ID);
+    };
+    let Some(before) = network_snapshot() else {
+        return request.failed(TOOL_ID, 0, TopReasonCode::SourceUnavailable);
+    };
+    let started = Instant::now();
+    if !request.wait_window(TOOL_ID, cancel).await? {
+        return request.cancelled(TOOL_ID);
+    }
+    let Some(after) = network_snapshot() else {
+        return request.failed(TOOL_ID, elapsed_millis(started.elapsed()), TopReasonCode::SourceUnavailable);
+    };
+    evaluate_network_window(request, before, after, elapsed_millis(started.elapsed()))
+}
+
+pub fn evaluate_network_window(
+    request: &TopCaptureRequest,
+    before: NetworkCounterSnapshot,
+    after: NetworkCounterSnapshot,
+    window_millis: u64,
+) -> Result<TopResult<TopNetData>, TopCaptureError> {
+    request.validate_scope(TOOL_ID)?;
+    if window_millis == 0 || window_millis > request.limits.max_duration_millis {
+        return Err(TopCaptureError::Limits);
+    }
+    let Some(received_bytes) = after.received_bytes.checked_sub(before.received_bytes) else {
+        return request.failed(TOOL_ID, window_millis, TopReasonCode::CollectionFailed);
+    };
+    let Some(sent_bytes) = after.sent_bytes.checked_sub(before.sent_bytes) else {
+        return request.failed(TOOL_ID, window_millis, TopReasonCode::CollectionFailed);
+    };
+    if received_bytes > MAX_SAFE_INTEGER || sent_bytes > MAX_SAFE_INTEGER {
+        return request.failed(TOOL_ID, window_millis, TopReasonCode::CollectionFailed);
+    }
+
+    request.succeeded(
+        TOOL_ID,
+        window_millis,
+        TopNetData {
+            received_bytes,
+            sent_bytes,
+            window_millis,
+        },
+    )
+}
+
+fn network_snapshot() -> Option<NetworkCounterSnapshot> {
+    let snapshot = rustfs_obs::metrics::stats_collector::collect_internode_network_stats()?;
+    Some(NetworkCounterSnapshot {
+        received_bytes: snapshot.internode_recv_bytes_total,
+        sent_bytes: snapshot.internode_sent_bytes_total,
+    })
+}
+
+fn elapsed_millis(duration: std::time::Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX).max(1)
+}

--- a/rustfs/src/connect/diagnostics/top_rpc.rs
+++ b/rustfs/src/connect/diagnostics/top_rpc.rs
@@ -1,0 +1,46 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Honest `top.rpc` capability result.
+
+use serde::Serialize;
+use tokio_util::sync::CancellationToken;
+
+use super::top_api::{TopCaptureError, TopCaptureRequest, TopReasonCode, TopResult};
+
+const TOOL_ID: &str = "top.rpc";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TopRpcData {
+    pub request_count: u64,
+    pub error_count: u64,
+    pub window_millis: u64,
+    pub total_duration_micros: u64,
+}
+
+pub async fn capture_top_rpc(
+    request: &TopCaptureRequest,
+    cancel: &CancellationToken,
+) -> Result<TopResult<TopRpcData>, TopCaptureError> {
+    request.validate_capture(TOOL_ID)?;
+    if cancel.is_cancelled() {
+        return request.cancelled(TOOL_ID);
+    }
+
+    // Internode metrics expose traffic, dial failures, and average dial time.
+    // They do not expose one matching RPC request/error/duration cohort, so v1
+    // cannot be produced without mixing unrelated counters.
+    request.unsupported(TOOL_ID, TopReasonCode::UnsupportedTool)
+}

--- a/rustfs/src/connect/mod.rs
+++ b/rustfs/src/connect/mod.rs
@@ -67,6 +67,13 @@ pub use diagnostics::{
     run_local_environment_once, save_signed_drive_export, save_signed_log_export, save_signed_profile_export,
     save_signed_telemetry_export, sign_drive_export, spawn_environment_schedule, validate_drive_limits,
 };
+pub use diagnostics::{
+    LocalTopConsent, MAX_TOP_DURATION, MAX_TOP_EXPORT_VALIDITY, NetworkCounterSnapshot, SavedTopExport, SignedTopExport,
+    TOP_CLASSIFICATION, TOP_SCHEMA_VERSION, TopApiData, TopApiOperation, TopCaptureError, TopCaptureLimits, TopCaptureRequest,
+    TopCaptureScope, TopCoverage, TopDiskData, TopLocksData, TopNetData, TopOutcome, TopProvenance, TopReasonCode, TopResult,
+    TopRpcData, capture_top_api, capture_top_disk, capture_top_locks, capture_top_net, capture_top_rpc, evaluate_disk_window,
+    evaluate_network_window, save_signed_top_export, sign_top_export,
+};
 pub use environment::{
     ENVIRONMENT_CAPABILITY, ENVIRONMENT_SCHEMA_VERSION, EnvironmentCollectionRequest, EnvironmentError,
     EnvironmentFilesystemType, EnvironmentInventory, EnvironmentOsFamily, MAX_ENVIRONMENT_DURATION, collect_environment,

--- a/rustfs/src/startup_entrypoint.rs
+++ b/rustfs/src/startup_entrypoint.rs
@@ -16,7 +16,7 @@ use crate::{
     config::{
         CommandResult, Config, ConnectDrivePerformanceOpts, ConnectLicenseCommands, ConnectLicenseScopeOpts, ConnectLogsMode,
         ConnectLogsOpts, ConnectProfileOpts, ConnectProfileTool, ConnectTelemetryArtifactOpts, ConnectTelemetryCommands,
-        ConnectThreadProfileScope, Opt,
+        ConnectThreadProfileScope, ConnectTopCommands, Opt,
     },
     startup_lifecycle::{StartupRuntimeLifecycle, run_startup_runtime_lifecycle},
     startup_preflight::{StartupServerPreflightError, bootstrap_external_prefix_compat, init_startup_server_preflight},
@@ -140,6 +140,7 @@ async fn async_main() -> Result<()> {
         CommandResult::ConnectProfile(options) => return execute_connect_profile(options).await,
         CommandResult::ConnectLogs(options) => return execute_connect_logs(options).await,
         CommandResult::ConnectTelemetry(command) => return execute_connect_telemetry(command).await,
+        CommandResult::ConnectTop(command) => return execute_connect_top(command).await,
         CommandResult::Server(config) => config,
     };
 
@@ -474,6 +475,135 @@ fn valid_environment_name(value: &str) -> bool {
 fn unix_now() -> Result<i64> {
     let duration = SystemTime::now().duration_since(UNIX_EPOCH).map_err(Error::other)?;
     i64::try_from(duration.as_secs()).map_err(Error::other)
+}
+
+async fn execute_connect_top(command: ConnectTopCommands) -> Result<()> {
+    use crate::connect::{
+        IdentityStore, LocalTopConsent, MAX_TOP_DURATION, MAX_TOP_EXPORT_VALIDITY, TOP_CLASSIFICATION, TopApiOperation,
+        TopCaptureLimits, TopCaptureRequest, TopCaptureScope, capture_top_api, capture_top_disk, capture_top_locks,
+        capture_top_net, capture_top_rpc,
+    };
+
+    let (tool_id, options) = match command {
+        ConnectTopCommands::Api(options) => ("top.api", options),
+        ConnectTopCommands::Disk(options) => ("top.disk", options),
+        ConnectTopCommands::Locks(options) => ("top.locks", options),
+        ConnectTopCommands::Net(options) => ("top.net", options),
+        ConnectTopCommands::Rpc(options) => ("top.rpc", options),
+    };
+    let window = Duration::from_millis(options.window_millis);
+    let export_validity = Duration::from_secs(options.export_validity_seconds);
+    if window.is_zero() || window > MAX_TOP_DURATION || export_validity.is_zero() || export_validity > MAX_TOP_EXPORT_VALIDITY {
+        return Err(Error::other("connect_top_limits_invalid"));
+    }
+
+    let identity = IdentityStore::new(options.state_dir.join("identity"))
+        .load()
+        .map_err(Error::other)?
+        .ok_or_else(|| Error::other("connect top requires an enrolled device identity"))?;
+    let request = TopCaptureRequest {
+        scope: TopCaptureScope {
+            organization_name: options.organization,
+            cluster_name: options.cluster,
+            device_name: options.device,
+            run_uid: options.run_uid,
+            artifact_uid: options.artifact_uid,
+            policy_revision: options.policy_revision,
+            run_expires_at_unix: options.run_expires_at_unix,
+            executable_sha256: hash_current_executable()?,
+            build_features: enabled_build_features(),
+            consent: LocalTopConsent {
+                uid: options.consent_uid,
+                tool_id: tool_id.to_owned(),
+                classification: TOP_CLASSIFICATION.to_owned(),
+                active: options.acknowledge_l3,
+                expires_at_unix: options.consent_expires_at_unix,
+            },
+        },
+        limits: TopCaptureLimits::default(),
+        window,
+        export_validity,
+    };
+    let cancel = CancellationToken::new();
+    match tool_id {
+        "top.api" => {
+            let result = await_top_capture(capture_top_api(&request, TopApiOperation::GetObject, &cancel), &cancel).await?;
+            finish_top_capture(&request, result, &identity, options.output, &cancel).await
+        }
+        "top.disk" => {
+            let result = await_top_capture(capture_top_disk(&request, &cancel), &cancel).await?;
+            finish_top_capture(&request, result, &identity, options.output, &cancel).await
+        }
+        "top.locks" => {
+            let result = await_top_capture(capture_top_locks(&request, &cancel), &cancel).await?;
+            finish_top_capture(&request, result, &identity, options.output, &cancel).await
+        }
+        "top.net" => {
+            let result = await_top_capture(capture_top_net(&request, &cancel), &cancel).await?;
+            finish_top_capture(&request, result, &identity, options.output, &cancel).await
+        }
+        "top.rpc" => {
+            let result = await_top_capture(capture_top_rpc(&request, &cancel), &cancel).await?;
+            finish_top_capture(&request, result, &identity, options.output, &cancel).await
+        }
+        _ => unreachable!("closed top command"),
+    }
+}
+
+async fn await_top_capture<T, F>(future: F, cancel: &CancellationToken) -> Result<crate::connect::TopResult<T>>
+where
+    T: serde::Serialize,
+    F: std::future::Future<Output = std::result::Result<crate::connect::TopResult<T>, crate::connect::TopCaptureError>>,
+{
+    tokio::pin!(future);
+    tokio::select! {
+        biased;
+        signal = tokio::signal::ctrl_c() => {
+            signal.map_err(Error::other)?;
+            cancel.cancel();
+            future.await.map_err(Error::other)
+        }
+        result = future.as_mut() => result.map_err(Error::other),
+    }
+}
+
+async fn finish_top_capture<T: serde::Serialize>(
+    request: &crate::connect::TopCaptureRequest,
+    result: crate::connect::TopResult<T>,
+    identity: &crate::connect::DeviceIdentity,
+    output: std::path::PathBuf,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    use crate::connect::{TopOutcome, save_signed_top_export, sign_top_export};
+
+    println!("result={}", serde_json::to_string(&result).map_err(Error::other)?);
+    std::io::stdout().flush()?;
+    if !matches!(result.outcome, TopOutcome::Succeeded | TopOutcome::Partial) {
+        return Err(Error::other(format!(
+            "top capture ended with {} ({})",
+            result.outcome.as_str(),
+            result.reason_code.as_str()
+        )));
+    }
+
+    let export = sign_top_export(request, &result, identity, cancel).map_err(Error::other)?;
+    let writer_cancel = cancel.clone();
+    let mut writer = tokio::task::spawn_blocking(move || save_signed_top_export(&output, &export, &writer_cancel));
+    let receipt = tokio::select! {
+        biased;
+        signal = tokio::signal::ctrl_c() => {
+            signal.map_err(Error::other)?;
+            cancel.cancel();
+            writer.await.map_err(Error::other)?.map_err(Error::other)?
+        }
+        result = &mut writer => result.map_err(Error::other)?.map_err(Error::other)?,
+    };
+    println!(
+        "artifact={} bytes={} sha256={}",
+        receipt.artifact_uid, receipt.archive_size_bytes, receipt.archive_sha256
+    );
+    println!("upload=not-performed");
+    Ok(())
 }
 
 async fn execute_connect_drive_performance(options: ConnectDrivePerformanceOpts) -> Result<()> {

--- a/rustfs/tests/connect_top_api.rs
+++ b/rustfs/tests/connect_top_api.rs
@@ -1,0 +1,125 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use rustfs::connect::DeviceIdentity;
+use rustfs::connect::diagnostics::{
+    LocalTopConsent, TopApiOperation, TopCaptureError, TopCaptureLimits, TopCaptureRequest, TopCaptureScope, TopOutcome,
+    TopReasonCode, capture_top_api, sign_top_export,
+};
+use time::OffsetDateTime;
+use tokio_util::sync::CancellationToken;
+
+fn request(tool_id: &str) -> TopCaptureRequest {
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+    TopCaptureRequest {
+        scope: TopCaptureScope {
+            organization_name: "organizations/019e3ae0-0000-7000-8000-000000000010".to_owned(),
+            cluster_name: "organizations/019e3ae0-0000-7000-8000-000000000010/clusters/019e3ae0-0000-7000-8000-000000000011"
+                .to_owned(),
+            device_name: "organizations/019e3ae0-0000-7000-8000-000000000010/clusters/019e3ae0-0000-7000-8000-000000000011/clusterDevices/019e3ae0-0000-7000-8000-000000000012".to_owned(),
+            run_uid: "019e3ae0-0000-7000-8000-000000000001".to_owned(),
+            artifact_uid: "019e3ae0-0000-7000-8000-000000000013".to_owned(),
+            policy_revision: 1,
+            run_expires_at_unix: now + 3_600,
+            executable_sha256: "b".repeat(64),
+            build_features: Vec::new(),
+            consent: LocalTopConsent {
+                uid: "019e3ae0-0000-7000-8000-000000000014".to_owned(),
+                tool_id: tool_id.to_owned(),
+                classification: "L3".to_owned(),
+                active: true,
+                expires_at_unix: now + 3_600,
+            },
+        },
+        limits: TopCaptureLimits::default(),
+        window: Duration::from_millis(1),
+        export_validity: Duration::from_secs(300),
+    }
+}
+
+#[tokio::test]
+async fn top_api_refuses_to_invent_the_missing_duration_counter() {
+    let result = capture_top_api(&request("top.api"), TopApiOperation::GetObject, &CancellationToken::new())
+        .await
+        .expect("structured unsupported result");
+
+    assert_eq!(result.outcome, TopOutcome::Unsupported);
+    assert_eq!(result.reason_code, TopReasonCode::UnsupportedTool);
+    assert!(result.data.is_none());
+    let value = serde_json::to_value(&result).expect("result json");
+    assert_eq!(value["toolId"], "top.api");
+    assert_eq!(value["capability"], "top.api@1");
+    assert_eq!(value["coverage"]["completedUnits"], 0);
+    assert!(value["data"].is_null());
+    assert_eq!(
+        sign_top_export(&request("top.api"), &result, &DeviceIdentity::generate(), &CancellationToken::new()),
+        Err(TopCaptureError::Result)
+    );
+}
+
+#[tokio::test]
+async fn top_api_enforces_local_consent_expiry_scope_and_limits_before_capture() {
+    let mut inactive = request("top.api");
+    inactive.scope.consent.active = false;
+    assert_eq!(
+        capture_top_api(&inactive, TopApiOperation::GetObject, &CancellationToken::new()).await,
+        Err(TopCaptureError::ConsentRequired)
+    );
+
+    let mut expired = request("top.api");
+    expired.scope.consent.expires_at_unix = OffsetDateTime::now_utc().unix_timestamp();
+    assert_eq!(
+        capture_top_api(&expired, TopApiOperation::GetObject, &CancellationToken::new()).await,
+        Err(TopCaptureError::ConsentExpired)
+    );
+
+    let mut foreign_tool = request("top.disk");
+    assert_eq!(
+        capture_top_api(&foreign_tool, TopApiOperation::GetObject, &CancellationToken::new()).await,
+        Err(TopCaptureError::ConsentScope)
+    );
+    foreign_tool.scope.consent.tool_id = "top.api".to_owned();
+    foreign_tool.scope.consent.classification = "L2".to_owned();
+    assert_eq!(
+        capture_top_api(&foreign_tool, TopApiOperation::GetObject, &CancellationToken::new()).await,
+        Err(TopCaptureError::ConsentScope)
+    );
+
+    let mut too_long = request("top.api");
+    too_long.window = Duration::from_millis(30_001);
+    assert_eq!(
+        capture_top_api(&too_long, TopApiOperation::GetObject, &CancellationToken::new()).await,
+        Err(TopCaptureError::Limits)
+    );
+    let mut too_large = request("top.api");
+    too_large.limits.max_result_bytes = 262_145;
+    assert_eq!(
+        capture_top_api(&too_large, TopApiOperation::GetObject, &CancellationToken::new()).await,
+        Err(TopCaptureError::Limits)
+    );
+}
+
+#[tokio::test]
+async fn top_api_acknowledges_cancellation_without_data() {
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+    let result = capture_top_api(&request("top.api"), TopApiOperation::GetObject, &cancel)
+        .await
+        .expect("cancelled result");
+    assert_eq!(result.outcome, TopOutcome::Cancelled);
+    assert_eq!(result.reason_code, TopReasonCode::Cancelled);
+    assert!(result.data.is_none());
+}

--- a/rustfs/tests/connect_top_disk.rs
+++ b/rustfs/tests/connect_top_disk.rs
@@ -1,0 +1,106 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use rustfs::connect::diagnostics::{
+    DiskCounterSnapshot, LocalTopConsent, MAX_SAFE_INTEGER, TopCaptureLimits, TopCaptureRequest, TopCaptureScope, TopOutcome,
+    TopReasonCode, evaluate_disk_window,
+};
+use time::OffsetDateTime;
+
+fn request() -> TopCaptureRequest {
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+    TopCaptureRequest {
+        scope: TopCaptureScope {
+            organization_name: "organizations/019e3ae0-0000-7000-8000-000000000010".to_owned(),
+            cluster_name: "organizations/019e3ae0-0000-7000-8000-000000000010/clusters/019e3ae0-0000-7000-8000-000000000011".to_owned(),
+            device_name: "organizations/019e3ae0-0000-7000-8000-000000000010/clusters/019e3ae0-0000-7000-8000-000000000011/clusterDevices/019e3ae0-0000-7000-8000-000000000012".to_owned(),
+            run_uid: "019e3ae0-0000-7000-8000-000000000001".to_owned(),
+            artifact_uid: "019e3ae0-0000-7000-8000-000000000013".to_owned(),
+            policy_revision: 1,
+            run_expires_at_unix: now + 3_600,
+            executable_sha256: "b".repeat(64),
+            build_features: Vec::new(),
+            consent: LocalTopConsent {
+                uid: "019e3ae0-0000-7000-8000-000000000014".to_owned(),
+                tool_id: "top.disk".to_owned(),
+                classification: "L3".to_owned(),
+                active: true,
+                expires_at_unix: now + 3_600,
+            },
+        },
+        limits: TopCaptureLimits::default(),
+        window: Duration::from_millis(1),
+        export_validity: Duration::from_secs(300),
+    }
+}
+
+#[test]
+fn top_disk_uses_exact_process_counter_deltas_and_redacts_the_source() {
+    let result = evaluate_disk_window(
+        &request(),
+        DiskCounterSnapshot {
+            read_bytes: 100,
+            write_bytes: 200,
+            io_count: 10,
+        },
+        DiskCounterSnapshot {
+            read_bytes: 4_196,
+            write_bytes: 200,
+            io_count: 11,
+        },
+        1_000,
+    )
+    .expect("disk result");
+
+    assert_eq!(result.outcome, TopOutcome::Succeeded);
+    let value = serde_json::to_value(result).expect("disk json");
+    assert_eq!(value["data"]["resourceAlias"], "resource-1");
+    assert_eq!(value["data"]["readBytes"], 4_096);
+    assert_eq!(value["data"]["writeBytes"], 0);
+    assert_eq!(value["data"]["ioCount"], 1);
+    assert!(!value["data"].to_string().contains('/'));
+}
+
+#[test]
+fn top_disk_counter_reset_and_safe_integer_overflow_fail_without_data() {
+    for after in [
+        DiskCounterSnapshot {
+            read_bytes: 99,
+            write_bytes: 200,
+            io_count: 10,
+        },
+        DiskCounterSnapshot {
+            read_bytes: MAX_SAFE_INTEGER + 101,
+            write_bytes: 200,
+            io_count: 10,
+        },
+    ] {
+        let result = evaluate_disk_window(
+            &request(),
+            DiskCounterSnapshot {
+                read_bytes: 100,
+                write_bytes: 200,
+                io_count: 10,
+            },
+            after,
+            1_000,
+        )
+        .expect("structured failed result");
+        assert_eq!(result.outcome, TopOutcome::Failed);
+        assert_eq!(result.reason_code, TopReasonCode::CollectionFailed);
+        assert!(result.data.is_none());
+    }
+}

--- a/rustfs/tests/connect_top_locks.rs
+++ b/rustfs/tests/connect_top_locks.rs
@@ -1,0 +1,59 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use rustfs::connect::diagnostics::{
+    LocalTopConsent, TopCaptureLimits, TopCaptureRequest, TopCaptureScope, TopOutcome, TopReasonCode, capture_top_locks,
+};
+use time::OffsetDateTime;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+async fn top_locks_reports_unsupported_instead_of_inventing_waiters_or_exposing_names() {
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+    let request = TopCaptureRequest {
+        scope: TopCaptureScope {
+            organization_name: "organizations/019e3ae0-0000-7000-8000-000000000010".to_owned(),
+            cluster_name: "organizations/019e3ae0-0000-7000-8000-000000000010/clusters/019e3ae0-0000-7000-8000-000000000011".to_owned(),
+            device_name: "organizations/019e3ae0-0000-7000-8000-000000000010/clusters/019e3ae0-0000-7000-8000-000000000011/clusterDevices/019e3ae0-0000-7000-8000-000000000012".to_owned(),
+            run_uid: "019e3ae0-0000-7000-8000-000000000001".to_owned(),
+            artifact_uid: "019e3ae0-0000-7000-8000-000000000013".to_owned(),
+            policy_revision: 1,
+            run_expires_at_unix: now + 3_600,
+            executable_sha256: "b".repeat(64),
+            build_features: Vec::new(),
+            consent: LocalTopConsent {
+                uid: "019e3ae0-0000-7000-8000-000000000014".to_owned(),
+                tool_id: "top.locks".to_owned(),
+                classification: "L3".to_owned(),
+                active: true,
+                expires_at_unix: now + 3_600,
+            },
+        },
+        limits: TopCaptureLimits::default(),
+        window: Duration::from_millis(1),
+        export_validity: Duration::from_secs(300),
+    };
+
+    let result = capture_top_locks(&request, &CancellationToken::new())
+        .await
+        .expect("structured unsupported result");
+    assert_eq!(result.outcome, TopOutcome::Unsupported);
+    assert_eq!(result.reason_code, TopReasonCode::UnsupportedTool);
+    let json = serde_json::to_string(&result).expect("locks json");
+    assert!(json.contains(r#""data":null"#));
+    assert!(!json.contains("resource"));
+    assert!(!json.contains("owner"));
+}

--- a/rustfs/tests/connect_top_net.rs
+++ b/rustfs/tests/connect_top_net.rs
@@ -1,0 +1,434 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs;
+use std::io::{Cursor, Read as _};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+use base64_simd::URL_SAFE_NO_PAD;
+use p256::ecdsa::{Signature, VerifyingKey, signature::Verifier as _};
+use p256::pkcs8::DecodePublicKey as _;
+use rustfs::connect::DeviceIdentity;
+use rustfs::connect::diagnostics::{
+    LocalTopConsent, NetworkCounterSnapshot, TopCaptureLimits, TopCaptureRequest, TopCaptureScope, TopOutcome, TopReasonCode,
+    evaluate_network_window, save_signed_top_export, sign_top_export,
+};
+use sha2::{Digest as _, Sha256};
+use time::OffsetDateTime;
+use tokio_util::sync::CancellationToken;
+use zip::ZipArchive;
+
+fn request() -> TopCaptureRequest {
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+    TopCaptureRequest {
+        scope: TopCaptureScope {
+            organization_name: "organizations/019e3ae0-0000-7000-8000-000000000010".to_owned(),
+            cluster_name: "organizations/019e3ae0-0000-7000-8000-000000000010/clusters/019e3ae0-0000-7000-8000-000000000011".to_owned(),
+            device_name: "organizations/019e3ae0-0000-7000-8000-000000000010/clusters/019e3ae0-0000-7000-8000-000000000011/clusterDevices/019e3ae0-0000-7000-8000-000000000012".to_owned(),
+            run_uid: "019e3ae0-0000-7000-8000-000000000001".to_owned(),
+            artifact_uid: "019e3ae0-0000-7000-8000-000000000013".to_owned(),
+            policy_revision: 1,
+            run_expires_at_unix: now + 3_600,
+            executable_sha256: "b".repeat(64),
+            build_features: Vec::new(),
+            consent: LocalTopConsent {
+                uid: "019e3ae0-0000-7000-8000-000000000014".to_owned(),
+                tool_id: "top.net".to_owned(),
+                classification: "L3".to_owned(),
+                active: true,
+                expires_at_unix: now + 3_600,
+            },
+        },
+        limits: TopCaptureLimits::default(),
+        window: Duration::from_millis(1),
+        export_validity: Duration::from_secs(300),
+    }
+}
+
+fn archive_entry(archive: &mut ZipArchive<Cursor<Vec<u8>>>, name: &str) -> Vec<u8> {
+    let mut entry = archive.by_name(name).expect("archive member");
+    let mut bytes = Vec::new();
+    entry.read_to_end(&mut bytes).expect("read archive member");
+    bytes
+}
+
+#[test]
+fn top_network_uses_exact_counter_deltas_and_fails_closed_on_reset() {
+    let succeeded = evaluate_network_window(
+        &request(),
+        NetworkCounterSnapshot {
+            received_bytes: 100,
+            sent_bytes: 50,
+        },
+        NetworkCounterSnapshot {
+            received_bytes: 4_196,
+            sent_bytes: 178,
+        },
+        1_000,
+    )
+    .expect("network result");
+    assert_eq!(succeeded.outcome, TopOutcome::Succeeded);
+    let value = serde_json::to_value(succeeded).expect("network json");
+    assert_eq!(value["data"]["receivedBytes"], 4_096);
+    assert_eq!(value["data"]["sentBytes"], 128);
+    assert_eq!(value["data"]["windowMillis"], 1_000);
+
+    let reset = evaluate_network_window(
+        &request(),
+        NetworkCounterSnapshot {
+            received_bytes: 100,
+            sent_bytes: 50,
+        },
+        NetworkCounterSnapshot {
+            received_bytes: 99,
+            sent_bytes: 51,
+        },
+        1_000,
+    )
+    .expect("failed reset result");
+    assert_eq!(reset.outcome, TopOutcome::Failed);
+    assert_eq!(reset.reason_code, TopReasonCode::CollectionFailed);
+    assert!(reset.data.is_none());
+}
+
+#[test]
+fn top_network_export_is_bounded_redacted_and_signed_over_exact_envelope_bytes() {
+    let request = request();
+    let result = evaluate_network_window(
+        &request,
+        NetworkCounterSnapshot {
+            received_bytes: 100,
+            sent_bytes: 50,
+        },
+        NetworkCounterSnapshot {
+            received_bytes: 4_196,
+            sent_bytes: 178,
+        },
+        1_000,
+    )
+    .expect("network result");
+    let identity = DeviceIdentity::generate();
+    let export = sign_top_export(&request, &result, &identity, &CancellationToken::new()).expect("signed export");
+
+    assert_eq!(export.artifact_uid, request.scope.artifact_uid);
+    assert_eq!(
+        export.archive_sha256,
+        hex_simd::encode_to_string(Sha256::digest(&export.archive_bytes), hex_simd::AsciiCase::Lower)
+    );
+    assert!(export.envelope_json.len() <= 16_384);
+    assert!(export.result_json.len() <= request.limits.max_result_bytes);
+    assert_eq!(
+        hex_simd::encode_to_string(Sha256::digest(&export.result_json), hex_simd::AsciiCase::Lower),
+        export.result_sha256
+    );
+    let mut archive = ZipArchive::new(Cursor::new(export.archive_bytes.clone())).expect("top archive");
+    assert_eq!(archive.len(), 3);
+    assert_eq!(archive_entry(&mut archive, "envelope.json"), export.envelope_json);
+    assert_eq!(archive_entry(&mut archive, "envelope.sig"), export.envelope_signature);
+    assert_eq!(archive_entry(&mut archive, "result.json"), export.result_json);
+    let envelope: serde_json::Value = serde_json::from_slice(&export.envelope_json).expect("envelope");
+    assert_eq!(envelope["toolId"], "top.net");
+    assert_eq!(envelope["classification"], "L3");
+    assert_eq!(envelope["payload"]["path"], "result.json");
+    assert_eq!(envelope["payload"]["sha256"], export.result_sha256);
+    let result_text = String::from_utf8_lossy(&export.result_json);
+    assert!(!result_text.contains("address"));
+    assert!(!result_text.contains("path"));
+
+    let signature_document: serde_json::Value = serde_json::from_slice(&export.envelope_signature).expect("signature");
+    assert_eq!(signature_document["algorithm"], "ES256");
+    let signature_bytes = URL_SAFE_NO_PAD
+        .decode_to_vec(signature_document["value"].as_str().expect("signature value"))
+        .expect("base64url signature");
+    let signature = Signature::from_slice(&signature_bytes).expect("fixed signature");
+    assert_eq!(signature, signature.normalize_s());
+    let mut signed = b"rustfs-diagnostic-envelope-v1\0".to_vec();
+    signed.extend_from_slice(&export.envelope_json);
+    VerifyingKey::from_public_key_der(&identity.public_key_der())
+        .expect("device public key")
+        .verify(&signed, &signature)
+        .expect("exact envelope signature");
+}
+
+#[test]
+fn top_export_rejects_forged_coverage_reason_and_tool() {
+    let request = request();
+    let result = evaluate_network_window(
+        &request,
+        NetworkCounterSnapshot {
+            received_bytes: 100,
+            sent_bytes: 50,
+        },
+        NetworkCounterSnapshot {
+            received_bytes: 4_196,
+            sent_bytes: 178,
+        },
+        1_000,
+    )
+    .expect("network result");
+    let identity = DeviceIdentity::generate();
+
+    for reason_code in [
+        TopReasonCode::LimitExceeded,
+        TopReasonCode::SourceUnavailable,
+        TopReasonCode::CounterReset,
+    ] {
+        let mut valid_partial = result.clone();
+        valid_partial.outcome = TopOutcome::Partial;
+        valid_partial.reason_code = reason_code;
+        valid_partial.coverage.requested_units = 2;
+        assert!(sign_top_export(&request, &valid_partial, &identity, &CancellationToken::new()).is_ok());
+    }
+
+    let mut forged_coverage = result.clone();
+    forged_coverage.coverage.completed_units = 0;
+    assert_eq!(
+        sign_top_export(&request, &forged_coverage, &identity, &CancellationToken::new()),
+        Err(rustfs::connect::diagnostics::TopCaptureError::Result)
+    );
+
+    let mut forged_reason = result.clone();
+    forged_reason.reason_code = TopReasonCode::LimitExceeded;
+    assert_eq!(
+        sign_top_export(&request, &forged_reason, &identity, &CancellationToken::new()),
+        Err(rustfs::connect::diagnostics::TopCaptureError::Result)
+    );
+
+    let mut forged_tool = result;
+    forged_tool.tool_id = "logs.capture";
+    forged_tool.capability = "logs.capture@1".to_owned();
+    assert_eq!(
+        sign_top_export(&request, &forged_tool, &identity, &CancellationToken::new()),
+        Err(rustfs::connect::diagnostics::TopCaptureError::Result)
+    );
+}
+
+#[test]
+fn local_top_export_is_private_no_clobber_cancel_safe_and_rejects_forged_artifact_uid() {
+    let request = request();
+    let result = evaluate_network_window(
+        &request,
+        NetworkCounterSnapshot {
+            received_bytes: 100,
+            sent_bytes: 50,
+        },
+        NetworkCounterSnapshot {
+            received_bytes: 4_196,
+            sent_bytes: 178,
+        },
+        1_000,
+    )
+    .expect("network result");
+    let export =
+        sign_top_export(&request, &result, &DeviceIdentity::generate(), &CancellationToken::new()).expect("signed export");
+    let directory = tempfile::tempdir().expect("output directory");
+    let output = directory.path().join("top.zip");
+    let receipt = save_signed_top_export(&output, &export, &CancellationToken::new()).expect("saved export");
+    assert_eq!(receipt.artifact_uid, export.artifact_uid);
+    assert_eq!(receipt.archive_sha256, export.archive_sha256);
+    assert_eq!(receipt.archive_size_bytes, export.archive_bytes.len() as u64);
+    assert_eq!(fs::read(&output).expect("saved bytes"), export.archive_bytes);
+    #[cfg(unix)]
+    assert_eq!(fs::metadata(&output).expect("saved mode").permissions().mode() & 0o777, 0o600);
+    assert!(matches!(
+        save_signed_top_export(&output, &export, &CancellationToken::new()),
+        Err(rustfs::connect::diagnostics::TopCaptureError::AlreadyExists)
+    ));
+
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+    let cancelled_output = directory.path().join("cancelled.zip");
+    assert!(matches!(
+        save_signed_top_export(&cancelled_output, &export, &cancel),
+        Err(rustfs::connect::diagnostics::TopCaptureError::Cancelled)
+    ));
+    assert!(!cancelled_output.exists());
+
+    let mut forged = export.clone();
+    forged.artifact_uid = "../../escape".to_owned();
+    let forged_output = directory.path().join("forged.zip");
+    assert!(matches!(
+        save_signed_top_export(&forged_output, &forged, &CancellationToken::new()),
+        Err(rustfs::connect::diagnostics::TopCaptureError::Scope)
+    ));
+    assert!(!forged_output.exists());
+
+    let mut tampered = export.clone();
+    tampered.archive_bytes[0] ^= 1;
+    assert!(matches!(
+        save_signed_top_export(&directory.path().join("tampered.zip"), &tampered, &CancellationToken::new()),
+        Err(rustfs::connect::diagnostics::TopCaptureError::Result)
+    ));
+    let mut empty = export.clone();
+    empty.archive_bytes.clear();
+    empty.archive_sha256 = hex_simd::encode_to_string(Sha256::digest(&empty.archive_bytes), hex_simd::AsciiCase::Lower);
+    assert!(matches!(
+        save_signed_top_export(&directory.path().join("empty.zip"), &empty, &CancellationToken::new()),
+        Err(rustfs::connect::diagnostics::TopCaptureError::Result)
+    ));
+    let mut oversized = export;
+    oversized.archive_bytes = vec![0; 524_289];
+    oversized.archive_sha256 = hex_simd::encode_to_string(Sha256::digest(&oversized.archive_bytes), hex_simd::AsciiCase::Lower);
+    assert!(matches!(
+        save_signed_top_export(&directory.path().join("oversized.zip"), &oversized, &CancellationToken::new()),
+        Err(rustfs::connect::diagnostics::TopCaptureError::Result)
+    ));
+}
+
+#[test]
+fn production_cli_exports_top_net_and_fails_closed_for_unsupported_and_invalid_runs() {
+    let directory = tempfile::tempdir().expect("CLI directory");
+    let state = directory.path().join("state");
+    let identity = rustfs::connect::IdentityStore::new(state.join("identity"))
+        .load_or_create()
+        .expect("enrolled identity");
+
+    let net_output = directory.path().join("net.zip");
+    let net = top_command("net", &state, &net_output, "019e3ae0-0000-7000-8000-000000000021", 1, true)
+        .output()
+        .expect("run top.net");
+    assert!(net.status.success(), "stderr: {}", String::from_utf8_lossy(&net.stderr));
+    let stdout = String::from_utf8(net.stdout).expect("UTF-8 stdout");
+    let result: serde_json::Value = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("result="))
+        .map(|line| serde_json::from_str(line).expect("result JSON"))
+        .expect("result line");
+    assert_eq!(result["toolId"], "top.net");
+    assert_eq!(result["outcome"], "SUCCEEDED");
+    assert_eq!(result["reasonCode"], "COMPLETE");
+    assert_eq!(result["coverage"]["requestedUnits"], 1);
+    assert_eq!(result["coverage"]["completedUnits"], 1);
+    assert_eq!(result["provenance"]["sourceCommit"], rustfs::version::build::COMMIT_HASH);
+    assert_eq!(
+        result["provenance"]["executableSha256"],
+        sha256_file(Path::new(env!("CARGO_BIN_EXE_rustfs")))
+    );
+
+    let bytes = fs::read(&net_output).expect("top.net archive");
+    #[cfg(unix)]
+    assert_eq!(fs::metadata(&net_output).expect("output metadata").permissions().mode() & 0o777, 0o600);
+    let mut archive = ZipArchive::new(Cursor::new(bytes)).expect("top.net archive");
+    let names = (0..archive.len())
+        .map(|index| archive.by_index(index).expect("archive member").name().to_owned())
+        .collect::<Vec<_>>();
+    assert_eq!(names, ["envelope.json", "envelope.sig", "result.json"]);
+
+    let envelope = archive_entry(&mut archive, "envelope.json");
+    let signature_document = archive_entry(&mut archive, "envelope.sig");
+    let signature_document: serde_json::Value = serde_json::from_slice(&signature_document).expect("signature JSON");
+    let raw = URL_SAFE_NO_PAD
+        .decode_to_vec(signature_document["value"].as_str().expect("signature value"))
+        .expect("base64url signature");
+    let signature = Signature::from_slice(&raw).expect("P-256 signature");
+    let mut signed = b"rustfs-diagnostic-envelope-v1\0".to_vec();
+    signed.extend_from_slice(&envelope);
+    VerifyingKey::from_public_key_der(&identity.public_key_der())
+        .expect("public key")
+        .verify(&signed, &signature)
+        .expect("valid ES256 signature");
+
+    for (index, tool) in ["api", "locks", "rpc"].into_iter().enumerate() {
+        let output = directory.path().join(format!("{tool}.zip"));
+        let artifact_uid = format!("019e3ae0-0000-7000-8000-00000000003{}", index + 1);
+        let run = top_command(tool, &state, &output, &artifact_uid, 1, true)
+            .output()
+            .expect("run unsupported top command");
+        assert!(!run.status.success());
+        let stdout = String::from_utf8(run.stdout).expect("UTF-8 stdout");
+        assert!(stdout.contains("\"outcome\":\"UNSUPPORTED\""));
+        assert!(stdout.contains("\"reasonCode\":\"UNSUPPORTED_TOOL\""));
+        assert!(!output.exists());
+    }
+
+    let no_consent = top_command(
+        "net",
+        &state,
+        &directory.path().join("no-consent.zip"),
+        "019e3ae0-0000-7000-8000-000000000041",
+        1,
+        false,
+    )
+    .output()
+    .expect("run without consent");
+    assert!(!no_consent.status.success());
+    assert!(String::from_utf8_lossy(&no_consent.stderr).contains("--acknowledge-l3"));
+
+    let missing_state = directory.path().join("missing-state");
+    let over_limit = top_command(
+        "net",
+        &missing_state,
+        &directory.path().join("over-limit.zip"),
+        "019e3ae0-0000-7000-8000-000000000042",
+        30_001,
+        true,
+    )
+    .output()
+    .expect("run over limit");
+    assert!(!over_limit.status.success());
+    assert!(String::from_utf8_lossy(&over_limit.stderr).contains("connect_top_limits_invalid"));
+    assert!(!missing_state.exists(), "limit preflight must precede identity access");
+}
+
+fn top_command(tool: &str, state: &Path, output: &Path, artifact_uid: &str, window_millis: u64, acknowledge_l3: bool) -> Command {
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+    let organization = "organizations/019e3ae0-0000-7000-8000-000000000010";
+    let cluster = format!("{organization}/clusters/019e3ae0-0000-7000-8000-000000000011");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_rustfs"));
+    command
+        .args(["connect", "top", tool, "--state-dir"])
+        .arg(state)
+        .arg("--output")
+        .arg(output)
+        .args(["--organization", organization, "--cluster", &cluster, "--device"])
+        .arg(format!("{cluster}/clusterDevices/019e3ae0-0000-7000-8000-000000000012"))
+        .args([
+            "--run-uid",
+            "019e3ae0-0000-7000-8000-000000000013",
+            "--artifact-uid",
+            artifact_uid,
+            "--consent-uid",
+            "019e3ae0-0000-7000-8000-000000000015",
+            "--policy-revision",
+            "7",
+            "--consent-expires-at",
+            &(now + 120).to_string(),
+            "--run-expires-at",
+            &(now + 60).to_string(),
+            "--window-millis",
+            &window_millis.to_string(),
+        ]);
+    if acknowledge_l3 {
+        command.arg("--acknowledge-l3");
+    }
+    command
+}
+
+fn sha256_file(path: &Path) -> String {
+    let mut file = fs::File::open(path).expect("open exact binary");
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let count = file.read(&mut buffer).expect("read exact binary");
+        if count == 0 {
+            break;
+        }
+        digest.update(&buffer[..count]);
+    }
+    hex_simd::encode_to_string(digest.finalize(), hex_simd::AsciiCase::Lower)
+}

--- a/rustfs/tests/connect_top_rpc.rs
+++ b/rustfs/tests/connect_top_rpc.rs
@@ -1,0 +1,56 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use rustfs::connect::diagnostics::{
+    LocalTopConsent, TopCaptureLimits, TopCaptureRequest, TopCaptureScope, TopOutcome, TopReasonCode, capture_top_rpc,
+};
+use time::OffsetDateTime;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+async fn top_rpc_reports_unsupported_instead_of_mixing_network_and_trace_counters() {
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+    let request = TopCaptureRequest {
+        scope: TopCaptureScope {
+            organization_name: "organizations/019e3ae0-0000-7000-8000-000000000010".to_owned(),
+            cluster_name: "organizations/019e3ae0-0000-7000-8000-000000000010/clusters/019e3ae0-0000-7000-8000-000000000011".to_owned(),
+            device_name: "organizations/019e3ae0-0000-7000-8000-000000000010/clusters/019e3ae0-0000-7000-8000-000000000011/clusterDevices/019e3ae0-0000-7000-8000-000000000012".to_owned(),
+            run_uid: "019e3ae0-0000-7000-8000-000000000001".to_owned(),
+            artifact_uid: "019e3ae0-0000-7000-8000-000000000013".to_owned(),
+            policy_revision: 1,
+            run_expires_at_unix: now + 3_600,
+            executable_sha256: "b".repeat(64),
+            build_features: Vec::new(),
+            consent: LocalTopConsent {
+                uid: "019e3ae0-0000-7000-8000-000000000014".to_owned(),
+                tool_id: "top.rpc".to_owned(),
+                classification: "L3".to_owned(),
+                active: true,
+                expires_at_unix: now + 3_600,
+            },
+        },
+        limits: TopCaptureLimits::default(),
+        window: Duration::from_millis(1),
+        export_validity: Duration::from_secs(300),
+    };
+
+    let result = capture_top_rpc(&request, &CancellationToken::new())
+        .await
+        .expect("structured unsupported result");
+    assert_eq!(result.outcome, TopOutcome::Unsupported);
+    assert_eq!(result.reason_code, TopReasonCode::UnsupportedTool);
+    assert!(result.data.is_none());
+}


### PR DESCRIPTION
## Related Issues

- rustfs/connect#623

## Summary of Changes

- add bounded `top.api`, `top.disk`, `top.locks`, `top.net`, and `top.rpc` producers
- enforce explicit L3 consent, expiry, resource limits, cancellation, redacted output, and exact executable provenance
- add a customer-reviewable ES256-signed ZIP export through `rustfs connect top`; unavailable typed sources return `UNSUPPORTED` without writing an artifact

## Verification

- source SHA: `3c6cd91aa95a2d51f5c802b95140257fe169af4f`
- exact binary SHA-256: `f86bb33ed4ece1cbc4f20fd2f54300b7567f2be1defeb7749e831cd7c9df7492`
- `cargo test -p rustfs --test connect_top_api --test connect_top_disk --test connect_top_locks --test connect_top_net --test connect_top_rpc --no-fail-fast` (12 passed)
- `cargo fmt --all -- --check`
- Connect `make protocol-check`
- real CLI coverage: `top.net` produced a signed private archive; unsupported categories, missing consent, and over-limit requests produced no artifact

## Impact

This adds an explicit local diagnostics command. It does not change the server data path or add inbound connectivity.

## Rollback

Revert this commit to remove the command and producer modules.
