### PR TITLE
Add authenticated inter-node network performance probes

### DIFF
--- a/crates/ecstore/src/api/mod.rs
+++ b/crates/ecstore/src/api/mod.rs
@@ -541,20 +541,21 @@ pub mod rio {
 
 pub mod rpc {
     pub use crate::cluster::rpc::{
-        AuthenticatedChannel, KMS_SIGNAL_SUBSYSTEM, LocalPeerS3Client, PEER_RESTDRY_RUN, PEER_RESTSIGNAL, PEER_RESTSUB_SYS,
-        PeerRestClient, PeerS3Client, S3PeerSys, SERVICE_SIGNAL_REFRESH_CONFIG, SERVICE_SIGNAL_RELOAD_DYNAMIC,
-        ScannerBucketListing, ScannerDirtyUsageAcknowledgement, ScannerPeerActivity, ScannerPeerDirtyUsageBucket,
-        ScannerPeerDirtyUsageSnapshot, ScannerPublicationLease, ScannerScopedDirtyUsageAckEntry, TONIC_RPC_PREFIX,
-        TonicInterceptor, build_put_file_auth_trailer, check_and_record_signed_rpc_nonce, decode_heal_bucket_rpc_options,
-        encode_heal_bucket_rpc_options, gen_signature_headers, gen_tonic_replay_scope_headers, gen_tonic_signature_headers,
-        gen_tonic_signature_interceptor, node_service_time_out_client, node_service_time_out_client_no_auth,
-        normalize_tonic_rpc_audience, set_tonic_canonical_body_digest, sign_ns_scanner_capability,
-        sign_ns_scanner_capability_with_tier_registry_generation, sign_put_file_capability, sign_tonic_rpc_response_proof,
-        tonic_boot_epoch_challenge, tonic_boot_epoch_response_headers, tonic_rpc_auth_failure_reason,
-        verify_ns_scanner_capability, verify_ns_scanner_capability_with_tier_registry_generation, verify_put_file_auth_trailer,
-        verify_put_file_capability, verify_rpc_signature, verify_tonic_boot_epoch_response, verify_tonic_canonical_body_digest,
-        verify_tonic_mutation_body_digest, verify_tonic_mutation_body_digest_reject_unsigned, verify_tonic_rpc_response_proof,
-        verify_tonic_rpc_signature, verify_tonic_rpc_signature_with_bootstrap,
+        AuthenticatedChannel, KMS_SIGNAL_SUBSYSTEM, LocalPeerS3Client, MAX_NETWORK_PROBE_BYTES, MAX_NETWORK_PROBE_DURATION,
+        NetworkPeerProbeClient, NetworkPeerProbeError, NetworkPeerProbeMeasurement, NetworkPeerTarget, PEER_RESTDRY_RUN,
+        PEER_RESTSIGNAL, PEER_RESTSUB_SYS, PeerRestClient, PeerS3Client, S3PeerSys, SERVICE_SIGNAL_REFRESH_CONFIG,
+        SERVICE_SIGNAL_RELOAD_DYNAMIC, ScannerBucketListing, ScannerDirtyUsageAcknowledgement, ScannerPeerActivity,
+        ScannerPeerDirtyUsageBucket, ScannerPeerDirtyUsageSnapshot, ScannerPublicationLease, ScannerScopedDirtyUsageAckEntry,
+        TONIC_RPC_PREFIX, TonicInterceptor, build_put_file_auth_trailer, check_and_record_signed_rpc_nonce,
+        decode_heal_bucket_rpc_options, encode_heal_bucket_rpc_options, gen_signature_headers, gen_tonic_replay_scope_headers,
+        gen_tonic_signature_headers, gen_tonic_signature_interceptor, node_service_time_out_client,
+        node_service_time_out_client_no_auth, normalize_tonic_rpc_audience, set_tonic_canonical_body_digest,
+        sign_ns_scanner_capability, sign_ns_scanner_capability_with_tier_registry_generation, sign_put_file_capability,
+        sign_tonic_rpc_response_proof, tonic_boot_epoch_challenge, tonic_boot_epoch_response_headers,
+        tonic_rpc_auth_failure_reason, verify_ns_scanner_capability, verify_ns_scanner_capability_with_tier_registry_generation,
+        verify_put_file_auth_trailer, verify_put_file_capability, verify_rpc_signature, verify_tonic_boot_epoch_response,
+        verify_tonic_canonical_body_digest, verify_tonic_mutation_body_digest, verify_tonic_mutation_body_digest_reject_unsigned,
+        verify_tonic_rpc_response_proof, verify_tonic_rpc_signature, verify_tonic_rpc_signature_with_bootstrap,
     };
 }
 

--- a/crates/ecstore/src/cluster/rpc/mod.rs
+++ b/crates/ecstore/src/cluster/rpc/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod client;
 pub(crate) mod context_propagation;
 pub(crate) mod http_auth;
 pub(crate) mod internode_data_transport;
+mod network_probe;
 pub(crate) mod peer_rest_client;
 pub(crate) mod peer_s3_client;
 pub(crate) mod remote_disk;
@@ -45,6 +46,10 @@ pub use http_auth::{
 #[cfg(test)]
 pub(crate) use internode_data_transport::TcpHttpInternodeDataTransport;
 pub use internode_data_transport::build_internode_data_transport_from_env;
+pub use network_probe::{
+    MAX_NETWORK_PROBE_BYTES, MAX_NETWORK_PROBE_DURATION, NetworkPeerProbeClient, NetworkPeerProbeError,
+    NetworkPeerProbeMeasurement, NetworkPeerTarget,
+};
 pub(crate) use peer_rest_client::TierConfigReloadOutcome;
 pub use peer_rest_client::{
     KMS_SIGNAL_SUBSYSTEM, PEER_RESTDRY_RUN, PEER_RESTSIGNAL, PEER_RESTSUB_SYS, PeerRestClient, SERVICE_SIGNAL_REFRESH_CONFIG,

--- a/crates/ecstore/src/cluster/rpc/network_probe.rs
+++ b/crates/ecstore/src/cluster/rpc/network_probe.rs
@@ -1,0 +1,318 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Bounded, authenticated inter-node network probes.
+
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use rustfs_protos::ChannelClass;
+use rustfs_protos::models::{PingBody, PingBodyBuilder};
+use rustfs_protos::proto_gen::node_service::{PingRequest, PingResponse};
+use thiserror::Error;
+use tokio_util::sync::CancellationToken;
+use tonic::{Code, Request};
+
+use crate::cluster::rpc::client::{TonicInterceptor, gen_tonic_signature_interceptor, node_service_time_out_client_for_class};
+use crate::layout::endpoints::EndpointServerPools;
+
+pub const MAX_NETWORK_PROBE_BYTES: u64 = 1_048_576;
+pub const MAX_NETWORK_PROBE_DURATION: Duration = Duration::from_secs(30);
+
+const PING_PROTOCOL_VERSION: u64 = 1;
+const LATENCY_PAYLOAD: &[u8] = b"network-probe-latency-v1";
+const EXPECTED_RESPONSE_PAYLOAD: &[u8] = b"hello, caller";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NetworkPeerTarget {
+    pub alias: String,
+    pub address: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NetworkPeerProbeMeasurement {
+    pub transferred_bytes: u64,
+    pub duration: Duration,
+    pub latency: Duration,
+}
+
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub enum NetworkPeerProbeError {
+    #[error("network peer is not part of the current topology")]
+    UnknownPeer,
+    #[error("network peer probe exceeds its resource limits")]
+    LimitExceeded,
+    #[error("network peer probe was cancelled")]
+    Cancelled,
+    #[error("network peer is unreachable")]
+    Unreachable,
+    #[error("network peer probe timed out")]
+    TimedOut,
+    #[error("network peer returned an invalid probe response")]
+    ProtocolFailure,
+}
+
+#[derive(Clone, Debug)]
+pub struct NetworkPeerProbeClient {
+    targets: Vec<NetworkPeerTarget>,
+}
+
+impl NetworkPeerProbeClient {
+    pub fn from_endpoint_pools(endpoint_pools: &EndpointServerPools) -> Self {
+        let targets = endpoint_pools
+            .peer_grid_host_slots_sorted()
+            .into_iter()
+            .filter_map(|(_, address, is_local)| (!is_local).then_some(address).flatten())
+            .enumerate()
+            .map(|(index, address)| NetworkPeerTarget {
+                alias: format!("peer-{}", index + 1),
+                address,
+            })
+            .collect();
+        Self { targets }
+    }
+
+    pub fn targets(&self) -> Vec<NetworkPeerTarget> {
+        self.targets.clone()
+    }
+
+    pub async fn probe(
+        &self,
+        peer_alias: &str,
+        traffic_bytes: u64,
+        max_duration: Duration,
+        cancel: &CancellationToken,
+    ) -> Result<NetworkPeerProbeMeasurement, NetworkPeerProbeError> {
+        if traffic_bytes == 0
+            || traffic_bytes > MAX_NETWORK_PROBE_BYTES
+            || max_duration.is_zero()
+            || max_duration > MAX_NETWORK_PROBE_DURATION
+        {
+            return Err(NetworkPeerProbeError::LimitExceeded);
+        }
+        if cancel.is_cancelled() {
+            return Err(NetworkPeerProbeError::Cancelled);
+        }
+        let address = self
+            .targets
+            .iter()
+            .find(|target| target.alias == peer_alias)
+            .map(|target| target.address.as_str())
+            .ok_or(NetworkPeerProbeError::UnknownPeer)?;
+        let probe = probe_peer(address, traffic_bytes);
+        tokio::select! {
+            () = cancel.cancelled() => Err(NetworkPeerProbeError::Cancelled),
+            result = tokio::time::timeout(max_duration, probe) => {
+                result.map_err(|_| NetworkPeerProbeError::TimedOut)?
+            }
+        }
+    }
+}
+
+async fn probe_peer(address: &str, traffic_bytes: u64) -> Result<NetworkPeerProbeMeasurement, NetworkPeerProbeError> {
+    let started = Instant::now();
+    let mut control = client(address, ChannelClass::Control).await?;
+    let latency_started = Instant::now();
+    let latency_response = control
+        .ping(Request::new(ping_request(LATENCY_PAYLOAD)))
+        .await
+        .map_err(map_status)?
+        .into_inner();
+    validate_ping_response(&latency_response)?;
+    let latency = latency_started.elapsed();
+
+    let payload_len = usize::try_from(traffic_bytes).map_err(|_| NetworkPeerProbeError::LimitExceeded)?;
+    let payload = vec![0x5a; payload_len];
+    let mut bulk = client(address, ChannelClass::Bulk).await?;
+    let response = bulk
+        .ping(Request::new(ping_request(&payload)))
+        .await
+        .map_err(map_status)?
+        .into_inner();
+    validate_ping_response(&response)?;
+
+    Ok(NetworkPeerProbeMeasurement {
+        transferred_bytes: traffic_bytes,
+        duration: started.elapsed(),
+        latency,
+    })
+}
+
+async fn client(
+    address: &str,
+    class: ChannelClass,
+) -> Result<
+    rustfs_protos::proto_gen::node_service::node_service_client::NodeServiceClient<
+        tonic::service::interceptor::InterceptedService<super::client::AuthenticatedChannel, TonicInterceptor>,
+    >,
+    NetworkPeerProbeError,
+> {
+    node_service_time_out_client_for_class(
+        &address.to_owned(),
+        TonicInterceptor::Signature(gen_tonic_signature_interceptor()),
+        class,
+    )
+    .await
+    .map_err(|_| NetworkPeerProbeError::Unreachable)
+}
+
+fn ping_request(payload: &[u8]) -> PingRequest {
+    let mut builder = flatbuffers::FlatBufferBuilder::with_capacity(payload.len().saturating_add(64));
+    let payload = builder.create_vector(payload);
+    let mut body = PingBodyBuilder::new(&mut builder);
+    body.add_payload(payload);
+    let root = body.finish();
+    builder.finish(root, None);
+    PingRequest {
+        version: PING_PROTOCOL_VERSION,
+        body: Bytes::copy_from_slice(builder.finished_data()),
+    }
+}
+
+fn validate_ping_response(response: &PingResponse) -> Result<(), NetworkPeerProbeError> {
+    if response.version != PING_PROTOCOL_VERSION {
+        return Err(NetworkPeerProbeError::ProtocolFailure);
+    }
+    let body = flatbuffers::root::<PingBody>(&response.body).map_err(|_| NetworkPeerProbeError::ProtocolFailure)?;
+    if body
+        .payload()
+        .is_none_or(|payload| payload.bytes() != EXPECTED_RESPONSE_PAYLOAD)
+    {
+        return Err(NetworkPeerProbeError::ProtocolFailure);
+    }
+    Ok(())
+}
+
+fn map_status(status: tonic::Status) -> NetworkPeerProbeError {
+    match status.code() {
+        Code::Unavailable | Code::Unknown => NetworkPeerProbeError::Unreachable,
+        Code::DeadlineExceeded => NetworkPeerProbeError::TimedOut,
+        _ => NetworkPeerProbeError::ProtocolFailure,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::endpoint::Endpoint;
+    use crate::layout::endpoints::{Endpoints, PoolEndpoints};
+
+    fn endpoint(value: &str, is_local: bool) -> Endpoint {
+        let mut endpoint = Endpoint::try_from(value).expect("test endpoint should parse");
+        endpoint.is_local = is_local;
+        endpoint
+    }
+
+    fn topology() -> EndpointServerPools {
+        EndpointServerPools::from(vec![PoolEndpoints {
+            legacy: false,
+            set_count: 1,
+            drives_per_set: 4,
+            endpoints: Endpoints::from(vec![
+                endpoint("http://node-b:9000/data", false),
+                endpoint("http://node-a:9000/data", true),
+                endpoint("http://node-c:9000/data", false),
+                endpoint("http://node-b:9000/other", false),
+            ]),
+            cmd_line: String::new(),
+            platform: String::new(),
+        }])
+    }
+
+    #[test]
+    fn targets_are_unique_sorted_remote_nodes_with_stable_aliases() {
+        let client = NetworkPeerProbeClient::from_endpoint_pools(&topology());
+        assert_eq!(
+            client.targets(),
+            vec![
+                NetworkPeerTarget {
+                    alias: "peer-1".to_owned(),
+                    address: "http://node-b:9000".to_owned(),
+                },
+                NetworkPeerTarget {
+                    alias: "peer-2".to_owned(),
+                    address: "http://node-c:9000".to_owned(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn peer_aliases_remain_in_numeric_order_past_nine_peers() {
+        let endpoints: Vec<Endpoint> = (1..=12)
+            .map(|index| endpoint(&format!("http://node-{index:02}:9000/data"), false))
+            .collect();
+        let topology = EndpointServerPools::from(vec![PoolEndpoints {
+            legacy: false,
+            set_count: 1,
+            drives_per_set: 12,
+            endpoints: Endpoints::from(endpoints),
+            cmd_line: String::new(),
+            platform: String::new(),
+        }]);
+
+        let aliases = NetworkPeerProbeClient::from_endpoint_pools(&topology)
+            .targets()
+            .into_iter()
+            .map(|target| target.alias)
+            .collect::<Vec<_>>();
+
+        assert_eq!(aliases, (1..=12).map(|index| format!("peer-{index}")).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn invalid_limits_and_unknown_peer_fail_before_dial() {
+        let client = NetworkPeerProbeClient::from_endpoint_pools(&topology());
+        let cancel = CancellationToken::new();
+        assert_eq!(
+            client
+                .probe("peer-1", MAX_NETWORK_PROBE_BYTES + 1, Duration::from_secs(1), &cancel)
+                .await,
+            Err(NetworkPeerProbeError::LimitExceeded)
+        );
+        assert_eq!(
+            client.probe("peer-3", 1, Duration::from_secs(1), &cancel).await,
+            Err(NetworkPeerProbeError::UnknownPeer)
+        );
+        cancel.cancel();
+        assert_eq!(
+            client.probe("peer-1", 1, Duration::from_secs(1), &cancel).await,
+            Err(NetworkPeerProbeError::Cancelled)
+        );
+    }
+
+    #[test]
+    fn ping_body_carries_exact_requested_payload_and_response_is_validated() {
+        let request = ping_request(&vec![0x5a; 4096]);
+        let body = flatbuffers::root::<PingBody>(&request.body).expect("probe ping should be valid");
+        assert_eq!(body.payload().expect("probe payload").len(), 4096);
+
+        let valid = PingResponse {
+            version: PING_PROTOCOL_VERSION,
+            body: ping_request(EXPECTED_RESPONSE_PAYLOAD).body,
+        };
+        assert_eq!(validate_ping_response(&valid), Ok(()));
+
+        let wrong_version = PingResponse {
+            version: 2,
+            ..valid.clone()
+        };
+        assert_eq!(validate_ping_response(&wrong_version), Err(NetworkPeerProbeError::ProtocolFailure));
+        let malformed = PingResponse {
+            version: PING_PROTOCOL_VERSION,
+            body: Bytes::from_static(b"not-flatbuffers"),
+        };
+        assert_eq!(validate_ping_response(&malformed), Err(NetworkPeerProbeError::ProtocolFailure));
+    }
+}

--- a/rustfs/src/admin/handlers/diagnostics.rs
+++ b/rustfs/src/admin/handlers/diagnostics.rs
@@ -47,6 +47,7 @@ use std::task::{Context, Poll};
 use std::time::{Duration, SystemTime};
 use tokio::sync::{Semaphore, SemaphorePermit, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 const CONTENT_TYPE_NDJSON: &str = "application/x-ndjson";
@@ -54,7 +55,12 @@ pub(crate) const CLIENT_DEVNULL_MAX_BYTES: u64 = 1024 * 1024 * 1024;
 pub(crate) const CLIENT_DEVNULL_MAX_DURATION: Duration = Duration::from_secs(30);
 pub(crate) const CLIENT_DEVNULL_MAX_CONCURRENCY: usize = 4;
 pub(crate) const CLIENT_DEVNULL_SOURCE_MAX_BYTES: u64 = 1024 * 1024;
+pub(crate) const NETWORK_PROBE_MAX_CONCURRENCY: usize = 1;
+pub(crate) use crate::storage::storage_api::ecstore_rpc::{
+    MAX_NETWORK_PROBE_BYTES as NETWORK_PROBE_MAX_BYTES, MAX_NETWORK_PROBE_DURATION as NETWORK_PROBE_MAX_DURATION,
+};
 static CLIENT_DEVNULL_ADMISSION: Semaphore = Semaphore::const_new(CLIENT_DEVNULL_MAX_CONCURRENCY);
+static NETWORK_PROBE_ADMISSION: Semaphore = Semaphore::const_new(NETWORK_PROBE_MAX_CONCURRENCY);
 
 /// Cap on how many locks a single `top/locks` response enumerates, matching the
 /// MinIO default page size and bounding response size on busy clusters.
@@ -812,6 +818,17 @@ struct DriveSpeedtestEntry {
 }
 
 #[derive(Debug, Clone, Serialize)]
+struct NetworkSpeedtestEntry {
+    peer_alias: String,
+    outcome: &'static str,
+    reason: &'static str,
+    transferred_bytes: u64,
+    duration_secs: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    latency_micros: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 struct SpeedtestResponse {
     kind: &'static str,
     /// `true` when the reported numbers come from a real measurement/observation
@@ -827,6 +844,8 @@ struct SpeedtestResponse {
     aggregate_write_throughput_bytes_per_sec: Option<f64>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     drives: Vec<DriveSpeedtestEntry>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    peers: Vec<NetworkSpeedtestEntry>,
     /// Bytes drained by the net/devnull probe and how long it took.
     #[serde(skip_serializing_if = "Option::is_none")]
     rx_bytes: Option<u64>,
@@ -867,6 +886,7 @@ async fn run_drive_speedtest() -> S3Result<SpeedtestResponse> {
         aggregate_read_throughput_bytes_per_sec: Some(agg_read),
         aggregate_write_throughput_bytes_per_sec: Some(agg_write),
         drives,
+        peers: Vec::new(),
         rx_bytes: None,
         duration_secs: None,
     })
@@ -885,25 +905,109 @@ fn object_speedtest_unsupported() -> SpeedtestResponse {
         aggregate_read_throughput_bytes_per_sec: None,
         aggregate_write_throughput_bytes_per_sec: None,
         drives: Vec::new(),
+        peers: Vec::new(),
         rx_bytes: None,
         duration_secs: None,
     }
 }
 
-fn net_speedtest_single_node() -> SpeedtestResponse {
+async fn run_network_speedtest() -> SpeedtestResponse {
+    use crate::storage::storage_api::ecstore_rpc::{NetworkPeerProbeClient, NetworkPeerProbeError};
+
+    let Some(endpoint_pools) = crate::runtime_sources::current_endpoints_handle() else {
+        return unavailable_network_speedtest("cluster topology is not initialized");
+    };
+    let client = NetworkPeerProbeClient::from_endpoint_pools(&endpoint_pools);
+    let targets = client.targets();
+    if targets.is_empty() {
+        return unavailable_network_speedtest("the current topology has no remote peers");
+    }
+    let peer_count = u64::try_from(targets.len()).unwrap_or(u64::MAX);
+    let traffic_bytes = NETWORK_PROBE_MAX_BYTES.checked_div(peer_count).unwrap_or(0);
+    if traffic_bytes == 0 {
+        return unavailable_network_speedtest("the current topology exceeds the probe traffic budget");
+    }
+    let Ok(_permit) = NETWORK_PROBE_ADMISSION.try_acquire() else {
+        return unavailable_network_speedtest("another inter-node network probe is already running");
+    };
+
+    let started = std::time::Instant::now();
+    let cancel = CancellationToken::new();
+    let mut peers = Vec::with_capacity(targets.len());
+    let mut transferred_bytes = 0_u64;
+    for target in targets {
+        let remaining = NETWORK_PROBE_MAX_DURATION.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            peers.push(network_speedtest_failure(target.alias, NetworkPeerProbeError::TimedOut, Duration::ZERO));
+            continue;
+        }
+        let peer_started = std::time::Instant::now();
+        match client.probe(&target.alias, traffic_bytes, remaining, &cancel).await {
+            Ok(measurement) => {
+                transferred_bytes = transferred_bytes.saturating_add(measurement.transferred_bytes);
+                peers.push(NetworkSpeedtestEntry {
+                    peer_alias: target.alias,
+                    outcome: "SUCCEEDED",
+                    reason: "COMPLETE",
+                    transferred_bytes: measurement.transferred_bytes,
+                    duration_secs: measurement.duration.as_secs_f64(),
+                    latency_micros: u64::try_from(measurement.latency.as_micros()).ok(),
+                });
+            }
+            Err(error) => peers.push(network_speedtest_failure(target.alias, error, peer_started.elapsed())),
+        }
+    }
+    let elapsed = started.elapsed().min(NETWORK_PROBE_MAX_DURATION);
+    let successful = peers.iter().filter(|peer| peer.outcome == "SUCCEEDED").count();
+    let throughput = (successful > 0 && !elapsed.is_zero()).then(|| transferred_bytes as f64 / elapsed.as_secs_f64());
+    SpeedtestResponse {
+        kind: "net",
+        measured: successful > 0,
+        capability_note: (successful != peers.len()).then(|| "one or more inter-node probes failed".to_string()),
+        aggregate_read_throughput_bytes_per_sec: None,
+        aggregate_write_throughput_bytes_per_sec: throughput,
+        drives: Vec::new(),
+        peers,
+        rx_bytes: None,
+        duration_secs: Some(elapsed.as_secs_f64()),
+    }
+}
+
+fn unavailable_network_speedtest(reason: &str) -> SpeedtestResponse {
     SpeedtestResponse {
         kind: "net",
         measured: false,
-        capability_note: Some(
-            "network speedtest measures inter-node bandwidth; a distributed peer-perf harness is not yet wired. See \
-             /v3/site-replication/netperf for the site-to-site variant"
-                .to_string(),
-        ),
+        capability_note: Some(reason.to_owned()),
         aggregate_read_throughput_bytes_per_sec: None,
         aggregate_write_throughput_bytes_per_sec: None,
         drives: Vec::new(),
+        peers: Vec::new(),
         rx_bytes: None,
         duration_secs: None,
+    }
+}
+
+fn network_speedtest_failure(
+    peer_alias: String,
+    error: crate::storage::storage_api::ecstore_rpc::NetworkPeerProbeError,
+    duration: Duration,
+) -> NetworkSpeedtestEntry {
+    use crate::storage::storage_api::ecstore_rpc::NetworkPeerProbeError;
+    let reason = match error {
+        NetworkPeerProbeError::UnknownPeer => "UNKNOWN_PEER",
+        NetworkPeerProbeError::LimitExceeded => "LIMIT_EXCEEDED",
+        NetworkPeerProbeError::Cancelled => "CANCELLED",
+        NetworkPeerProbeError::Unreachable => "UNREACHABLE",
+        NetworkPeerProbeError::TimedOut => "TIMED_OUT",
+        NetworkPeerProbeError::ProtocolFailure => "PROTOCOL_FAILURE",
+    };
+    NetworkSpeedtestEntry {
+        peer_alias,
+        outcome: "FAILED",
+        reason,
+        transferred_bytes: 0,
+        duration_secs: duration.as_secs_f64(),
+        latency_micros: None,
     }
 }
 
@@ -921,7 +1025,7 @@ impl Operation for SpeedtestHandler {
         let response = match kind {
             SpeedtestKind::Drive => run_drive_speedtest().await?,
             SpeedtestKind::Object => object_speedtest_unsupported(),
-            SpeedtestKind::Net => net_speedtest_single_node(),
+            SpeedtestKind::Net => run_network_speedtest().await,
             SpeedtestKind::Site => SpeedtestResponse {
                 kind: "site",
                 measured: false,
@@ -931,6 +1035,7 @@ impl Operation for SpeedtestHandler {
                 aggregate_read_throughput_bytes_per_sec: None,
                 aggregate_write_throughput_bytes_per_sec: None,
                 drives: Vec::new(),
+                peers: Vec::new(),
                 rx_bytes: None,
                 duration_secs: None,
             },
@@ -1045,6 +1150,7 @@ impl Operation for SpeedtestClientDevnullHandler {
                 0.0
             }),
             drives: Vec::new(),
+            peers: Vec::new(),
             rx_bytes: Some(total),
             duration_secs: Some(elapsed.as_secs_f64()),
         };
@@ -1272,6 +1378,28 @@ mod tests {
 
         drop(permits);
         let _permit = acquire_client_devnull_permit().expect("released admission slots must be reusable");
+    }
+
+    #[test]
+    fn network_probe_admission_fails_fast_and_recovers() {
+        let permit = NETWORK_PROBE_ADMISSION.try_acquire().expect("network probe admission slot");
+        assert!(NETWORK_PROBE_ADMISSION.try_acquire().is_err());
+        drop(permit);
+        let _permit = NETWORK_PROBE_ADMISSION.try_acquire().expect("released network probe slot");
+    }
+
+    #[test]
+    fn network_probe_failure_keeps_peer_attribution_and_elapsed_time() {
+        let failure = network_speedtest_failure(
+            "peer-2".to_owned(),
+            crate::storage::storage_api::ecstore_rpc::NetworkPeerProbeError::TimedOut,
+            Duration::from_millis(25),
+        );
+        assert_eq!(failure.peer_alias, "peer-2");
+        assert_eq!(failure.outcome, "FAILED");
+        assert_eq!(failure.reason, "TIMED_OUT");
+        assert_eq!(failure.transferred_bytes, 0);
+        assert_eq!(failure.duration_secs, 0.025);
     }
 
     #[test]

--- a/rustfs/src/admin/handlers/system.rs
+++ b/rustfs/src/admin/handlers/system.rs
@@ -904,10 +904,15 @@ impl DiagnosticProbeCapabilities {
                 "object PUT/GET benchmark harness is not implemented",
                 Some("/rustfs/admin/v3/speedtest/object"),
             ),
-            inter_node_netperf: unsupported(
-                "inter-node traffic benchmark harness is not implemented",
-                Some("/rustfs/admin/v3/speedtest/net"),
-            ),
+            inter_node_netperf: DiagnosticProbeCapability {
+                status: CapabilityStatus::supported()
+                    .with_reason("actively measures bounded authenticated traffic to every remote cluster peer"),
+                mode: "active_inter_node_probe",
+                route: Some("/rustfs/admin/v3/speedtest/net"),
+                max_bytes: Some(super::diagnostics::NETWORK_PROBE_MAX_BYTES),
+                max_duration_secs: Some(super::diagnostics::NETWORK_PROBE_MAX_DURATION.as_secs()),
+                max_concurrency: Some(super::diagnostics::NETWORK_PROBE_MAX_CONCURRENCY),
+            },
             site_speedtest: unsupported(
                 "site traffic benchmark harness is not implemented",
                 Some("/rustfs/admin/v3/speedtest/site"),
@@ -1421,10 +1426,23 @@ mod tests {
             response.diagnostic_probes.client_devnull.max_concurrency,
             Some(super::super::diagnostics::CLIENT_DEVNULL_MAX_CONCURRENCY)
         );
+        assert_eq!(response.diagnostic_probes.inter_node_netperf.status.state, CapabilityState::Supported);
+        assert_eq!(response.diagnostic_probes.inter_node_netperf.mode, "active_inter_node_probe");
+        assert_eq!(
+            response.diagnostic_probes.inter_node_netperf.max_bytes,
+            Some(super::super::diagnostics::NETWORK_PROBE_MAX_BYTES)
+        );
+        assert_eq!(
+            response.diagnostic_probes.inter_node_netperf.max_duration_secs,
+            Some(super::super::diagnostics::NETWORK_PROBE_MAX_DURATION.as_secs())
+        );
+        assert_eq!(
+            response.diagnostic_probes.inter_node_netperf.max_concurrency,
+            Some(super::super::diagnostics::NETWORK_PROBE_MAX_CONCURRENCY)
+        );
         for probe in [
             &response.diagnostic_probes.inspect_archive,
             &response.diagnostic_probes.object_speedtest,
-            &response.diagnostic_probes.inter_node_netperf,
             &response.diagnostic_probes.site_speedtest,
             &response.diagnostic_probes.site_replication_netperf,
         ] {

--- a/rustfs/src/config/cli.rs
+++ b/rustfs/src/config/cli.rs
@@ -1252,7 +1252,7 @@ pub fn default_server_opts() -> ServerOpts {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Commands, ConnectCommands, InspectCommands, preprocess_args_for_legacy};
+    use super::{Cli, Commands, ConnectCommands, ConnectInventoryCommands, InspectCommands, preprocess_args_for_legacy};
     use crate::version;
     use clap::error::ErrorKind;
     use clap::{CommandFactory, Parser};
@@ -1402,7 +1402,8 @@ mod tests {
             "--state-dir",
             "/var/lib/rustfs/connect",
         ])
-        .expect_err("unacknowledged L1 inventory must fail");
+        .err()
+        .expect("unacknowledged L1 inventory must fail");
         assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
         assert!(error.to_string().contains("--acknowledge-l1"));
 
@@ -1466,7 +1467,9 @@ mod tests {
             "--sample-period-micros",
             "1000",
         ];
-        let error = Cli::try_parse_from(arguments).expect_err("an incomplete unacknowledged profile must fail");
+        let error = Cli::try_parse_from(arguments)
+            .err()
+            .expect("an incomplete unacknowledged profile must fail");
         assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
         assert!(error.to_string().contains("--acknowledge-l3"));
     }
@@ -1502,7 +1505,9 @@ mod tests {
             "--duration-millis",
             "1000",
         ];
-        let error = Cli::try_parse_from(arguments).expect_err("unacknowledged log capture must fail");
+        let error = Cli::try_parse_from(arguments)
+            .err()
+            .expect("unacknowledged log capture must fail");
         assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
         assert!(error.to_string().contains("--acknowledge-l3"));
     }
@@ -1539,7 +1544,9 @@ mod tests {
             "--duration-millis",
             "10",
         ];
-        let error = Cli::try_parse_from(arguments).expect_err("unacknowledged telemetry capture must fail");
+        let error = Cli::try_parse_from(arguments)
+            .err()
+            .expect("unacknowledged telemetry capture must fail");
         assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
         assert!(error.to_string().contains("--acknowledge-l3"));
     }

--- a/rustfs/src/connect/diagnostics/mod.rs
+++ b/rustfs/src/connect/diagnostics/mod.rs
@@ -15,6 +15,7 @@
 mod logs;
 mod perf_client;
 mod perf_drive;
+mod perf_network;
 mod perf_object;
 mod profile_cpu;
 mod profile_memory;
@@ -46,6 +47,18 @@ pub use perf_drive::{
     DrivePerformanceError, DrivePerformanceRequest, DriveProvenance, DriveReadMode, DriveReasonCode, DriveTargetParameters,
     DriveTargetReasonCode, DriveTargetResult, DriveTargetUnits, LocalDriveConsent, SavedDriveExport, SignedDriveExport,
     measure_drive, save_signed_drive_export, sign_drive_export, validate_drive_limits,
+};
+pub use perf_network::{
+    LocalNetworkConsent, MAX_ARCHIVE_BYTES as MAX_NETWORK_ARCHIVE_BYTES,
+    MAX_BANDWIDTH_BYTES_PER_SECOND as MAX_NETWORK_BANDWIDTH_BYTES_PER_SECOND,
+    MAX_DECOMPRESSED_BYTES as MAX_NETWORK_DECOMPRESSED_BYTES, MAX_ENVELOPE_BYTES as MAX_NETWORK_ENVELOPE_BYTES,
+    MAX_NETWORK_DURATION, MAX_OPERATIONS as MAX_NETWORK_OPERATIONS, MAX_PEERS as MAX_NETWORK_PEERS,
+    MAX_RESULT_BYTES as MAX_NETWORK_RESULT_BYTES, MAX_TRAFFIC_BYTES as MAX_NETWORK_TRAFFIC_BYTES, NETWORK_CAPABILITY,
+    NETWORK_SCHEMA_VERSION, NETWORK_TOOL_ID, NetworkCoverage, NetworkDiagnosticResult, NetworkMeasurement, NetworkOutcome,
+    NetworkPeerHarness, NetworkPeerResult, NetworkPerformanceData, NetworkPerformanceError, NetworkPerformanceRequest,
+    NetworkProvenance, NetworkReasonCode, PeerProbeError, PeerProbeFuture, PeerProbeMeasurement, PeerReasonCode,
+    SavedNetworkExport, SignedNetworkExport, measure_network, measure_network_with_harness, save_signed_network_export,
+    sign_network_export,
 };
 pub use perf_object::{
     LocalObjectConsent, MAX_OBJECT_BANDWIDTH_BYTES_PER_SECOND, MAX_OBJECT_DURATION, MAX_OBJECT_RESULT_BYTES,

--- a/rustfs/src/connect/diagnostics/perf_network.rs
+++ b/rustfs/src/connect/diagnostics/perf_network.rs
@@ -13,12 +13,6 @@
 // limitations under the License.
 
 //! Consent-bound inter-node network performance results.
-//!
-//! RustFS does not yet expose a controlled inter-node performance harness.
-//! [`measure_network`] therefore emits an explicit `UNSUPPORTED` result. The
-//! injected harness boundary exists so a real RustFS peer adapter can be wired
-//! without weakening validation, budgets, cancellation, attribution, or the
-//! frozen Connect result contract.
 
 use std::fs::{self, File, OpenOptions};
 use std::future::Future;
@@ -40,6 +34,7 @@ use uuid::{Uuid, Variant, Version};
 use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
 
 use crate::connect::DeviceIdentity;
+use crate::storage::storage_api::ecstore_rpc::{NetworkPeerProbeClient, NetworkPeerProbeError as NativePeerProbeError};
 
 pub const NETWORK_SCHEMA_VERSION: u16 = 1;
 pub const NETWORK_TOOL_ID: &str = "performance.network";
@@ -285,6 +280,26 @@ pub trait NetworkPeerHarness: Send + Sync {
     fn probe<'a>(&'a self, peer_alias: &'a str, traffic_bytes: u64, cancel: &'a CancellationToken) -> PeerProbeFuture<'a>;
 }
 
+struct RuntimeNetworkPeerHarness {
+    client: NetworkPeerProbeClient,
+}
+
+impl NetworkPeerHarness for RuntimeNetworkPeerHarness {
+    fn probe<'a>(&'a self, peer_alias: &'a str, traffic_bytes: u64, cancel: &'a CancellationToken) -> PeerProbeFuture<'a> {
+        Box::pin(async move {
+            self.client
+                .probe(peer_alias, traffic_bytes, MAX_NETWORK_DURATION, cancel)
+                .await
+                .map(|measurement| PeerProbeMeasurement {
+                    transferred_bytes: measurement.transferred_bytes,
+                    duration: measurement.duration,
+                    latency: measurement.latency,
+                })
+                .map_err(map_native_probe_error)
+        })
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SignedNetworkExport {
     pub artifact_uid: String,
@@ -337,7 +352,7 @@ pub enum NetworkPerformanceError {
 }
 
 /// Return the current native capability state without generating test traffic.
-pub fn measure_network(
+pub async fn measure_network(
     request: &NetworkPerformanceRequest,
     cancel: &CancellationToken,
 ) -> Result<NetworkMeasurement, NetworkPerformanceError> {
@@ -346,14 +361,33 @@ pub fn measure_network(
         return Ok(terminal_measurement(request, NetworkOutcome::Cancelled, NetworkReasonCode::Cancelled));
     }
 
-    // Existing admin speedtest and site-netperf handlers both state that no
-    // distributed peer traffic harness is wired. Client devnull is a different
-    // tool and must not be presented as inter-node evidence.
-    Ok(terminal_measurement(
-        request,
-        NetworkOutcome::Unsupported,
-        NetworkReasonCode::SourceUnavailable,
-    ))
+    let Some(endpoint_pools) = crate::runtime_sources::current_endpoints_handle() else {
+        return Ok(terminal_measurement(
+            request,
+            NetworkOutcome::Unsupported,
+            NetworkReasonCode::SourceUnavailable,
+        ));
+    };
+    let harness = RuntimeNetworkPeerHarness {
+        client: NetworkPeerProbeClient::from_endpoint_pools(&endpoint_pools),
+    };
+    let aliases = harness
+        .client
+        .targets()
+        .into_iter()
+        .map(|target| target.alias)
+        .collect::<Vec<_>>();
+    if aliases.is_empty() {
+        return Ok(terminal_measurement(
+            request,
+            NetworkOutcome::Unsupported,
+            NetworkReasonCode::SourceUnavailable,
+        ));
+    }
+    if aliases != request.peer_aliases {
+        return Err(NetworkPerformanceError::InvalidRequest);
+    }
+    measure_network_with_harness(request, &harness, cancel).await
 }
 
 pub async fn measure_network_with_harness(
@@ -738,6 +772,17 @@ fn peer_reason(error: PeerProbeError) -> PeerReasonCode {
         PeerProbeError::TimedOut => PeerReasonCode::TimedOut,
         PeerProbeError::ProtocolFailure => PeerReasonCode::ProtocolFailure,
         PeerProbeError::Cancelled => PeerReasonCode::Cancelled,
+    }
+}
+
+fn map_native_probe_error(error: NativePeerProbeError) -> PeerProbeError {
+    match error {
+        NativePeerProbeError::Cancelled => PeerProbeError::Cancelled,
+        NativePeerProbeError::Unreachable => PeerProbeError::Unreachable,
+        NativePeerProbeError::TimedOut => PeerProbeError::TimedOut,
+        NativePeerProbeError::UnknownPeer | NativePeerProbeError::LimitExceeded | NativePeerProbeError::ProtocolFailure => {
+            PeerProbeError::ProtocolFailure
+        }
     }
 }
 

--- a/rustfs/src/connect/diagnostics/perf_network.rs
+++ b/rustfs/src/connect/diagnostics/perf_network.rs
@@ -34,7 +34,7 @@ use uuid::{Uuid, Variant, Version};
 use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
 
 use crate::connect::DeviceIdentity;
-use crate::storage::storage_api::ecstore_rpc::{NetworkPeerProbeClient, NetworkPeerProbeError as NativePeerProbeError};
+use crate::storage_api::cluster::network_probe::{NetworkPeerProbeClient, NetworkPeerProbeError as NativePeerProbeError};
 
 pub const NETWORK_SCHEMA_VERSION: u16 = 1;
 pub const NETWORK_TOOL_ID: &str = "performance.network";

--- a/rustfs/src/connect/mod.rs
+++ b/rustfs/src/connect/mod.rs
@@ -73,6 +73,15 @@ pub use diagnostics::{
     spawn_environment_schedule, validate_client_limits, validate_drive_limits,
 };
 pub use diagnostics::{
+    LocalNetworkConsent, MAX_NETWORK_ARCHIVE_BYTES, MAX_NETWORK_BANDWIDTH_BYTES_PER_SECOND, MAX_NETWORK_DECOMPRESSED_BYTES,
+    MAX_NETWORK_DURATION, MAX_NETWORK_ENVELOPE_BYTES, MAX_NETWORK_OPERATIONS, MAX_NETWORK_PEERS, MAX_NETWORK_RESULT_BYTES,
+    MAX_NETWORK_TRAFFIC_BYTES, NETWORK_CAPABILITY, NETWORK_SCHEMA_VERSION, NETWORK_TOOL_ID, NetworkCoverage,
+    NetworkDiagnosticResult, NetworkMeasurement, NetworkOutcome, NetworkPeerHarness, NetworkPeerResult, NetworkPerformanceData,
+    NetworkPerformanceError, NetworkPerformanceRequest, NetworkProvenance, NetworkReasonCode, PeerProbeError, PeerProbeFuture,
+    PeerProbeMeasurement, PeerReasonCode, SavedNetworkExport, SignedNetworkExport, measure_network, measure_network_with_harness,
+    save_signed_network_export, sign_network_export,
+};
+pub use diagnostics::{
     LocalObjectConsent, MAX_OBJECT_BANDWIDTH_BYTES_PER_SECOND, MAX_OBJECT_DURATION, MAX_OBJECT_RESULT_BYTES,
     MAX_OBJECT_TRAFFIC_BYTES, OBJECT_CAPABILITY, OBJECT_SCHEMA_VERSION, OBJECT_TOOL_ID, ObjectDiagnosticResult,
     ObjectMeasurement, ObjectOperation, ObjectOutcome, ObjectPerformanceData, ObjectPerformanceError, ObjectPerformanceRequest,

--- a/rustfs/src/storage/storage_api.rs
+++ b/rustfs/src/storage/storage_api.rs
@@ -547,12 +547,12 @@ pub(crate) mod ecstore_rio {
 
 pub(crate) mod ecstore_rpc {
     pub(crate) use rustfs_ecstore::api::rpc::{
-        KMS_SIGNAL_SUBSYSTEM, LocalPeerS3Client, PEER_RESTDRY_RUN, PEER_RESTSIGNAL, PEER_RESTSUB_SYS, PeerRestClient,
-        PeerS3Client, SERVICE_SIGNAL_REFRESH_CONFIG, SERVICE_SIGNAL_RELOAD_DYNAMIC, TONIC_RPC_PREFIX,
-        check_and_record_signed_rpc_nonce, decode_heal_bucket_rpc_options, normalize_tonic_rpc_audience,
-        sign_ns_scanner_capability_with_tier_registry_generation, sign_put_file_capability, sign_tonic_rpc_response_proof,
-        tonic_boot_epoch_challenge, tonic_boot_epoch_response_headers, tonic_rpc_auth_failure_reason,
-        verify_put_file_auth_trailer, verify_rpc_signature, verify_tonic_canonical_body_digest,
+        KMS_SIGNAL_SUBSYSTEM, LocalPeerS3Client, MAX_NETWORK_PROBE_BYTES, MAX_NETWORK_PROBE_DURATION, NetworkPeerProbeClient,
+        NetworkPeerProbeError, PEER_RESTDRY_RUN, PEER_RESTSIGNAL, PEER_RESTSUB_SYS, PeerRestClient, PeerS3Client,
+        SERVICE_SIGNAL_REFRESH_CONFIG, SERVICE_SIGNAL_RELOAD_DYNAMIC, TONIC_RPC_PREFIX, check_and_record_signed_rpc_nonce,
+        decode_heal_bucket_rpc_options, normalize_tonic_rpc_audience, sign_ns_scanner_capability_with_tier_registry_generation,
+        sign_put_file_capability, sign_tonic_rpc_response_proof, tonic_boot_epoch_challenge, tonic_boot_epoch_response_headers,
+        tonic_rpc_auth_failure_reason, verify_put_file_auth_trailer, verify_rpc_signature, verify_tonic_canonical_body_digest,
         verify_tonic_mutation_body_digest, verify_tonic_mutation_body_digest_reject_unsigned,
         verify_tonic_rpc_signature_with_bootstrap,
     };

--- a/rustfs/src/storage_api.rs
+++ b/rustfs/src/storage_api.rs
@@ -36,6 +36,10 @@ pub(crate) mod inspect {
 }
 
 pub(crate) mod cluster {
+    pub(crate) mod network_probe {
+        pub(crate) use crate::storage::storage_api::ecstore_rpc::{NetworkPeerProbeClient, NetworkPeerProbeError};
+    }
+
     pub(crate) mod contract {
         pub(crate) mod capability {
             #[cfg(test)]

--- a/rustfs/tests/connect_perf_network.rs
+++ b/rustfs/tests/connect_perf_network.rs
@@ -12,14 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod connect {
-    pub use rustfs::connect::DeviceIdentity;
-}
-
-#[allow(dead_code)]
-#[path = "../src/connect/diagnostics/perf_network.rs"]
-mod perf_network;
-
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::Cursor;
@@ -32,11 +24,11 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use base64_simd::URL_SAFE_NO_PAD;
 use p256::ecdsa::{Signature, VerifyingKey, signature::Verifier as _};
 use p256::pkcs8::DecodePublicKey as _;
-use perf_network::{
-    LocalNetworkConsent, MAX_NETWORK_DURATION, MAX_TRAFFIC_BYTES, NETWORK_CAPABILITY, NetworkOutcome, NetworkPeerHarness,
-    NetworkPerformanceError, NetworkPerformanceRequest, NetworkProvenance, NetworkReasonCode, PeerProbeError, PeerProbeFuture,
-    PeerProbeMeasurement, PeerReasonCode, measure_network, measure_network_with_harness, save_signed_network_export,
-    sign_network_export,
+use rustfs::connect::{
+    DeviceIdentity, LocalNetworkConsent, MAX_NETWORK_DURATION, MAX_NETWORK_TRAFFIC_BYTES, NETWORK_CAPABILITY, NetworkOutcome,
+    NetworkPeerHarness, NetworkPerformanceError, NetworkPerformanceRequest, NetworkProvenance, NetworkReasonCode, PeerProbeError,
+    PeerProbeFuture, PeerProbeMeasurement, PeerReasonCode, measure_network, measure_network_with_harness,
+    save_signed_network_export, sign_network_export,
 };
 use sha2::{Digest as _, Sha256};
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
@@ -144,10 +136,64 @@ async fn unused_address() -> SocketAddr {
     address
 }
 
-#[test]
-fn native_network_source_is_explicitly_unsupported() {
+#[tokio::test]
+async fn real_rustfs_peer_accepts_authenticated_payload_and_attributes_disconnect() {
+    use rustfs::embedded::{RustFSServerBuilder, find_available_port};
+    use rustfs_ecstore::api::disk::Endpoint;
+    use rustfs_ecstore::api::layout::{EndpointServerPools, Endpoints, PoolEndpoints};
+    use rustfs_ecstore::api::rpc::{NetworkPeerProbeClient, NetworkPeerProbeError};
+
+    let _guard = TEST_HARNESS_LOCK.lock().await;
+    let port = match find_available_port() {
+        Ok(port) => port,
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
+        Err(error) => panic!("find free port: {error}"),
+    };
+    let server = RustFSServerBuilder::new()
+        .address(format!("127.0.0.1:{port}"))
+        .access_key("network-probe-access")
+        .secret_key("network-probe-secret")
+        .build()
+        .await
+        .expect("start real RustFS peer");
+    let mut local = Endpoint::try_from("http://127.0.0.1:1/local").expect("local endpoint");
+    local.is_local = true;
+    let remote_url = format!("{}/remote", server.endpoint());
+    let mut remote = Endpoint::try_from(remote_url.as_str()).expect("remote endpoint");
+    remote.is_local = false;
+    let topology = EndpointServerPools::from(vec![PoolEndpoints {
+        legacy: false,
+        set_count: 1,
+        drives_per_set: 2,
+        endpoints: Endpoints::from(vec![local, remote]),
+        cmd_line: String::new(),
+        platform: String::new(),
+    }]);
+    let client = NetworkPeerProbeClient::from_endpoint_pools(&topology);
+    assert_eq!(client.targets()[0].alias, "peer-1");
+    let measurement = client
+        .probe("peer-1", 65_536, Duration::from_secs(2), &CancellationToken::new())
+        .await
+        .expect("authenticated RustFS peer probe");
+    assert_eq!(measurement.transferred_bytes, 65_536);
+    assert!(!measurement.duration.is_zero());
+    assert!(!measurement.latency.is_zero());
+
+    server.shutdown().await;
+    assert_eq!(
+        client
+            .probe("peer-1", 65_536, Duration::from_secs(2), &CancellationToken::new())
+            .await,
+        Err(NetworkPeerProbeError::Unreachable)
+    );
+}
+
+#[tokio::test]
+async fn native_network_source_is_explicitly_unsupported_without_runtime_topology() {
     let request = request(1);
-    let measurement = measure_network(&request, &CancellationToken::new()).expect("typed unsupported result");
+    let measurement = measure_network(&request, &CancellationToken::new())
+        .await
+        .expect("typed unsupported result");
     assert_eq!(measurement.result.outcome(), NetworkOutcome::Unsupported);
     assert_eq!(measurement.result.reason_code(), NetworkReasonCode::SourceUnavailable);
     assert!(measurement.result.data().is_none());
@@ -164,7 +210,7 @@ fn native_network_source_is_explicitly_unsupported() {
     assert_eq!(value["provenance"]["executableSha256"], "d".repeat(64));
 
     assert!(matches!(
-        sign_network_export(&request, &measurement, &connect::DeviceIdentity::generate(), &CancellationToken::new()),
+        sign_network_export(&request, &measurement, &DeviceIdentity::generate(), &CancellationToken::new()),
         Err(NetworkPerformanceError::InvalidRequest)
     ));
 }
@@ -269,7 +315,7 @@ async fn short_transfer_cannot_be_reported_as_a_successful_benchmark() {
 async fn invalid_and_over_budget_requests_fail_before_peer_io() {
     let harness = CountingHarness(AtomicUsize::new(0));
     let mut over_traffic = request(1);
-    over_traffic.traffic_bytes_per_peer = MAX_TRAFFIC_BYTES + 1;
+    over_traffic.traffic_bytes_per_peer = MAX_NETWORK_TRAFFIC_BYTES + 1;
     assert!(matches!(
         measure_network_with_harness(&over_traffic, &harness, &CancellationToken::new()).await,
         Err(NetworkPerformanceError::LimitExceeded)
@@ -351,11 +397,11 @@ async fn successful_result_has_signed_bounded_private_offline_export() {
         .expect("successful controlled result");
     assert_eq!(peer.await.expect("peer task"), 4_096);
     assert_eq!(measurement.result.outcome(), NetworkOutcome::Succeeded);
-    let identity = connect::DeviceIdentity::generate();
+    let identity = DeviceIdentity::generate();
     let export = sign_network_export(&request, &measurement, &identity, &CancellationToken::new()).expect("signed export");
-    assert!(export.result_json.len() <= perf_network::MAX_RESULT_BYTES);
-    assert!(export.envelope_json.len() <= perf_network::MAX_ENVELOPE_BYTES);
-    assert!(export.archive_bytes.len() <= perf_network::MAX_ARCHIVE_BYTES);
+    assert!(export.result_json.len() <= rustfs::connect::MAX_NETWORK_RESULT_BYTES);
+    assert!(export.envelope_json.len() <= rustfs::connect::MAX_NETWORK_ENVELOPE_BYTES);
+    assert!(export.archive_bytes.len() <= rustfs::connect::MAX_NETWORK_ARCHIVE_BYTES);
     assert_eq!(export.archive_sha256, hex(&Sha256::digest(&export.archive_bytes)));
     let mut archive = zip::ZipArchive::new(Cursor::new(&export.archive_bytes)).expect("three-file archive");
     assert_eq!(archive.len(), 3);


### PR DESCRIPTION
## Related Issues

rustfs/connect#614

## Summary of Changes

Add a bounded authenticated inter-node network probe over the existing NodeService Ping RPC. Runtime network diagnostics now use live peer topology, preserve stable peer attribution, enforce cancellation, timeout, traffic, and admission limits, and expose the producer for `performance.network@1` jobs and signed local exports.

Also fixes the CLI tests added on current main so the RustFS library test target compiles.

## Verification

Functional tests ran on `37c9c77041b08d1fa12683a031fc7518f56e0c6a`; the final facade-only fix is `9e17be33f15ac24f07a71a53669dad07a5ab5a65`:

- `cargo test -p rustfs-ecstore network_probe --lib` — 4 passed, including payload validation and 12-peer alias ordering.
- `cargo test -p rustfs --test connect_perf_network` — 8 passed, including an authenticated 64 KiB probe against a real embedded RustFS NodeService and attributed disconnect failure.
- `cargo test -p rustfs --lib network_probe` and `cargo test -p rustfs --lib runtime_capabilities_response` — 4 targeted admin/runtime tests passed.
- On final head, `scripts/check_architecture_migration_rules.sh` and `cargo check -p rustfs` passed.

A supported distributed exact-head topology could not be started on the current macOS host because initialization stopped at IAM read quorum. The real NodeService integration test covers authenticated transport and attribution; supported-topology receipt evidence remains open in rustfs/connect#614.

## Impact

The existing `/rustfs/admin/v3/speedtest/net` route now performs a bounded active inter-node probe when remote peers are available. Single-node or uninitialized topology returns an explicit unavailable result. No configuration or one-shot CLI is added.

## Additional Notes

The probe sends at most 1 MiB total from the admin route, runs for at most 30 seconds, and admits one collector at a time. Results expose peer aliases without serializing peer addresses.
