### PR TITLE
fix(scanner): prove dirty ACK after confirmed root write

### DIFF
--- a/crates/scanner/src/scanner/usage_store.rs
+++ b/crates/scanner/src/scanner/usage_store.rs
@@ -76,6 +76,24 @@ impl DataUsagePublicationResult {
     }
 }
 
+fn root_write_publication_proof(
+    outcome: DataUsagePersistOutcome,
+    write_confirmed: bool,
+    written_etag: Option<&str>,
+    expected: &crate::scanner_io::ScannerPublicationExpectation,
+    data_digest: &[u8; 32],
+) -> Option<RootPublicationProof> {
+    if outcome != DataUsagePersistOutcome::Saved || !write_confirmed || !expected.matches_encoded_candidate(data_digest) {
+        return None;
+    }
+
+    let etag = written_etag.filter(|etag| !etag.is_empty())?;
+    Some(RootPublicationProof {
+        candidate: expected.clone(),
+        root_version: (etag.to_string(), *data_digest),
+    })
+}
+
 fn root_ack_write_is_confirmed<T, E>(
     result: &std::result::Result<T, E>,
     state: Option<ScannerPublicationCommitState>,
@@ -123,6 +141,52 @@ mod root_publication_confirmation_tests {
             .map(|(result, state, etag)| root_ack_write_is_confirmed(result, *state, *etag))
             .collect::<Vec<_>>();
         assert_eq!(confirmations, [false, false, false, true]);
+    }
+}
+
+#[cfg(test)]
+mod root_write_publication_proof_tests {
+    use super::*;
+
+    fn expectation_for(info: &DataUsageInfo) -> crate::scanner_io::ScannerPublicationExpectation {
+        let data = serde_json::to_vec(info).expect("usage info should encode");
+        crate::scanner_io::ScannerPublicationExpectation::for_tests(
+            Sha256::digest(data).into(),
+            crate::data_usage_define::DataUsageScanPlanDigest([7; 32]),
+        )
+    }
+
+    #[test]
+    fn root_write_publication_proof_requires_committed_root_write_identity() {
+        let info = DataUsageInfo {
+            scanner_cycle: Some(11),
+            scanner_epoch: Some(7),
+            usage_snapshot_complete: true,
+            ..Default::default()
+        };
+        let expected = expectation_for(&info);
+        let data = serde_json::to_vec(&info).expect("usage info should encode");
+        let digest: [u8; 32] = Sha256::digest(&data).into();
+        let stale_digest = Sha256::digest(b"stale").into();
+
+        assert!(
+            root_write_publication_proof(DataUsagePersistOutcome::AlreadyDurable, true, Some("etag"), &expected, &digest)
+                .is_none()
+        );
+        assert!(root_write_publication_proof(DataUsagePersistOutcome::Saved, false, Some("etag"), &expected, &digest).is_none());
+        assert!(root_write_publication_proof(DataUsagePersistOutcome::Saved, true, None, &expected, &digest).is_none());
+        assert!(root_write_publication_proof(DataUsagePersistOutcome::Saved, true, Some(""), &expected, &digest).is_none());
+        assert!(
+            root_write_publication_proof(DataUsagePersistOutcome::Saved, true, Some("etag"), &expected, &stale_digest).is_none()
+        );
+
+        let proof = root_write_publication_proof(DataUsagePersistOutcome::Saved, true, Some("etag"), &expected, &digest)
+            .expect("a confirmed root CAS write should prove its own candidate");
+        let (etag, raw_digest) = proof
+            .verified_version_for(&expected)
+            .expect("proof should bind the expected candidate");
+        assert_eq!(etag, "etag");
+        assert_eq!(*raw_digest, digest);
     }
 }
 
@@ -1085,6 +1149,9 @@ where
                 written_etag.as_deref(),
             )
             .await;
+            if proof.is_none() {
+                proof = root_write_publication_proof(outcome, write_confirmed, written_etag.as_deref(), expected, &data_digest);
+            }
         }
     }
 

--- a/crates/scanner/src/scanner_io/cache.rs
+++ b/crates/scanner/src/scanner_io/cache.rs
@@ -321,6 +321,13 @@ impl ScannerPublicationExpectation {
     pub(crate) fn same_candidate(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.candidate, &other.candidate) && self.candidate.1 == other.candidate.1
     }
+
+    #[cfg(test)]
+    pub(crate) fn for_tests(candidate_digest: [u8; 32], coverage_digest: DataUsageScanPlanDigest) -> Self {
+        Self {
+            candidate: Arc::new((candidate_digest, coverage_digest)),
+        }
+    }
 }
 
 pub(super) struct ValidatedUsageCandidate {


### PR DESCRIPTION
## Related Issues

Refs #7702
Refs rustfs/backlog#2498

## Summary of Changes

The release scanner dirty-usage ACK path requires a root publication proof before clearing local dirty usage. A completed scanner cycle that successfully saves the root data-usage object already has a confirmed storage commit, the written root revision, and the exact encoded candidate digest, but the ACK still depended on an additional root readback proof. If that readback returned no proof because of a transient read failure, timeout, or exhausted deadline, the saved cycle stayed dirty and later scanner cycles kept doing maintenance work.

This change lets only a confirmed `Saved` root CAS write prove its own matching scanner candidate. The fallback requires:

- the persist outcome is `Saved`;
- the storage publication scope confirmed the root write;
- the written ETag is non-empty;
- the encoded candidate digest matches the scan's publication expectation.

`AlreadyDurable`, companion-only durability, observational writes, stale CAS paths, empty revisions, and digest mismatches still require the existing root readback proof and do not get this fallback.

## Verification

- `cargo test -p rustfs-scanner root_write_publication_proof --lib`  
  Result: 1 passed. Covers the new fallback guard matrix.
- `cargo test -p rustfs-scanner root_publication_confirmation --lib`  
  Result: 2 passed. Confirms only committed writes with non-empty revisions count as confirmed.
- `cargo test -p rustfs-scanner scoped_ack_publication --lib`  
  Result: 8 passed. Keeps companion-only, stale CAS, proof-transfer, semantic root readback, and mutation-after-publish boundaries intact.
- `cargo fmt --all --check`  
  Result: passed.
- `git diff --check`  
  Result: passed.

Docker validation was attempted for a local release-fix image. The build reached the RustFS scanner/protocol compilation path but did not complete in the available window and was canceled; published rc.5/rc.6 manifest checks also timed out against Docker Hub. Runtime scaled reproduction remains the main unverified boundary for this PR.

## Impact

This is limited to scanner data-usage maintenance liveness after a confirmed root usage save. It does not change S3 request semantics, disk format, wire format, configuration, or compatibility behavior. The intended user-visible effect is that a scanner cycle that has already durably published its matching root usage snapshot can clear the matching dirty-usage generation even if the extra root proof readback is unavailable.

## Additional Notes

Adversarial review covered correctness, concurrency/durability, compatibility, performance, and test coverage. No supported finding remained after review. The main residual risk is the lack of a Docker runtime reproduction in this environment; the code path is covered by focused scanner tests, including the existing scoped ACK publication regressions.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
